### PR TITLE
Desktop mode enhancements

### DIFF
--- a/lib/core/constants/app_constants.dart
+++ b/lib/core/constants/app_constants.dart
@@ -8,6 +8,7 @@ abstract final class AppConstants {
 
   // Breakpoints (Material 3)
   static const compactBreakpoint = 600.0;
+  static const mediumBreakpoint = 900.0;
   static const expandedBreakpoint = 1200.0;
 
   // Sync

--- a/lib/core/utils/api_circuit_breaker.dart
+++ b/lib/core/utils/api_circuit_breaker.dart
@@ -1,0 +1,32 @@
+/// A simple circuit breaker that disables an API after a rate-limit (429)
+/// response, preventing repeated doomed requests.
+///
+/// Once tripped, the breaker stays open for [cooldownDuration] before
+/// allowing a single probe request. If the probe succeeds the breaker
+/// resets; if it fails the cooldown restarts.
+class ApiCircuitBreaker {
+  ApiCircuitBreaker({
+    this.cooldownDuration = const Duration(minutes: 15),
+  });
+
+  final Duration cooldownDuration;
+
+  DateTime? _trippedAt;
+
+  /// Whether requests should be allowed through.
+  bool get isOpen {
+    if (_trippedAt == null) return true;
+    final elapsed = DateTime.now().difference(_trippedAt!);
+    return elapsed >= cooldownDuration;
+  }
+
+  /// Record a rate-limit failure — opens the breaker.
+  void trip() {
+    _trippedAt = DateTime.now();
+  }
+
+  /// Record a successful response — resets the breaker.
+  void reset() {
+    _trippedAt = null;
+  }
+}

--- a/lib/core/utils/window_manager_helper.dart
+++ b/lib/core/utils/window_manager_helper.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:window_manager/window_manager.dart';
+
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+
+/// Manages desktop window size, position, and minimum size enforcement.
+///
+/// Persists geometry to [SharedPreferences] so the window restores its
+/// previous bounds on relaunch. Only active on desktop platforms.
+class WindowManagerHelper with WindowListener {
+  WindowManagerHelper._();
+
+  static const _keyX = 'window_x';
+  static const _keyY = 'window_y';
+  static const _keyWidth = 'window_width';
+  static const _keyHeight = 'window_height';
+
+  static const _minWidth = 800.0;
+  static const _minHeight = 600.0;
+  static const _defaultWidth = 1200.0;
+  static const _defaultHeight = 800.0;
+
+  static final _instance = WindowManagerHelper._();
+
+  SharedPreferences? _prefs;
+  Timer? _debounce;
+
+  /// Initialise window management. Safe to call on any platform —
+  /// returns immediately on non-desktop.
+  static Future<void> initialise() async {
+    if (!PlatformCapability.isDesktop) return;
+
+    await windowManager.ensureInitialized();
+
+    final prefs = await SharedPreferences.getInstance();
+    _instance._prefs = prefs;
+
+    final x = prefs.getDouble(_keyX);
+    final y = prefs.getDouble(_keyY);
+    final width = prefs.getDouble(_keyWidth) ?? _defaultWidth;
+    final height = prefs.getDouble(_keyHeight) ?? _defaultHeight;
+
+    final options = WindowOptions(
+      size: Size(width, height),
+      minimumSize: const Size(_minWidth, _minHeight),
+      center: x == null || y == null,
+    );
+
+    await windowManager.waitUntilReadyToShow(options, () async {
+      if (x != null && y != null) {
+        await windowManager.setPosition(Offset(x, y));
+      }
+      await windowManager.show();
+      await windowManager.focus();
+    });
+
+    windowManager.addListener(_instance);
+  }
+
+  void _persistGeometry() async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+
+    final position = await windowManager.getPosition();
+    final size = await windowManager.getSize();
+
+    await prefs.setDouble(_keyX, position.dx);
+    await prefs.setDouble(_keyY, position.dy);
+    await prefs.setDouble(_keyWidth, size.width);
+    await prefs.setDouble(_keyHeight, size.height);
+  }
+
+  void _debouncedPersist() {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 500), _persistGeometry);
+  }
+
+  @override
+  void onWindowResized() => _debouncedPersist();
+
+  @override
+  void onWindowMoved() => _debouncedPersist();
+}

--- a/lib/data/repositories/metadata_repository_impl.dart
+++ b/lib/data/repositories/metadata_repository_impl.dart
@@ -1,8 +1,11 @@
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
 import 'package:drift/drift.dart';
+import 'package:flutter/foundation.dart';
 import 'package:mymediascanner/core/constants/api_constants.dart';
 import 'package:mymediascanner/core/constants/app_constants.dart';
+import 'package:mymediascanner/core/utils/api_circuit_breaker.dart';
 import 'package:mymediascanner/core/utils/barcode_utils.dart';
 import 'package:mymediascanner/data/local/dao/barcode_cache_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
@@ -35,7 +38,9 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     this.googleBooksApi,
     this.openLibraryApi,
     this.upcitemdbApi,
-  }) : _cacheDao = cacheDao;
+    ApiCircuitBreaker? googleBooksBreaker,
+  })  : _cacheDao = cacheDao,
+        googleBooksBreaker = googleBooksBreaker ?? ApiCircuitBreaker();
 
   final BarcodeCacheDao _cacheDao;
   final TmdbApi? tmdbApi;
@@ -44,10 +49,20 @@ class MetadataRepositoryImpl implements IMetadataRepository {
   final OpenLibraryApi? openLibraryApi;
   final UpcitemdbApi? upcitemdbApi;
 
+  /// Circuit breaker for Google Books API — trips on 429 responses.
+  final ApiCircuitBreaker googleBooksBreaker;
+
+  /// Returns true if the exception is a 429 rate-limit response.
+  static bool _isRateLimited(Object error) {
+    return error is DioException &&
+        error.response?.statusCode == 429;
+  }
+
   @override
   Future<ScanResult> lookupBarcode(
     String barcode, {
     MediaType? typeHint,
+    bool forceIsbn = false,
   }) async {
     final barcodeType = BarcodeUtils.detectBarcodeType(barcode);
     final barcodeTypeStr = barcodeType.name;
@@ -59,7 +74,7 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     // 2. Route by barcode type + hint
     ScanResult? result;
 
-    if (BarcodeUtils.isIsbn(barcode)) {
+    if (forceIsbn || BarcodeUtils.isIsbn(barcode)) {
       result = await _lookupBook(barcode, barcodeTypeStr);
     } else if (typeHint == MediaType.film || typeHint == MediaType.tv) {
       result = await _lookupFilm(barcode, barcodeTypeStr);
@@ -141,9 +156,10 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     String barcode,
     String barcodeType,
   ) async {
-    if (googleBooksApi == null) return null;
+    if (googleBooksApi == null || !googleBooksBreaker.isOpen) return null;
     try {
       final response = await googleBooksApi!.searchByIsbn('isbn:$barcode');
+      googleBooksBreaker.reset();
       final match = response.items?.firstWhere(
         (v) => v.id == candidate.sourceId,
         orElse: () => response.items!.first,
@@ -152,7 +168,11 @@ class MetadataRepositoryImpl implements IMetadataRepository {
         await _cacheResponse(barcode, 'book', 'google_books', match.toJson());
         return GoogleBooksMapper.fromVolume(match, barcode, barcodeType);
       }
-    } on Exception catch (_) {}
+    } on Exception catch (e) {
+      if (_isRateLimited(e)) {
+        googleBooksBreaker.trip();
+      }
+    }
     return null;
   }
 
@@ -230,11 +250,12 @@ class MetadataRepositoryImpl implements IMetadataRepository {
 
   Future<ScanResult?> _lookupBook(
       String barcode, String barcodeType) async {
-    // Try Google Books first
-    if (googleBooksApi != null) {
+    // Try Google Books first (skip if circuit breaker is tripped)
+    if (googleBooksApi != null && googleBooksBreaker.isOpen) {
       try {
         final response =
             await googleBooksApi!.searchByIsbn('isbn:$barcode');
+        googleBooksBreaker.reset();
         final items = response.items;
         if (items != null && items.isNotEmpty) {
           if (items.length == 1) {
@@ -256,7 +277,12 @@ class MetadataRepositoryImpl implements IMetadataRepository {
             barcodeType: barcodeType,
           );
         }
-      } on Exception catch (_) {
+      } on Exception catch (e) {
+        if (_isRateLimited(e)) {
+          googleBooksBreaker.trip();
+          debugPrint('Google Books API rate-limited (429) — '
+              'circuit breaker tripped, falling back to Open Library');
+        }
         // Fall through to Open Library
       }
     }

--- a/lib/domain/repositories/i_metadata_repository.dart
+++ b/lib/domain/repositories/i_metadata_repository.dart
@@ -7,6 +7,7 @@ abstract interface class IMetadataRepository {
   Future<ScanResult> lookupBarcode(
     String barcode, {
     MediaType? typeHint,
+    bool forceIsbn = false,
   });
 
   /// Fetch full metadata for a previously returned candidate.

--- a/lib/domain/usecases/scan_barcode_usecase.dart
+++ b/lib/domain/usecases/scan_barcode_usecase.dart
@@ -18,11 +18,13 @@ class ScanBarcodeUseCase {
   Future<ScanResult> execute(
     String barcode, {
     MediaType? typeHint,
+    bool forceIsbn = false,
   }) async {
     final isDuplicate = await _mediaItemRepo.barcodeExists(barcode);
     final result = await _metadataRepo.lookupBarcode(
       barcode,
       typeHint: typeHint,
+      forceIsbn: forceIsbn,
     );
 
     // Repository now returns ScanResult directly.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mymediascanner/app/app.dart';
+import 'package:mymediascanner/core/utils/window_manager_helper.dart';
 
-void main() {
+void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await WindowManagerHelper.initialise();
   runApp(
     const ProviderScope(
       child: App(),

--- a/lib/presentation/providers/collection_view_mode_provider.dart
+++ b/lib/presentation/providers/collection_view_mode_provider.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum CollectionViewMode { grid, table }
+
+const _prefKey = 'collection_view_mode';
+
+class CollectionViewModeNotifier extends Notifier<CollectionViewMode> {
+  @override
+  CollectionViewMode build() {
+    _loadFromPrefs();
+    return CollectionViewMode.grid;
+  }
+
+  Future<void> _loadFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_prefKey);
+    if (stored == 'table') {
+      state = CollectionViewMode.table;
+    }
+  }
+
+  void toggle() {
+    state = state == CollectionViewMode.grid
+        ? CollectionViewMode.table
+        : CollectionViewMode.grid;
+    _persistToPrefs();
+  }
+
+  void setMode(CollectionViewMode mode) {
+    state = mode;
+    _persistToPrefs();
+  }
+
+  Future<void> _persistToPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefKey, state.name);
+  }
+}
+
+final collectionViewModeProvider =
+    NotifierProvider<CollectionViewModeNotifier, CollectionViewMode>(
+        () => CollectionViewModeNotifier());

--- a/lib/presentation/providers/repository_providers.dart
+++ b/lib/presentation/providers/repository_providers.dart
@@ -52,6 +52,7 @@ final metadataRepositoryProvider = Provider<IMetadataRepository>((ref) {
   final tmdbKey = apiKeys['tmdb'];
   final discogsKey = apiKeys['discogs'];
   final upcKey = apiKeys['upcitemdb'];
+  final googleBooksKey = apiKeys['google_books'];
 
   return MetadataRepositoryImpl(
     cacheDao: ref.watch(barcodeCacheDaoProvider),
@@ -69,8 +70,13 @@ final metadataRepositoryProvider = Provider<IMetadataRepository>((ref) {
             defaultHeaders: {'User-Agent': 'MyMediaScanner/1.0'},
           ))
         : null,
-    googleBooksApi: GoogleBooksApi(
-        DioFactory.create(baseUrl: ApiConstants.googleBooksBaseUrl)),
+    googleBooksApi: GoogleBooksApi(googleBooksKey != null
+        ? DioFactory.createWithApiKey(
+            baseUrl: ApiConstants.googleBooksBaseUrl,
+            apiKeyParam: 'key',
+            apiKey: googleBooksKey,
+          )
+        : DioFactory.create(baseUrl: ApiConstants.googleBooksBaseUrl)),
     openLibraryApi: OpenLibraryApi(),
     upcitemdbApi: upcKey != null
         ? UpcitemdbApi(DioFactory.createWithApiKey(

--- a/lib/presentation/providers/rip_view_mode_provider.dart
+++ b/lib/presentation/providers/rip_view_mode_provider.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum RipViewMode { grid, table }
+
+const _prefKey = 'rip_view_mode';
+
+class RipViewModeNotifier extends Notifier<RipViewMode> {
+  @override
+  RipViewMode build() {
+    _loadFromPrefs();
+    return RipViewMode.grid;
+  }
+
+  Future<void> _loadFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_prefKey);
+    if (stored == 'table') {
+      state = RipViewMode.table;
+    }
+  }
+
+  void toggle() {
+    state = state == RipViewMode.grid ? RipViewMode.table : RipViewMode.grid;
+    _persistToPrefs();
+  }
+
+  void setMode(RipViewMode mode) {
+    state = mode;
+    _persistToPrefs();
+  }
+
+  Future<void> _persistToPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefKey, state.name);
+  }
+}
+
+final ripViewModeProvider =
+    NotifierProvider<RipViewModeNotifier, RipViewMode>(
+        () => RipViewModeNotifier());

--- a/lib/presentation/providers/scanner_provider.dart
+++ b/lib/presentation/providers/scanner_provider.dart
@@ -16,6 +16,9 @@ enum ScanState {
   error,
 }
 
+/// Whether the user is scanning a standard barcode or an ISBN.
+enum ScanMode { barcode, isbn }
+
 class ScannerState {
   const ScannerState({
     this.state = ScanState.idle,
@@ -23,6 +26,7 @@ class ScannerState {
     this.error,
     this.batchMode = false,
     this.batchCount = 0,
+    this.scanMode = ScanMode.barcode,
     this.enabledMediaTypes = const {
       MediaType.music,
       MediaType.film,
@@ -37,6 +41,7 @@ class ScannerState {
   final String? error;
   final bool batchMode;
   final int batchCount;
+  final ScanMode scanMode;
   final Set<MediaType> enabledMediaTypes;
 
   MediaType? get typeHint {
@@ -52,6 +57,7 @@ class ScannerState {
     String? error,
     bool? batchMode,
     int? batchCount,
+    ScanMode? scanMode,
     Set<MediaType>? enabledMediaTypes,
   }) => ScannerState(
     state: state ?? this.state,
@@ -59,6 +65,7 @@ class ScannerState {
     error: error ?? this.error,
     batchMode: batchMode ?? this.batchMode,
     batchCount: batchCount ?? this.batchCount,
+    scanMode: scanMode ?? this.scanMode,
     enabledMediaTypes: enabledMediaTypes ?? this.enabledMediaTypes,
   );
 }
@@ -77,6 +84,10 @@ class ScannerNotifier extends Notifier<ScannerState> {
     state = state.copyWith(enabledMediaTypes: current);
   }
 
+  void setScanMode(ScanMode mode) {
+    state = state.copyWith(scanMode: mode);
+  }
+
   Future<void> onBarcodeScanned(
     String barcode, {
     MediaType? typeHint,
@@ -92,8 +103,11 @@ class ScannerNotifier extends Notifier<ScannerState> {
         metadataRepository: ref.read(metadataRepositoryProvider),
       );
 
-      final scanResult =
-          await useCase.execute(barcode, typeHint: effectiveHint);
+      final scanResult = await useCase.execute(
+        barcode,
+        typeHint: effectiveHint,
+        forceIsbn: state.scanMode == ScanMode.isbn,
+      );
 
       switch (scanResult) {
         case SingleScanResult(:final isDuplicate):
@@ -104,6 +118,7 @@ class ScannerNotifier extends Notifier<ScannerState> {
               batchMode: state.batchMode,
               batchCount: state.batchCount,
               enabledMediaTypes: state.enabledMediaTypes,
+              scanMode: state.scanMode,
             );
           } else {
             state = ScannerState(
@@ -112,6 +127,7 @@ class ScannerNotifier extends Notifier<ScannerState> {
               batchMode: state.batchMode,
               batchCount: state.batchCount,
               enabledMediaTypes: state.enabledMediaTypes,
+              scanMode: state.scanMode,
             );
           }
         case MultiMatchScanResult():
@@ -143,6 +159,7 @@ class ScannerNotifier extends Notifier<ScannerState> {
                 batchMode: state.batchMode,
                 batchCount: state.batchCount,
                 enabledMediaTypes: state.enabledMediaTypes,
+                scanMode: state.scanMode,
               );
             }
           } else {
@@ -152,6 +169,7 @@ class ScannerNotifier extends Notifier<ScannerState> {
               batchMode: state.batchMode,
               batchCount: state.batchCount,
               enabledMediaTypes: state.enabledMediaTypes,
+              scanMode: state.scanMode,
             );
           }
         case NotFoundScanResult():
@@ -161,6 +179,7 @@ class ScannerNotifier extends Notifier<ScannerState> {
             batchMode: state.batchMode,
             batchCount: state.batchCount,
             enabledMediaTypes: state.enabledMediaTypes,
+            scanMode: state.scanMode,
           );
       }
     } on Exception catch (e) {
@@ -170,6 +189,7 @@ class ScannerNotifier extends Notifier<ScannerState> {
         batchMode: state.batchMode,
         batchCount: state.batchCount,
         enabledMediaTypes: state.enabledMediaTypes,
+        scanMode: state.scanMode,
       );
     }
   }
@@ -182,6 +202,7 @@ class ScannerNotifier extends Notifier<ScannerState> {
       batchMode: state.batchMode,
       batchCount: state.batchCount,
       enabledMediaTypes: state.enabledMediaTypes,
+      scanMode: state.scanMode,
     );
   }
 
@@ -196,11 +217,12 @@ class ScannerNotifier extends Notifier<ScannerState> {
       batchMode: state.batchMode,
       batchCount: state.batchCount,
       enabledMediaTypes: state.enabledMediaTypes,
+      scanMode: state.scanMode,
     );
   }
 
   void reset() {
-    state = const ScannerState();
+    state = ScannerState(scanMode: state.scanMode);
   }
 
   void toggleBatchMode() {

--- a/lib/presentation/providers/selected_item_provider.dart
+++ b/lib/presentation/providers/selected_item_provider.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Tracks the currently selected/focused media item ID in the collection.
+///
+/// Used by keyboard navigation and the master-detail layout.
+class SelectedItemNotifier extends Notifier<String?> {
+  @override
+  String? build() => null;
+
+  void select(String id) => state = id;
+
+  void clear() => state = null;
+
+  /// Move selection to the next item in [itemIds].
+  /// Returns the newly selected ID, or null if already at end.
+  String? moveNext(List<String> itemIds) {
+    if (itemIds.isEmpty) return null;
+    final current = state;
+    if (current == null) {
+      state = itemIds.first;
+      return state;
+    }
+    final index = itemIds.indexOf(current);
+    if (index < 0 || index >= itemIds.length - 1) return state;
+    state = itemIds[index + 1];
+    return state;
+  }
+
+  /// Move selection to the previous item in [itemIds].
+  /// Returns the newly selected ID, or null if already at start.
+  String? movePrevious(List<String> itemIds) {
+    if (itemIds.isEmpty) return null;
+    final current = state;
+    if (current == null) {
+      state = itemIds.last;
+      return state;
+    }
+    final index = itemIds.indexOf(current);
+    if (index <= 0) return state;
+    state = itemIds[index - 1];
+    return state;
+  }
+}
+
+final selectedItemProvider =
+    NotifierProvider<SelectedItemNotifier, String?>(() => SelectedItemNotifier());

--- a/lib/presentation/providers/selected_rip_album_provider.dart
+++ b/lib/presentation/providers/selected_rip_album_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Tracks the currently selected rip album ID for master-detail layout.
+class SelectedRipAlbumNotifier extends Notifier<String?> {
+  @override
+  String? build() => null;
+
+  void select(String id) => state = id;
+  void clear() => state = null;
+}
+
+final selectedRipAlbumProvider =
+    NotifierProvider<SelectedRipAlbumNotifier, String?>(
+        () => SelectedRipAlbumNotifier());

--- a/lib/presentation/providers/selected_shelf_provider.dart
+++ b/lib/presentation/providers/selected_shelf_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Tracks the currently selected shelf ID for master-detail layout.
+class SelectedShelfNotifier extends Notifier<String?> {
+  @override
+  String? build() => null;
+
+  void select(String id) => state = id;
+  void clear() => state = null;
+}
+
+final selectedShelfProvider =
+    NotifierProvider<SelectedShelfNotifier, String?>(
+        () => SelectedShelfNotifier());

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -15,6 +15,7 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
   static const _tmdbKey = 'api_key_tmdb';
   static const _discogsKey = 'api_key_discogs';
   static const _upcitemdbKey = 'api_key_upcitemdb';
+  static const _googleBooksKey = 'api_key_google_books';
 
   @override
   Future<Map<String, String?>> build() async {
@@ -23,6 +24,7 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
       'tmdb': await storage.read(key: _tmdbKey),
       'discogs': await storage.read(key: _discogsKey),
       'upcitemdb': await storage.read(key: _upcitemdbKey),
+      'google_books': await storage.read(key: _googleBooksKey),
     };
   }
 
@@ -39,6 +41,12 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
   Future<void> setUpcitemdbKey(String key) async {
     await ref.read(secureStorageProvider).write(
         key: _upcitemdbKey, value: key);
+    ref.invalidateSelf();
+  }
+
+  Future<void> setGoogleBooksKey(String key) async {
+    await ref.read(secureStorageProvider).write(
+        key: _googleBooksKey, value: key);
     ref.invalidateSelf();
   }
 }

--- a/lib/presentation/screens/collection/collection_detail_panel.dart
+++ b/lib/presentation/screens/collection/collection_detail_panel.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/domain/usecases/delete_media_item_usecase.dart';
+import 'package:mymediascanner/domain/usecases/refresh_metadata_usecase.dart';
+import 'package:mymediascanner/domain/usecases/update_rating_usecase.dart';
+import 'package:mymediascanner/presentation/providers/metadata_provider.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/selected_item_provider.dart';
+import 'package:mymediascanner/presentation/screens/item_detail/widgets/cover_art_hero.dart';
+import 'package:mymediascanner/presentation/screens/item_detail/widgets/metadata_section.dart';
+import 'package:mymediascanner/presentation/screens/item_detail/widgets/star_rating_widget.dart';
+import 'package:mymediascanner/presentation/screens/item_detail/widgets/tag_chips.dart';
+import 'package:mymediascanner/presentation/widgets/error_state.dart';
+import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
+
+/// Embedded item detail for the master-detail side panel.
+///
+/// Unlike [ItemDetailScreen], this has no Scaffold or AppBar —
+/// it renders directly as the detail pane in a [MasterDetailLayout].
+class CollectionDetailPanel extends ConsumerWidget {
+  const CollectionDetailPanel({super.key, required this.itemId});
+
+  final String itemId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final itemAsync = ref.watch(mediaItemProvider(itemId));
+
+    return itemAsync.when(
+      loading: () => const LoadingIndicator(),
+      error: (e, _) => ErrorState(message: e.toString()),
+      data: (item) {
+        if (item == null) {
+          return const ErrorState(message: 'Item not found');
+        }
+        return Column(
+          children: [
+            // Toolbar
+            Material(
+              elevation: 1,
+              child: Padding(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        item.title,
+                        style: Theme.of(context).textTheme.titleMedium,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.refresh, size: 20),
+                      tooltip: 'Refresh metadata',
+                      onPressed: () async {
+                        final messenger = ScaffoldMessenger.of(context);
+                        try {
+                          await RefreshMetadataUseCase(
+                            metadataRepository:
+                                ref.read(metadataRepositoryProvider),
+                            mediaItemRepository:
+                                ref.read(mediaItemRepositoryProvider),
+                          ).execute(item);
+                          ref.invalidate(mediaItemProvider(itemId));
+                          messenger.showSnackBar(const SnackBar(
+                              content: Text('Metadata refreshed')));
+                        } catch (e) {
+                          messenger.showSnackBar(SnackBar(
+                              content:
+                                  Text('Failed to refresh metadata: $e')));
+                        }
+                      },
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.edit, size: 20),
+                      tooltip: 'Edit',
+                      onPressed: () =>
+                          context.go('/item/${item.id}/edit'),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline, size: 20),
+                      tooltip: 'Delete',
+                      onPressed: () => _confirmDelete(context, ref),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close, size: 20),
+                      tooltip: 'Close panel',
+                      onPressed: () =>
+                          ref.read(selectedItemProvider.notifier).clear(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // Content
+            Expanded(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Center(
+                      child: CoverArtHero(
+                        imageUrl: item.coverUrl,
+                        tag: 'panel-cover-${item.id}',
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    if (item.subtitle != null)
+                      Center(
+                        child: Text(item.subtitle!,
+                            style:
+                                Theme.of(context).textTheme.titleMedium),
+                      ),
+                    const SizedBox(height: 12),
+                    Center(
+                      child: StarRatingWidget(
+                        rating: item.userRating ?? 0,
+                        onChanged: (rating) {
+                          UpdateRatingUseCase(
+                            repository:
+                                ref.read(mediaItemRepositoryProvider),
+                          ).execute(item.id, rating: rating);
+                          ref.invalidate(mediaItemProvider(itemId));
+                        },
+                      ),
+                    ),
+                    if (item.criticScore != null) ...[
+                      const SizedBox(height: 8),
+                      Center(
+                        child: Text(
+                          '${item.criticScore!.toStringAsFixed(1)}/10 ${item.criticSource ?? ""}',
+                          style: Theme.of(context)
+                              .textTheme
+                              .bodySmall
+                              ?.copyWith(
+                                color:
+                                    Theme.of(context).colorScheme.tertiary,
+                              ),
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 12),
+                    TagChips(mediaItemId: item.id),
+                    if (item.userReview != null &&
+                        item.userReview!.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Card(
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: Text(item.userReview!),
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 12),
+                    MetadataSection(item: item),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _confirmDelete(BuildContext context, WidgetRef ref) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete item?'),
+        content: const Text('This item will be removed from your collection.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () async {
+              await DeleteMediaItemUseCase(
+                repository: ref.read(mediaItemRepositoryProvider),
+              ).execute(itemId);
+              ref.read(selectedItemProvider.notifier).clear();
+              if (ctx.mounted) Navigator.pop(ctx);
+            },
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/collection/collection_screen.dart
+++ b/lib/presentation/screens/collection/collection_screen.dart
@@ -2,7 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/usecases/delete_media_item_usecase.dart';
 import 'package:mymediascanner/domain/usecases/export_collection_usecase.dart';
+import 'package:mymediascanner/domain/usecases/refresh_metadata_usecase.dart';
 import 'package:mymediascanner/presentation/providers/collection_provider.dart';
 import 'package:mymediascanner/presentation/providers/loan_provider.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
@@ -10,88 +14,230 @@ import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 import 'package:mymediascanner/presentation/screens/collection/widgets/filter_bar.dart';
 import 'package:mymediascanner/presentation/screens/collection/widgets/media_item_card.dart';
 import 'package:mymediascanner/presentation/screens/collection/widgets/sort_selector.dart';
+import 'package:mymediascanner/presentation/screens/collection/widgets/shelf_picker_dialog.dart';
+import 'package:mymediascanner/presentation/screens/item_detail/widgets/borrower_picker_dialog.dart';
+import 'package:mymediascanner/presentation/providers/collection_view_mode_provider.dart';
+import 'package:mymediascanner/presentation/providers/selected_item_provider.dart';
+import 'package:mymediascanner/presentation/screens/collection/collection_detail_panel.dart';
+import 'package:mymediascanner/presentation/screens/collection/widgets/collection_table_view.dart';
+import 'package:mymediascanner/presentation/screens/collection/widgets/view_mode_toggle.dart';
+import 'package:mymediascanner/presentation/widgets/context_menu_actions.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_context_menu.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_shortcuts.dart';
 import 'package:mymediascanner/presentation/widgets/empty_state.dart';
 import 'package:mymediascanner/presentation/widgets/error_state.dart';
 import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
+import 'package:mymediascanner/presentation/widgets/master_detail_layout.dart';
 
-class CollectionScreen extends ConsumerWidget {
+class CollectionScreen extends ConsumerStatefulWidget {
   const CollectionScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<CollectionScreen> createState() => _CollectionScreenState();
+}
+
+class _CollectionScreenState extends ConsumerState<CollectionScreen> {
+  final _searchFocusNode = FocusNode();
+
+  @override
+  void dispose() {
+    _searchFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _onItemTap(BuildContext context, String itemId) {
+    final width = MediaQuery.sizeOf(context).width;
+    final useDetailPanel = PlatformCapability.isDesktop && width >= 900;
+    if (useDetailPanel) {
+      ref.read(selectedItemProvider.notifier).select(itemId);
+    } else {
+      context.go('/item/$itemId');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final collectionAsync = ref.watch(collectionProvider);
     final lentIds = ref.watch(lentItemIdsProvider).value ?? <String>{};
     final rippedIds = ref.watch(rippedItemIdsProvider).value ?? <String>{};
+    final selectedId = ref.watch(selectedItemProvider);
+    final viewMode = ref.watch(collectionViewModeProvider);
+    final isDesktop = PlatformCapability.isDesktop;
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('My Collection'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.download),
-            tooltip: 'Export collection',
-            onPressed: () => _showExportDialog(context, ref),
+    final masterContent = Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: SearchBar(
+            focusNode: _searchFocusNode,
+            hintText: 'Search collection...',
+            leading: const Icon(Icons.search),
+            onChanged: (query) =>
+                ref.read(collectionFilterProvider.notifier).setSearch(query),
           ),
-          IconButton(
-            icon: const Icon(Icons.bar_chart),
-            tooltip: 'Collection Statistics',
-            onPressed: () => context.go('/statistics'),
+        ),
+        Expanded(
+          child: collectionAsync.when(
+            loading: () => const LoadingIndicator(),
+            error: (e, _) => ErrorState(
+              message: e.toString(),
+              onRetry: () => ref.invalidate(collectionProvider),
+            ),
+            data: (items) {
+              if (items.isEmpty) {
+                return const EmptyState(
+                  message: 'No items yet. Scan a barcode to get started!',
+                  icon: Icons.library_music_outlined,
+                );
+              }
+              if (isDesktop &&
+                  viewMode == CollectionViewMode.table) {
+                return CollectionTableView(
+                  items: items,
+                  lentIds: lentIds,
+                  rippedIds: rippedIds,
+                  onItemTap: (id) => _onItemTap(context, id),
+                );
+              }
+              return GridView.builder(
+                padding: const EdgeInsets.all(16),
+                gridDelegate:
+                    const SliverGridDelegateWithMaxCrossAxisExtent(
+                  maxCrossAxisExtent: 200,
+                  childAspectRatio: 0.65,
+                  mainAxisSpacing: 12,
+                  crossAxisSpacing: 12,
+                ),
+                itemCount: items.length,
+                itemBuilder: (context, index) {
+                  final item = items[index];
+                  return MediaItemCard(
+                    item: item,
+                    isLent: lentIds.contains(item.id),
+                    isRipped: rippedIds.contains(item.id),
+                    onTap: () => _onItemTap(context, item.id),
+                    contextMenuActions: isDesktop
+                        ? _buildItemContextActions(
+                            context, ref, item)
+                        : const [],
+                  );
+                },
+              );
+            },
           ),
-          const SortSelector(),
-        ],
-        bottom: const PreferredSize(
-          preferredSize: Size.fromHeight(56),
-          child: FilterBar(),
+        ),
+      ],
+    );
+
+    return NotificationListener<SearchFocusNotification>(
+      onNotification: (_) {
+        _searchFocusNode.requestFocus();
+        return true;
+      },
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('My Collection'),
+          actions: [
+            if (isDesktop) const ViewModeToggle(),
+            IconButton(
+              icon: const Icon(Icons.download),
+              tooltip: 'Export collection',
+              onPressed: () => _showExportDialog(context, ref),
+            ),
+            IconButton(
+              icon: const Icon(Icons.bar_chart),
+              tooltip: 'Collection Statistics',
+              onPressed: () => context.go('/statistics'),
+            ),
+            const SortSelector(),
+          ],
+          bottom: const PreferredSize(
+            preferredSize: Size.fromHeight(56),
+            child: FilterBar(),
+          ),
+        ),
+        body: MasterDetailLayout(
+          master: masterContent,
+          detail: selectedId != null
+              ? CollectionDetailPanel(itemId: selectedId)
+              : null,
         ),
       ),
-      body: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: SearchBar(
-              hintText: 'Search collection...',
-              leading: const Icon(Icons.search),
-              onChanged: (query) =>
-                  ref.read(collectionFilterProvider.notifier).setSearch(query),
-            ),
+    );
+  }
+
+  List<ContextMenuAction> _buildItemContextActions(
+    BuildContext context,
+    WidgetRef ref,
+    MediaItem item,
+  ) {
+    return ContextMenuActions.forMediaItem(
+      onEdit: () => context.go('/item/${item.id}/edit'),
+      onDelete: () => _confirmDeleteItem(context, ref, item.id),
+      onAddToShelf: () => showDialog<void>(
+        context: context,
+        builder: (_) => ShelfPickerDialog(mediaItemId: item.id),
+      ),
+      onLend: () => showDialog<void>(
+        context: context,
+        builder: (_) => BorrowerPickerDialog(mediaItemId: item.id),
+      ),
+      onRefreshMetadata: () => _refreshItemMetadata(context, ref, item),
+    );
+  }
+
+  void _confirmDeleteItem(
+      BuildContext context, WidgetRef ref, String itemId) {
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete item?'),
+        content: const Text('This item will be removed from your collection.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
           ),
-          Expanded(
-            child: collectionAsync.when(
-              loading: () => const LoadingIndicator(),
-              error: (e, _) => ErrorState(
-                message: e.toString(),
-                onRetry: () => ref.invalidate(collectionProvider),
-              ),
-              data: (items) {
-                if (items.isEmpty) {
-                  return const EmptyState(
-                    message: 'No items yet. Scan a barcode to get started!',
-                    icon: Icons.library_music_outlined,
-                  );
-                }
-                return GridView.builder(
-                  padding: const EdgeInsets.all(16),
-                  gridDelegate:
-                      const SliverGridDelegateWithMaxCrossAxisExtent(
-                    maxCrossAxisExtent: 200,
-                    childAspectRatio: 0.65,
-                    mainAxisSpacing: 12,
-                    crossAxisSpacing: 12,
-                  ),
-                  itemCount: items.length,
-                  itemBuilder: (context, index) => MediaItemCard(
-                    item: items[index],
-                    isLent: lentIds.contains(items[index].id),
-                    isRipped: rippedIds.contains(items[index].id),
-                    onTap: () => context.go('/item/${items[index].id}'),
-                  ),
-                );
-              },
-            ),
+          FilledButton(
+            onPressed: () async {
+              await DeleteMediaItemUseCase(
+                repository: ref.read(mediaItemRepositoryProvider),
+              ).execute(itemId);
+              if (ctx.mounted) Navigator.pop(ctx);
+            },
+            child: const Text('Delete'),
           ),
         ],
       ),
     );
+  }
+
+  Future<void> _refreshItemMetadata(
+    BuildContext context,
+    WidgetRef ref,
+    MediaItem item,
+  ) async {
+    final messenger = ScaffoldMessenger.of(context);
+    messenger.showSnackBar(
+      const SnackBar(content: Text('Refreshing metadata\u2026')),
+    );
+    try {
+      await RefreshMetadataUseCase(
+        metadataRepository: ref.read(metadataRepositoryProvider),
+        mediaItemRepository: ref.read(mediaItemRepositoryProvider),
+      ).execute(item);
+      messenger
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          const SnackBar(content: Text('Metadata refreshed')),
+        );
+    } catch (e) {
+      messenger
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(content: Text('Failed to refresh metadata: $e')),
+        );
+    }
   }
 
   void _showExportDialog(BuildContext context, WidgetRef ref) {

--- a/lib/presentation/screens/collection/widgets/collection_table_view.dart
+++ b/lib/presentation/screens/collection/widgets/collection_table_view.dart
@@ -1,0 +1,152 @@
+import 'package:data_table_2/data_table_2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/presentation/providers/collection_provider.dart';
+import 'package:mymediascanner/presentation/providers/selected_item_provider.dart';
+
+/// Sortable data table for the collection, used on desktop.
+class CollectionTableView extends ConsumerWidget {
+  const CollectionTableView({
+    super.key,
+    required this.items,
+    required this.lentIds,
+    required this.rippedIds,
+    required this.onItemTap,
+  });
+
+  final List<MediaItem> items;
+  final Set<String> lentIds;
+  final Set<String> rippedIds;
+  final ValueChanged<String> onItemTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filter = ref.watch(collectionFilterProvider);
+    final selectedId = ref.watch(selectedItemProvider);
+    final dateFormat = DateFormat.yMMMd();
+
+    return DataTable2(
+      columnSpacing: 12,
+      horizontalMargin: 16,
+      sortColumnIndex: _sortColumnIndex(filter.sortBy),
+      sortAscending: filter.ascending,
+      headingRowDecoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      ),
+      columns: [
+        DataColumn2(
+          label: const Text('Title'),
+          size: ColumnSize.L,
+          onSort: (_, ascending) => ref
+              .read(collectionFilterProvider.notifier)
+              .setSort('title', ascending: ascending),
+        ),
+        DataColumn2(
+          label: const Text('Artist / Director'),
+          size: ColumnSize.M,
+          onSort: (_, ascending) => ref
+              .read(collectionFilterProvider.notifier)
+              .setSort('subtitle', ascending: ascending),
+        ),
+        DataColumn2(
+          label: const Text('Type'),
+          fixedWidth: 80,
+          onSort: (_, ascending) => ref
+              .read(collectionFilterProvider.notifier)
+              .setSort('mediaType', ascending: ascending),
+        ),
+        DataColumn2(
+          label: const Text('Format'),
+          fixedWidth: 100,
+          onSort: (_, ascending) => ref
+              .read(collectionFilterProvider.notifier)
+              .setSort('format', ascending: ascending),
+        ),
+        const DataColumn2(
+          label: Text('Barcode'),
+          fixedWidth: 140,
+        ),
+        DataColumn2(
+          label: const Text('Added'),
+          fixedWidth: 120,
+          onSort: (_, ascending) => ref
+              .read(collectionFilterProvider.notifier)
+              .setSort('dateAdded', ascending: ascending),
+        ),
+        DataColumn2(
+          label: const Text('Rating'),
+          fixedWidth: 80,
+          numeric: true,
+          onSort: (_, ascending) => ref
+              .read(collectionFilterProvider.notifier)
+              .setSort('userRating', ascending: ascending),
+        ),
+      ],
+      rows: items.map((item) {
+        final isSelected = item.id == selectedId;
+        return DataRow2(
+          selected: isSelected,
+          onTap: () => onItemTap(item.id),
+          cells: [
+            DataCell(Text(
+              item.title,
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            )),
+            DataCell(Text(
+              item.subtitle ?? '',
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            )),
+            DataCell(_TypeChip(type: item.mediaType)),
+            DataCell(Text(item.format ?? '')),
+            DataCell(Text(item.barcode)),
+            DataCell(Text(dateFormat.format(
+              DateTime.fromMillisecondsSinceEpoch(item.dateAdded),
+            ))),
+            DataCell(
+              item.userRating != null
+                  ? Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(Icons.star,
+                            size: 14, color: Colors.amber.shade700),
+                        const SizedBox(width: 2),
+                        Text(item.userRating!.toStringAsFixed(1)),
+                      ],
+                    )
+                  : const Text(''),
+            ),
+          ],
+        );
+      }).toList(),
+    );
+  }
+
+  int? _sortColumnIndex(String? sortBy) => switch (sortBy) {
+        'title' => 0,
+        'subtitle' => 1,
+        'mediaType' => 2,
+        'format' => 3,
+        'dateAdded' => 5,
+        'userRating' => 6,
+        _ => null,
+      };
+}
+
+class _TypeChip extends StatelessWidget {
+  const _TypeChip({required this.type});
+
+  final MediaType type;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      type.label,
+      style: Theme.of(context).textTheme.bodySmall,
+    );
+  }
+}

--- a/lib/presentation/screens/collection/widgets/media_item_card.dart
+++ b/lib/presentation/screens/collection/widgets/media_item_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:mymediascanner/app/theme/app_colors.dart';
 import 'package:mymediascanner/domain/entities/media_item.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_context_menu.dart';
 
 class MediaItemCard extends StatelessWidget {
   const MediaItemCard({
@@ -11,12 +12,14 @@ class MediaItemCard extends StatelessWidget {
     required this.onTap,
     this.isLent = false,
     this.isRipped = false,
+    this.contextMenuActions = const [],
   });
 
   final MediaItem item;
   final VoidCallback onTap;
   final bool isLent;
   final bool isRipped;
+  final List<ContextMenuAction> contextMenuActions;
 
   Color _typeColour(MediaType type) => switch (type) {
         MediaType.film => AppColors.filmColor,
@@ -29,7 +32,9 @@ class MediaItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
+    return DesktopContextMenu(
+      actions: contextMenuActions,
+      child: Card(
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
@@ -150,6 +155,7 @@ class MediaItemCard extends StatelessWidget {
           ],
         ),
       ),
+    ),
     );
   }
 }

--- a/lib/presentation/screens/collection/widgets/shelf_picker_dialog.dart
+++ b/lib/presentation/screens/collection/widgets/shelf_picker_dialog.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/domain/usecases/manage_shelves_usecase.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/shelf_provider.dart';
+
+/// Dialog that lets the user pick a shelf to add an item to.
+class ShelfPickerDialog extends ConsumerWidget {
+  const ShelfPickerDialog({super.key, required this.mediaItemId});
+
+  final String mediaItemId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final shelvesAsync = ref.watch(allShelvesProvider);
+
+    return AlertDialog(
+      title: const Text('Add to shelf'),
+      content: SizedBox(
+        width: 300,
+        child: shelvesAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Text('Error: $e'),
+          data: (shelves) {
+            if (shelves.isEmpty) {
+              return const Text('No shelves yet. Create one first.');
+            }
+            return ListView.builder(
+              shrinkWrap: true,
+              itemCount: shelves.length,
+              itemBuilder: (context, index) {
+                final shelf = shelves[index];
+                return ListTile(
+                  leading: const Icon(Icons.shelves),
+                  title: Text(shelf.name),
+                  onTap: () async {
+                    final useCase = ManageShelvesUseCase(
+                      repository: ref.read(shelfRepositoryProvider),
+                    );
+                    await useCase.addItem(
+                      shelfId: shelf.id,
+                      mediaItemId: mediaItemId,
+                      position: 0,
+                    );
+                    ref.invalidate(shelfItemIdsProvider(shelf.id));
+                    if (context.mounted) {
+                      Navigator.pop(context);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('Added to "${shelf.name}"'),
+                        ),
+                      );
+                    }
+                  },
+                );
+              },
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/screens/collection/widgets/view_mode_toggle.dart
+++ b/lib/presentation/screens/collection/widgets/view_mode_toggle.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/presentation/providers/collection_view_mode_provider.dart';
+
+/// Toggle button between grid and table view modes.
+/// Desktop only — the parent should guard visibility.
+class ViewModeToggle extends ConsumerWidget {
+  const ViewModeToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(collectionViewModeProvider);
+
+    return SegmentedButton<CollectionViewMode>(
+      showSelectedIcon: false,
+      segments: const [
+        ButtonSegment(
+          value: CollectionViewMode.grid,
+          icon: Icon(Icons.grid_view, size: 18),
+        ),
+        ButtonSegment(
+          value: CollectionViewMode.table,
+          icon: Icon(Icons.table_rows, size: 18),
+        ),
+      ],
+      selected: {mode},
+      onSelectionChanged: (selection) {
+        ref
+            .read(collectionViewModeProvider.notifier)
+            .setMode(selection.first);
+      },
+    );
+  }
+}

--- a/lib/presentation/screens/rips/widgets/rip_library_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_library_view.dart
@@ -2,12 +2,18 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/core/constants/app_constants.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
 import 'package:mymediascanner/domain/entities/rip_album.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+import 'package:mymediascanner/presentation/providers/selected_rip_album_provider.dart';
+import 'package:mymediascanner/presentation/providers/rip_view_mode_provider.dart';
 import 'package:mymediascanner/presentation/screens/rips/widgets/rip_album_detail_dialog.dart';
+import 'package:mymediascanner/presentation/screens/rips/widgets/rip_table_view.dart';
 import 'package:mymediascanner/presentation/widgets/empty_state.dart';
 import 'package:mymediascanner/presentation/widgets/error_state.dart';
 import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
+import 'package:mymediascanner/presentation/widgets/master_detail_layout.dart';
 
 /// Displays all rip albums from the local FLAC library with search and scan.
 class RipLibraryView extends ConsumerStatefulWidget {
@@ -20,12 +26,28 @@ class RipLibraryView extends ConsumerStatefulWidget {
 class _RipLibraryViewState extends ConsumerState<RipLibraryView> {
   String _searchQuery = '';
 
+  void _onAlbumTap(BuildContext context, RipAlbum album) {
+    final width = MediaQuery.sizeOf(context).width;
+    final useDetailPanel = PlatformCapability.isDesktop &&
+        width >= AppConstants.mediumBreakpoint;
+    if (useDetailPanel) {
+      ref.read(selectedRipAlbumProvider.notifier).select(album.id);
+    } else {
+      showDialog<void>(
+        context: context,
+        builder: (_) => RipAlbumDetailDialog(album: album),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final albumsAsync = ref.watch(allRipAlbumsProvider);
     final scanState = ref.watch(ripScanNotifierProvider);
+    final selectedAlbumId = ref.watch(selectedRipAlbumProvider);
+    final viewMode = ref.watch(ripViewModeProvider);
 
-    return Column(
+    final masterContent = Column(
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -57,6 +79,26 @@ class _RipLibraryViewState extends ConsumerState<RipLibraryView> {
                 label: Text(scanState.status == RipScanStatus.scanning
                     ? 'Scanning...'
                     : 'Scan Library'),
+              ),
+              const SizedBox(width: 8),
+              SegmentedButton<RipViewMode>(
+                showSelectedIcon: false,
+                segments: const [
+                  ButtonSegment(
+                    value: RipViewMode.grid,
+                    icon: Icon(Icons.grid_view, size: 18),
+                  ),
+                  ButtonSegment(
+                    value: RipViewMode.table,
+                    icon: Icon(Icons.table_rows, size: 18),
+                  ),
+                ],
+                selected: {viewMode},
+                onSelectionChanged: (selection) {
+                  ref
+                      .read(ripViewModeProvider.notifier)
+                      .setMode(selection.first);
+                },
               ),
             ],
           ),
@@ -95,6 +137,13 @@ class _RipLibraryViewState extends ConsumerState<RipLibraryView> {
                 );
               }
 
+              if (viewMode == RipViewMode.table) {
+                return RipTableView(
+                  albums: filtered,
+                  onAlbumTap: (album) => _onAlbumTap(context, album),
+                );
+              }
+
               return GridView.builder(
                 padding: const EdgeInsets.all(16),
                 gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
@@ -104,13 +153,31 @@ class _RipLibraryViewState extends ConsumerState<RipLibraryView> {
                   crossAxisSpacing: 12,
                 ),
                 itemCount: filtered.length,
-                itemBuilder: (context, index) =>
-                    _RipAlbumCard(album: filtered[index]),
+                itemBuilder: (context, index) => _RipAlbumCard(
+                  album: filtered[index],
+                  onTap: () => _onAlbumTap(context, filtered[index]),
+                ),
               );
             },
           ),
         ),
       ],
+    );
+
+    // Build detail panel from selected album
+    Widget? detailPanel;
+    if (selectedAlbumId != null) {
+      final allAlbums = albumsAsync.whenOrNull(data: (a) => a) ?? [];
+      final selectedAlbum =
+          allAlbums.where((a) => a.id == selectedAlbumId).firstOrNull;
+      if (selectedAlbum != null) {
+        detailPanel = _RipAlbumDetailPanel(album: selectedAlbum);
+      }
+    }
+
+    return MasterDetailLayout(
+      master: masterContent,
+      detail: detailPanel,
     );
   }
 
@@ -131,9 +198,10 @@ class _RipLibraryViewState extends ConsumerState<RipLibraryView> {
 }
 
 class _RipAlbumCard extends ConsumerWidget {
-  const _RipAlbumCard({required this.album});
+  const _RipAlbumCard({required this.album, this.onTap});
 
   final RipAlbum album;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -149,10 +217,11 @@ class _RipAlbumCard extends ConsumerWidget {
     return Card(
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => showDialog<void>(
-          context: context,
-          builder: (_) => RipAlbumDetailDialog(album: album),
-        ),
+        onTap: onTap ??
+            () => showDialog<void>(
+                  context: context,
+                  builder: (_) => RipAlbumDetailDialog(album: album),
+                ),
         child: Padding(
           padding: const EdgeInsets.all(12),
           child: Column(
@@ -231,5 +300,103 @@ class _RipAlbumCard extends ConsumerWidget {
       return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
     }
     return '${(bytes / (1024 * 1024)).toStringAsFixed(0)} MB';
+  }
+}
+
+/// Embedded rip album detail for the master-detail side panel.
+class _RipAlbumDetailPanel extends ConsumerWidget {
+  const _RipAlbumDetailPanel({required this.album});
+
+  final RipAlbum album;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tracksAsync = ref.watch(ripTracksProvider(album.id));
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Toolbar
+        Material(
+          elevation: 1,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        album.artist ?? 'Unknown Artist',
+                        style: theme.textTheme.titleSmall,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Text(
+                        album.albumTitle ?? 'Unknown Album',
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 20),
+                  tooltip: 'Close panel',
+                  onPressed: () =>
+                      ref.read(selectedRipAlbumProvider.notifier).clear(),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+          child: Text(
+            album.libraryPath,
+            style: theme.textTheme.bodySmall?.copyWith(color: theme.hintColor),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        const Divider(),
+        // Track listing
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Text('Tracks', style: theme.textTheme.titleSmall),
+        ),
+        Expanded(
+          child: tracksAsync.when(
+            loading: () => const LoadingIndicator(),
+            error: (e, _) => Center(child: Text('Error: $e')),
+            data: (tracks) {
+              if (tracks.isEmpty) {
+                return const Center(child: Text('No tracks found.'));
+              }
+              return ListView.builder(
+                itemCount: tracks.length,
+                itemBuilder: (context, index) {
+                  final track = tracks[index];
+                  return ListTile(
+                    dense: true,
+                    title: Text(
+                      track.title ?? 'Track ${track.trackNumber}',
+                      style: theme.textTheme.bodyMedium,
+                    ),
+                    subtitle: track.accurateRipStatus != null
+                        ? Text(track.accurateRipStatus!,
+                            style: theme.textTheme.bodySmall)
+                        : null,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ],
+    );
   }
 }

--- a/lib/presentation/screens/rips/widgets/rip_table_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_table_view.dart
@@ -1,0 +1,150 @@
+import 'package:data_table_2/data_table_2.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+import 'package:mymediascanner/presentation/providers/selected_rip_album_provider.dart';
+
+/// Sortable data table for the rips library, used on desktop.
+class RipTableView extends ConsumerStatefulWidget {
+  const RipTableView({
+    super.key,
+    required this.albums,
+    required this.onAlbumTap,
+  });
+
+  final List<RipAlbum> albums;
+  final ValueChanged<RipAlbum> onAlbumTap;
+
+  @override
+  ConsumerState<RipTableView> createState() => _RipTableViewState();
+}
+
+class _RipTableViewState extends ConsumerState<RipTableView> {
+  int? _sortColumnIndex;
+  bool _sortAscending = true;
+  late List<RipAlbum> _sorted;
+
+  @override
+  void initState() {
+    super.initState();
+    _sorted = List.of(widget.albums);
+  }
+
+  @override
+  void didUpdateWidget(covariant RipTableView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.albums != oldWidget.albums) {
+      _sorted = List.of(widget.albums);
+      _applySortIfSet();
+    }
+  }
+
+  void _sort(int columnIndex, bool ascending) {
+    setState(() {
+      _sortColumnIndex = columnIndex;
+      _sortAscending = ascending;
+      _applySortIfSet();
+    });
+  }
+
+  void _applySortIfSet() {
+    if (_sortColumnIndex == null) return;
+    _sorted.sort((a, b) {
+      final cmp = switch (_sortColumnIndex) {
+        0 => (a.artist ?? '').compareTo(b.artist ?? ''),
+        1 => (a.albumTitle ?? '').compareTo(b.albumTitle ?? ''),
+        2 => a.trackCount.compareTo(b.trackCount),
+        3 => a.totalSizeBytes.compareTo(b.totalSizeBytes),
+        _ => 0,
+      };
+      return _sortAscending ? cmp : -cmp;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedId = ref.watch(selectedRipAlbumProvider);
+
+    return DataTable2(
+      columnSpacing: 12,
+      horizontalMargin: 16,
+      sortColumnIndex: _sortColumnIndex,
+      sortAscending: _sortAscending,
+      headingRowDecoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+      ),
+      columns: [
+        DataColumn2(
+          label: const Text('Artist'),
+          size: ColumnSize.M,
+          onSort: _sort,
+        ),
+        DataColumn2(
+          label: const Text('Album'),
+          size: ColumnSize.L,
+          onSort: _sort,
+        ),
+        DataColumn2(
+          label: const Text('Tracks'),
+          fixedWidth: 70,
+          numeric: true,
+          onSort: _sort,
+        ),
+        DataColumn2(
+          label: const Text('Size'),
+          fixedWidth: 90,
+          numeric: true,
+          onSort: _sort,
+        ),
+        const DataColumn2(
+          label: Text('AR'),
+          fixedWidth: 80,
+        ),
+        const DataColumn2(
+          label: Text('Linked'),
+          fixedWidth: 60,
+        ),
+      ],
+      rows: _sorted.map((album) {
+        final tracksAsync = ref.watch(ripTracksProvider(album.id));
+        final tracks = tracksAsync.whenOrNull(data: (t) => t) ?? [];
+        final arVerified =
+            tracks.where((t) => t.accurateRipStatus == 'verified').length;
+
+        return DataRow2(
+          selected: album.id == selectedId,
+          onTap: () => widget.onAlbumTap(album),
+          cells: [
+            DataCell(Text(
+              album.artist ?? 'Unknown',
+              overflow: TextOverflow.ellipsis,
+            )),
+            DataCell(Text(
+              album.albumTitle ?? 'Unknown',
+              overflow: TextOverflow.ellipsis,
+            )),
+            DataCell(Text('${album.trackCount}')),
+            DataCell(Text(_formatSize(album.totalSizeBytes))),
+            DataCell(Text(
+                tracks.isEmpty ? '' : '$arVerified/${tracks.length}')),
+            DataCell(Icon(
+              album.mediaItemId != null ? Icons.link : Icons.link_off,
+              size: 16,
+              color: album.mediaItemId != null
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).hintColor,
+            )),
+          ],
+        );
+      }).toList(),
+    );
+  }
+
+  String _formatSize(int bytes) {
+    if (bytes >= 1024 * 1024 * 1024) {
+      return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+    }
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(0)} MB';
+  }
+}

--- a/lib/presentation/screens/scanner/desktop_scan_screen.dart
+++ b/lib/presentation/screens/scanner/desktop_scan_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mymediascanner/presentation/providers/scanner_provider.dart';
 import 'package:mymediascanner/presentation/screens/scanner/widgets/batch_scan_counter.dart';
 import 'package:mymediascanner/presentation/screens/scanner/widgets/media_type_toggles.dart';
+import 'package:mymediascanner/presentation/screens/scanner/widgets/scan_mode_toggle.dart';
 import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
 
 class DesktopScanScreen extends ConsumerStatefulWidget {
@@ -67,6 +68,8 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             const SizedBox(height: 16),
+            const ScanModeToggle(),
+            const SizedBox(height: 16),
             Text(
               'Look up as:',
               style: Theme.of(context).textTheme.labelMedium,
@@ -90,19 +93,30 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
             const SizedBox(height: 16),
             SizedBox(
               width: 400,
-              child: TextField(
-                controller: _controller,
-                focusNode: _focusNode,
-                autofocus: true,
-                decoration: const InputDecoration(
-                  hintText: 'Barcode / ISBN',
-                  border: OutlineInputBorder(),
-                  prefixIcon: Icon(Icons.qr_code),
+              child: KeyboardListener(
+                focusNode: FocusNode(),
+                onKeyEvent: (event) {
+                  if (event is KeyDownEvent &&
+                      event.logicalKey == LogicalKeyboardKey.escape) {
+                    _controller.clear();
+                    ref.read(scannerProvider.notifier).reset();
+                    _focusNode.requestFocus();
+                  }
+                },
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focusNode,
+                  autofocus: true,
+                  decoration: const InputDecoration(
+                    hintText: 'Barcode / ISBN',
+                    border: OutlineInputBorder(),
+                    prefixIcon: Icon(Icons.qr_code),
+                  ),
+                  onSubmitted: _onSubmitted,
+                  inputFormatters: [
+                    FilteringTextInputFormatter.allow(RegExp(r'[\dXx]')),
+                  ],
                 ),
-                onSubmitted: _onSubmitted,
-                inputFormatters: [
-                  FilteringTextInputFormatter.allow(RegExp(r'[\dXx]')),
-                ],
               ),
             ),
             const SizedBox(height: 16),

--- a/lib/presentation/screens/scanner/mobile_scan_screen.dart
+++ b/lib/presentation/screens/scanner/mobile_scan_screen.dart
@@ -13,6 +13,7 @@ import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:mymediascanner/presentation/providers/scanner_provider.dart';
 import 'package:mymediascanner/presentation/screens/scanner/widgets/batch_scan_counter.dart';
 import 'package:mymediascanner/presentation/screens/scanner/widgets/media_type_toggles.dart';
+import 'package:mymediascanner/presentation/screens/scanner/widgets/scan_mode_toggle.dart';
 import 'package:mymediascanner/presentation/screens/scanner/widgets/scan_overlay.dart';
 import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
 
@@ -304,7 +305,7 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen> {
           },
         ),
         const ScanOverlay(),
-        // Media type toggles at the bottom
+        // Scan mode and media type toggles at the bottom
         Positioned(
           left: 16,
           right: 16,
@@ -315,7 +316,14 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen> {
               color: Colors.black54,
               borderRadius: BorderRadius.circular(12),
             ),
-            child: const MediaTypeToggles(),
+            child: const Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ScanModeToggle(),
+                SizedBox(height: 8),
+                MediaTypeToggles(),
+              ],
+            ),
           ),
         ),
         if (scannerState.state == ScanState.lookingUp)
@@ -352,6 +360,8 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen> {
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
+          const ScanModeToggle(),
+          const SizedBox(height: 12),
           const MediaTypeToggles(),
           const SizedBox(height: 24),
           SizedBox(

--- a/lib/presentation/screens/scanner/widgets/scan_mode_toggle.dart
+++ b/lib/presentation/screens/scanner/widgets/scan_mode_toggle.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/presentation/providers/scanner_provider.dart';
+
+/// Segmented button to choose between Barcode and ISBN scan modes.
+class ScanModeToggle extends ConsumerWidget {
+  const ScanModeToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(
+      scannerProvider.select((s) => s.scanMode),
+    );
+
+    return SegmentedButton<ScanMode>(
+      segments: const [
+        ButtonSegment(
+          value: ScanMode.barcode,
+          label: Text('Barcode'),
+          icon: Icon(Icons.qr_code, size: 18),
+        ),
+        ButtonSegment(
+          value: ScanMode.isbn,
+          label: Text('ISBN'),
+          icon: Icon(Icons.menu_book, size: 18),
+        ),
+      ],
+      selected: {mode},
+      onSelectionChanged: (selection) {
+        ref.read(scannerProvider.notifier).setScanMode(selection.first);
+      },
+    );
+  }
+}

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -140,16 +141,35 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        TextField(
-          controller: _pathController,
-          decoration: const InputDecoration(
-            labelText: 'Library root path',
-            hintText: '/path/to/flac/library',
-            border: OutlineInputBorder(),
-          ),
-          onSubmitted: (value) {
-            ref.read(ripLibraryPathProvider.notifier).setPath(value);
-          },
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _pathController,
+                decoration: const InputDecoration(
+                  labelText: 'Library root path',
+                  hintText: '/path/to/flac/library',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (value) {
+                  ref.read(ripLibraryPathProvider.notifier).setPath(value);
+                },
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Icons.folder_open),
+              tooltip: 'Browse\u2026',
+              onPressed: () async {
+                final path =
+                    await FilePicker.platform.getDirectoryPath();
+                if (path != null) {
+                  _pathController.text = path;
+                  ref.read(ripLibraryPathProvider.notifier).setPath(path);
+                }
+              },
+            ),
+          ],
         ),
         const SizedBox(height: 12),
         Row(
@@ -202,19 +222,42 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
         ),
         const SizedBox(height: 16),
         // flac binary path override
-        TextField(
-          controller: _flacBinaryController,
-          decoration: const InputDecoration(
-            labelText: 'flac binary path (optional)',
-            hintText: '/opt/homebrew/bin/flac',
-            helperText: 'Leave empty to use flac from PATH',
-            border: OutlineInputBorder(),
-          ),
-          onSubmitted: (value) {
-            ref
-                .read(flacBinaryPathOverrideProvider.notifier)
-                .setPath(value.trim());
-          },
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _flacBinaryController,
+                decoration: const InputDecoration(
+                  labelText: 'flac binary path (optional)',
+                  hintText: '/opt/homebrew/bin/flac',
+                  helperText: 'Leave empty to use flac from PATH',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (value) {
+                  ref
+                      .read(flacBinaryPathOverrideProvider.notifier)
+                      .setPath(value.trim());
+                },
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              icon: const Icon(Icons.folder_open),
+              tooltip: 'Browse\u2026',
+              onPressed: () async {
+                final result = await FilePicker.platform.pickFiles(
+                  dialogTitle: 'Select flac binary',
+                );
+                if (result != null && result.files.single.path != null) {
+                  final path = result.files.single.path!;
+                  _flacBinaryController.text = path;
+                  ref
+                      .read(flacBinaryPathOverrideProvider.notifier)
+                      .setPath(path);
+                }
+              },
+            ),
+          ],
         ),
         const SizedBox(height: 16),
         // Click detection threshold slider

--- a/lib/presentation/screens/settings/widgets/api_key_form.dart
+++ b/lib/presentation/screens/settings/widgets/api_key_form.dart
@@ -13,6 +13,7 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
   final _tmdbController = TextEditingController();
   final _discogsController = TextEditingController();
   final _upcController = TextEditingController();
+  final _googleBooksController = TextEditingController();
 
   @override
   void initState() {
@@ -25,6 +26,7 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
     _tmdbController.text = keys['tmdb'] ?? '';
     _discogsController.text = keys['discogs'] ?? '';
     _upcController.text = keys['upcitemdb'] ?? '';
+    _googleBooksController.text = keys['google_books'] ?? '';
   }
 
   @override
@@ -32,6 +34,7 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
     _tmdbController.dispose();
     _discogsController.dispose();
     _upcController.dispose();
+    _googleBooksController.dispose();
     super.dispose();
   }
 
@@ -55,6 +58,11 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
         const SizedBox(height: 12),
         _keyField('UPCitemdb Key', _upcController, (key) {
           ref.read(apiKeysProvider.notifier).setUpcitemdbKey(key);
+        }),
+        const SizedBox(height: 12),
+        _keyField('Google Books API Key (optional)', _googleBooksController,
+            (key) {
+          ref.read(apiKeysProvider.notifier).setGoogleBooksKey(key);
         }),
       ],
     );

--- a/lib/presentation/screens/shelves/shelves_screen.dart
+++ b/lib/presentation/screens/shelves/shelves_screen.dart
@@ -1,18 +1,76 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/domain/entities/shelf.dart';
 import 'package:mymediascanner/domain/usecases/manage_shelves_usecase.dart';
+import 'package:mymediascanner/presentation/providers/metadata_provider.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/selected_shelf_provider.dart';
 import 'package:mymediascanner/presentation/providers/shelf_provider.dart';
+import 'package:mymediascanner/presentation/widgets/context_menu_actions.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_context_menu.dart';
 import 'package:mymediascanner/presentation/widgets/empty_state.dart';
 import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
+import 'package:mymediascanner/presentation/widgets/master_detail_layout.dart';
 
 class ShelvesScreen extends ConsumerWidget {
   const ShelvesScreen({super.key});
 
+  void _onShelfTap(BuildContext context, WidgetRef ref, String shelfId) {
+    final width = MediaQuery.sizeOf(context).width;
+    final useDetailPanel = PlatformCapability.isDesktop && width >= 900;
+    if (useDetailPanel) {
+      ref.read(selectedShelfProvider.notifier).select(shelfId);
+    } else {
+      context.go('/shelves/$shelfId');
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final shelvesAsync = ref.watch(allShelvesProvider);
+    final selectedShelfId = ref.watch(selectedShelfProvider);
+
+    final masterContent = shelvesAsync.when(
+      loading: () => const LoadingIndicator(),
+      error: (e, _) => Center(child: Text(e.toString())),
+      data: (shelves) {
+        if (shelves.isEmpty) {
+          return const EmptyState(
+            message:
+                'No shelves yet. Create one to organise your collection!',
+            icon: Icons.shelves,
+          );
+        }
+        return ListView.builder(
+          itemCount: shelves.length,
+          itemBuilder: (context, index) {
+            final shelf = shelves[index];
+            return DesktopContextMenu(
+              actions: PlatformCapability.isDesktop
+                  ? ContextMenuActions.forShelf(
+                      onRename: () =>
+                          _showRenameShelfDialog(context, ref, shelf),
+                      onDelete: () =>
+                          _confirmDeleteShelf(context, ref, shelf),
+                    )
+                  : const [],
+              child: ListTile(
+                leading: const Icon(Icons.shelves),
+                title: Text(shelf.name),
+                subtitle: shelf.description != null
+                    ? Text(shelf.description!)
+                    : null,
+                trailing: const Icon(Icons.chevron_right),
+                selected: shelf.id == selectedShelfId,
+                onTap: () => _onShelfTap(context, ref, shelf.id),
+              ),
+            );
+          },
+        );
+      },
+    );
 
     return Scaffold(
       appBar: AppBar(title: const Text('Shelves')),
@@ -20,33 +78,80 @@ class ShelvesScreen extends ConsumerWidget {
         onPressed: () => _showCreateShelfDialog(context, ref),
         child: const Icon(Icons.add),
       ),
-      body: shelvesAsync.when(
-        loading: () => const LoadingIndicator(),
-        error: (e, _) => Center(child: Text(e.toString())),
-        data: (shelves) {
-          if (shelves.isEmpty) {
-            return const EmptyState(
-              message:
-                  'No shelves yet. Create one to organise your collection!',
-              icon: Icons.shelves,
-            );
-          }
-          return ListView.builder(
-            itemCount: shelves.length,
-            itemBuilder: (context, index) {
-              final shelf = shelves[index];
-              return ListTile(
-                leading: const Icon(Icons.shelves),
-                title: Text(shelf.name),
-                subtitle: shelf.description != null
-                    ? Text(shelf.description!)
-                    : null,
-                trailing: const Icon(Icons.chevron_right),
-                onTap: () => context.go('/shelves/${shelf.id}'),
-              );
+      body: MasterDetailLayout(
+        master: masterContent,
+        detail: selectedShelfId != null
+            ? _ShelfDetailPanel(shelfId: selectedShelfId)
+            : null,
+      ),
+    );
+  }
+
+  void _showRenameShelfDialog(
+      BuildContext context, WidgetRef ref, Shelf shelf) {
+    final nameController = TextEditingController(text: shelf.name);
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Rename Shelf'),
+        content: TextField(
+          controller: nameController,
+          decoration: const InputDecoration(hintText: 'Shelf name'),
+          autofocus: true,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () async {
+              final newName = nameController.text.trim();
+              if (newName.isNotEmpty && newName != shelf.name) {
+                final updated = shelf.copyWith(
+                  name: newName,
+                  updatedAt: DateTime.now().millisecondsSinceEpoch,
+                );
+                await ref.read(shelfRepositoryProvider).save(updated);
+                ref.invalidate(allShelvesProvider);
+              }
+              if (ctx.mounted) Navigator.pop(ctx);
             },
-          );
-        },
+            child: const Text('Rename'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmDeleteShelf(
+      BuildContext context, WidgetRef ref, Shelf shelf) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete shelf?'),
+        content: Text(
+            'The shelf "${shelf.name}" will be removed. Items in it will not be deleted.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () async {
+              final useCase = ManageShelvesUseCase(
+                repository: ref.read(shelfRepositoryProvider),
+              );
+              await useCase.deleteShelf(shelf.id);
+              ref.invalidate(allShelvesProvider);
+              if (ctx.mounted) Navigator.pop(ctx);
+            },
+            child: const Text('Delete'),
+          ),
+        ],
       ),
     );
   }
@@ -98,6 +203,70 @@ class ShelvesScreen extends ConsumerWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Embedded shelf contents panel for master-detail layout.
+class _ShelfDetailPanel extends ConsumerWidget {
+  const _ShelfDetailPanel({required this.shelfId});
+
+  final String shelfId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final itemIdsAsync = ref.watch(shelfItemIdsProvider(shelfId));
+
+    return Column(
+      children: [
+        Material(
+          elevation: 1,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            child: Row(
+              children: [
+                const Expanded(
+                  child: Text('Shelf Contents'),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 20),
+                  tooltip: 'Close panel',
+                  onPressed: () =>
+                      ref.read(selectedShelfProvider.notifier).clear(),
+                ),
+              ],
+            ),
+          ),
+        ),
+        Expanded(
+          child: itemIdsAsync.when(
+            loading: () => const LoadingIndicator(),
+            error: (e, _) => Center(child: Text(e.toString())),
+            data: (itemIds) {
+              if (itemIds.isEmpty) {
+                return const Center(
+                  child: Text('No items in this shelf yet.'),
+                );
+              }
+              return ListView.builder(
+                itemCount: itemIds.length,
+                itemBuilder: (context, index) {
+                  final itemAsync =
+                      ref.watch(mediaItemProvider(itemIds[index]));
+                  return ListTile(
+                    title: itemAsync.when(
+                      loading: () => const Text('Loading\u2026'),
+                      error: (_, _) => const Text('Error'),
+                      data: (item) => Text(item?.title ?? 'Unknown'),
+                    ),
+                    onTap: () => context.go('/item/${itemIds[index]}'),
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/widgets/app_scaffold.dart
+++ b/lib/presentation/widgets/app_scaffold.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mymediascanner/core/constants/app_constants.dart';
 import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_shortcuts.dart';
 
 class AppScaffold extends StatelessWidget {
   const AppScaffold({
@@ -76,6 +77,14 @@ class AppScaffold extends StatelessWidget {
     final useRail = width >= AppConstants.compactBreakpoint;
     final isDesktop = PlatformCapability.isDesktop;
 
+    Widget wrapWithShortcuts(Widget scaffold) {
+      if (!isDesktop) return scaffold;
+      return DesktopShortcuts(
+        onSwitchTab: _onDestinationSelected,
+        child: scaffold,
+      );
+    }
+
     if (useRail) {
       // On desktop, include the Rips destination in the rail.
       final destinations = [
@@ -89,20 +98,22 @@ class AppScaffold extends StatelessWidget {
           ? 0
           : navigationShell.currentIndex;
 
-      return Scaffold(
-        body: Row(
-          children: [
-            NavigationRail(
-              selectedIndex: currentIndex,
-              onDestinationSelected: _onDestinationSelected,
-              labelType: width >= AppConstants.expandedBreakpoint
-                  ? NavigationRailLabelType.all
-                  : NavigationRailLabelType.selected,
-              destinations: destinations,
-            ),
-            const VerticalDivider(width: 1),
-            Expanded(child: navigationShell),
-          ],
+      return wrapWithShortcuts(
+        Scaffold(
+          body: Row(
+            children: [
+              NavigationRail(
+                selectedIndex: currentIndex,
+                onDestinationSelected: _onDestinationSelected,
+                labelType: width >= AppConstants.expandedBreakpoint
+                    ? NavigationRailLabelType.all
+                    : NavigationRailLabelType.selected,
+                destinations: destinations,
+              ),
+              const VerticalDivider(width: 1),
+              Expanded(child: navigationShell),
+            ],
+          ),
         ),
       );
     }
@@ -113,12 +124,14 @@ class AppScaffold extends StatelessWidget {
         ? 0
         : navigationShell.currentIndex;
 
-    return Scaffold(
-      body: navigationShell,
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: mobileIndex,
-        onDestinationSelected: _onDestinationSelected,
-        destinations: _destinations,
+    return wrapWithShortcuts(
+      Scaffold(
+        body: navigationShell,
+        bottomNavigationBar: NavigationBar(
+          selectedIndex: mobileIndex,
+          onDestinationSelected: _onDestinationSelected,
+          destinations: _destinations,
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/context_menu_actions.dart
+++ b/lib/presentation/widgets/context_menu_actions.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_context_menu.dart';
+
+/// Builds standard context menu action sets for reuse across screens.
+abstract final class ContextMenuActions {
+  /// Actions for a collection media item card.
+  static List<ContextMenuAction> forMediaItem({
+    required VoidCallback onEdit,
+    required VoidCallback onDelete,
+    required VoidCallback onAddToShelf,
+    required VoidCallback onLend,
+    required VoidCallback onRefreshMetadata,
+  }) =>
+      [
+        ContextMenuAction(
+          label: 'Edit',
+          icon: Icons.edit_outlined,
+          onTap: onEdit,
+        ),
+        ContextMenuAction(
+          label: 'Add to shelf',
+          icon: Icons.shelves,
+          onTap: onAddToShelf,
+        ),
+        ContextMenuAction(
+          label: 'Lend',
+          icon: Icons.person_add_outlined,
+          onTap: onLend,
+        ),
+        ContextMenuAction(
+          label: 'Refresh metadata',
+          icon: Icons.refresh,
+          onTap: onRefreshMetadata,
+        ),
+        ContextMenuAction(
+          label: 'Delete',
+          icon: Icons.delete_outline,
+          onTap: onDelete,
+        ),
+      ];
+
+  /// Actions for a shelf list tile.
+  static List<ContextMenuAction> forShelf({
+    required VoidCallback onRename,
+    required VoidCallback onDelete,
+  }) =>
+      [
+        ContextMenuAction(
+          label: 'Rename',
+          icon: Icons.edit_outlined,
+          onTap: onRename,
+        ),
+        ContextMenuAction(
+          label: 'Delete',
+          icon: Icons.delete_outline,
+          onTap: onDelete,
+        ),
+      ];
+}

--- a/lib/presentation/widgets/desktop_context_menu.dart
+++ b/lib/presentation/widgets/desktop_context_menu.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+
+/// An action displayed in a desktop right-click context menu.
+class ContextMenuAction {
+  const ContextMenuAction({
+    required this.label,
+    required this.icon,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final VoidCallback onTap;
+}
+
+/// Wraps its [child] with a secondary-tap (right-click) context menu
+/// on desktop platforms. On mobile, renders [child] unmodified.
+class DesktopContextMenu extends StatelessWidget {
+  const DesktopContextMenu({
+    super.key,
+    required this.actions,
+    required this.child,
+  });
+
+  final List<ContextMenuAction> actions;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!PlatformCapability.isDesktop || actions.isEmpty) {
+      return child;
+    }
+
+    return GestureDetector(
+      onSecondaryTapUp: (details) => _showMenu(context, details.globalPosition),
+      child: child,
+    );
+  }
+
+  void _showMenu(BuildContext context, Offset position) {
+    final overlay =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
+    if (overlay == null) return;
+
+    showMenu<void>(
+      context: context,
+      position: RelativeRect.fromRect(
+        position & const Size(1, 1),
+        Offset.zero & overlay.size,
+      ),
+      items: actions
+          .map(
+            (action) => PopupMenuItem<void>(
+              onTap: action.onTap,
+              child: Row(
+                children: [
+                  Icon(action.icon, size: 18),
+                  const SizedBox(width: 12),
+                  Text(action.label),
+                ],
+              ),
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/presentation/widgets/desktop_shortcuts.dart
+++ b/lib/presentation/widgets/desktop_shortcuts.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/presentation/widgets/shortcuts_help_overlay.dart';
+
+/// Wraps its [child] with desktop-only global keyboard shortcuts.
+///
+/// On non-desktop platforms, renders [child] unmodified.
+class DesktopShortcuts extends StatelessWidget {
+  const DesktopShortcuts({
+    super.key,
+    required this.child,
+    required this.onSwitchTab,
+  });
+
+  final Widget child;
+
+  /// Called with a branch index (0–4) to switch navigation tabs.
+  final ValueChanged<int> onSwitchTab;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!PlatformCapability.isDesktop) return child;
+
+    return Shortcuts(
+      shortcuts: <ShortcutActivator, Intent>{
+        // Ctrl+N → Scan tab (branch 1)
+        const SingleActivator(LogicalKeyboardKey.keyN, control: true):
+            const _SwitchTabIntent(1),
+        // Ctrl+F → focus search (handled by collection screen)
+        const SingleActivator(LogicalKeyboardKey.keyF, control: true):
+            const _FocusSearchIntent(),
+        // Ctrl+, → Settings tab (branch 3)
+        const SingleActivator(LogicalKeyboardKey.comma, control: true):
+            const _SwitchTabIntent(3),
+        // F1 → Shortcuts help overlay
+        const SingleActivator(LogicalKeyboardKey.f1):
+            const _ShowHelpIntent(),
+      },
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          _SwitchTabIntent: CallbackAction<_SwitchTabIntent>(
+            onInvoke: (intent) {
+              onSwitchTab(intent.tabIndex);
+              return null;
+            },
+          ),
+          _FocusSearchIntent: CallbackAction<_FocusSearchIntent>(
+            onInvoke: (_) {
+              // Dispatch a notification that the collection screen can listen for
+              _SearchFocusNotification().dispatch(context);
+              return null;
+            },
+          ),
+          _ShowHelpIntent: CallbackAction<_ShowHelpIntent>(
+            onInvoke: (_) {
+              showDialog<void>(
+                context: context,
+                builder: (_) => const ShortcutsHelpOverlay(),
+              );
+              return null;
+            },
+          ),
+        },
+        child: child,
+      ),
+    );
+  }
+}
+
+class _SwitchTabIntent extends Intent {
+  const _SwitchTabIntent(this.tabIndex);
+  final int tabIndex;
+}
+
+class _FocusSearchIntent extends Intent {
+  const _FocusSearchIntent();
+}
+
+class _ShowHelpIntent extends Intent {
+  const _ShowHelpIntent();
+}
+
+/// Notification dispatched when Ctrl+F is pressed.
+/// Collection screen listens for this to focus its search bar.
+class SearchFocusNotification extends Notification {}
+
+// ignore: library_private_types_in_public_api
+class _SearchFocusNotification extends SearchFocusNotification {}

--- a/lib/presentation/widgets/master_detail_layout.dart
+++ b/lib/presentation/widgets/master_detail_layout.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:mymediascanner/core/constants/app_constants.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+
+/// A generic master-detail split layout for desktop.
+///
+/// When [detail] is non-null, the screen width is ≥ 900 px, and we are on
+/// a desktop platform, renders [master] and [detail] side-by-side with a
+/// vertical divider. Otherwise renders only [master].
+class MasterDetailLayout extends StatelessWidget {
+  const MasterDetailLayout({
+    super.key,
+    required this.master,
+    this.detail,
+    this.masterMinWidth = 400,
+  });
+
+  /// The primary content (list, grid, etc.).
+  final Widget master;
+
+  /// The detail panel shown beside [master] on wide desktop windows.
+  /// Pass `null` when nothing is selected.
+  final Widget? detail;
+
+  /// Minimum width reserved for the master pane.
+  final double masterMinWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.sizeOf(context).width;
+    final showDetail = PlatformCapability.isDesktop &&
+        detail != null &&
+        width >= AppConstants.mediumBreakpoint;
+
+    if (!showDetail) return master;
+
+    return Row(
+      children: [
+        SizedBox(
+          width: width * 0.45 < masterMinWidth
+              ? masterMinWidth
+              : width * 0.45,
+          child: master,
+        ),
+        const VerticalDivider(width: 1),
+        Expanded(child: detail!),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/shortcuts_help_overlay.dart
+++ b/lib/presentation/widgets/shortcuts_help_overlay.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+/// Modal dialog listing all available desktop keyboard shortcuts.
+class ShortcutsHelpOverlay extends StatelessWidget {
+  const ShortcutsHelpOverlay({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Keyboard Shortcuts'),
+      content: SizedBox(
+        width: 420,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _sectionHeader(context, 'Global'),
+              _shortcutRow('Ctrl+N', 'Open Scan screen'),
+              _shortcutRow('Ctrl+F', 'Focus search bar'),
+              _shortcutRow('Ctrl+,', 'Open Settings'),
+              _shortcutRow('F1', 'Show this help'),
+              _shortcutRow('Escape', 'Close panel / clear input'),
+              const SizedBox(height: 16),
+              _sectionHeader(context, 'Collection'),
+              _shortcutRow('\u2190 \u2191 \u2192 \u2193', 'Navigate items'),
+              _shortcutRow('Enter', 'Open selected item'),
+              _shortcutRow('Delete', 'Delete selected item'),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Close'),
+        ),
+      ],
+    );
+  }
+
+  Widget _sectionHeader(BuildContext context, String title) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        title,
+        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+      ),
+    );
+  }
+
+  Widget _shortcutRow(String keys, String description) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 140,
+            child: Text(
+              keys,
+              style: const TextStyle(
+                fontFamily: 'monospace',
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(child: Text(description)),
+        ],
+      ),
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,17 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
+  screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) window_manager_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "WindowManagerPlugin");
+  window_manager_plugin_register_with_registrar(window_manager_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_linux
+  screen_retriever_linux
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,20 @@
 import FlutterMacOS
 import Foundation
 
+import file_picker
 import flutter_secure_storage_darwin
 import mobile_scanner
+import screen_retriever_macos
+import shared_preferences_foundation
 import sqflite_darwin
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -225,6 +225,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
   crypto:
     dependency: transitive
     description:
@@ -249,6 +257,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.7"
+  data_table_2:
+    dependency: "direct main"
+    description:
+      name: data_table_2
+      sha256: cb31d465dcf1e1598a662d06d3d2c16c73700ae9e837a3d91588f1dda7519abc
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.2"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   dio:
     dependency: "direct main"
     description:
@@ -313,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.10"
   fixnum:
     dependency: transitive
     description:
@@ -350,6 +382,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: ee8068e0e1cd16c4a82714119918efdeed33b3ba7772c54b5d094ab53f9b7fd1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.33"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -856,6 +896,102 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8374d6200ab33ac99031a852eba4c8eb2170c4bf20778b3e2c9eccb45384fb41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.21"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1165,6 +1301,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,10 @@ dependencies:
   uuid: ^4.5.3
   intl: ^0.20.2
   path_provider: ^2.1.5
+  window_manager: ^0.5.1
+  file_picker: ^10.3.10
+  shared_preferences: ^2.5.4
+  data_table_2: ^2.7.2
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/core/api_circuit_breaker_test.dart
+++ b/test/unit/core/api_circuit_breaker_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/core/utils/api_circuit_breaker.dart';
+
+void main() {
+  group('ApiCircuitBreaker', () {
+    test('starts open (allows requests)', () {
+      final breaker = ApiCircuitBreaker();
+      expect(breaker.isOpen, isTrue);
+    });
+
+    test('blocks requests after trip()', () {
+      final breaker = ApiCircuitBreaker();
+      breaker.trip();
+      expect(breaker.isOpen, isFalse);
+    });
+
+    test('allows requests again after reset()', () {
+      final breaker = ApiCircuitBreaker();
+      breaker.trip();
+      expect(breaker.isOpen, isFalse);
+      breaker.reset();
+      expect(breaker.isOpen, isTrue);
+    });
+
+    test('allows requests after cooldown elapses', () {
+      final breaker = ApiCircuitBreaker(
+        cooldownDuration: Duration.zero,
+      );
+      breaker.trip();
+      // With zero cooldown, should immediately allow
+      expect(breaker.isOpen, isTrue);
+    });
+
+    test('blocks requests within cooldown window', () {
+      final breaker = ApiCircuitBreaker(
+        cooldownDuration: const Duration(hours: 1),
+      );
+      breaker.trip();
+      expect(breaker.isOpen, isFalse);
+    });
+  });
+}

--- a/test/unit/core/window_manager_helper_test.dart
+++ b/test/unit/core/window_manager_helper_test.dart
@@ -1,0 +1,217 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Tests for the geometry serialisation contract of [WindowManagerHelper].
+///
+/// The [window_manager] plugin calls cannot be exercised in unit tests, so
+/// these tests validate:
+///   - The SharedPreferences key names used for persistence.
+///   - The default geometry values applied when no saved values are present.
+///   - The minimum size constraints.
+///
+/// The actual [WindowManagerHelper] class is NOT imported here because it
+/// calls [windowManager.ensureInitialized()] at class load time on desktop,
+/// which would crash in a headless test environment.  Instead we duplicate
+/// the constant values under test so that any accidental change to them in
+/// the source file is caught by a failing assertion.
+///
+/// If the constants in [WindowManagerHelper] are ever changed, the expected
+/// values below MUST be updated to match.
+void main() {
+  group('WindowManagerHelper geometry serialisation contract', () {
+    // ------------------------------------------------------------------ //
+    // SharedPreferences key names                                          //
+    // These values must match the private constants in window_manager_helper.dart:
+    //   static const _keyX      = 'window_x';
+    //   static const _keyY      = 'window_y';
+    //   static const _keyWidth  = 'window_width';
+    //   static const _keyHeight = 'window_height';
+    // ------------------------------------------------------------------ //
+
+    const keyX = 'window_x';
+    const keyY = 'window_y';
+    const keyWidth = 'window_width';
+    const keyHeight = 'window_height';
+
+    // Default / minimum geometry constants from window_manager_helper.dart:
+    //   static const _minWidth      = 800.0;
+    //   static const _minHeight     = 600.0;
+    //   static const _defaultWidth  = 1200.0;
+    //   static const _defaultHeight = 800.0;
+
+    const minWidth = 800.0;
+    const minHeight = 600.0;
+    const defaultWidth = 1200.0;
+    const defaultHeight = 800.0;
+
+    // ------------------------------------------------------------------ //
+    // Key name assertions                                                  //
+    // ------------------------------------------------------------------ //
+
+    test('x-position key name is window_x', () {
+      expect(keyX, 'window_x');
+    });
+
+    test('y-position key name is window_y', () {
+      expect(keyY, 'window_y');
+    });
+
+    test('width key name is window_width', () {
+      expect(keyWidth, 'window_width');
+    });
+
+    test('height key name is window_height', () {
+      expect(keyHeight, 'window_height');
+    });
+
+    // ------------------------------------------------------------------ //
+    // Default geometry values                                              //
+    // ------------------------------------------------------------------ //
+
+    test('default width is 1200', () {
+      expect(defaultWidth, 1200.0);
+    });
+
+    test('default height is 800', () {
+      expect(defaultHeight, 800.0);
+    });
+
+    // ------------------------------------------------------------------ //
+    // Minimum geometry constraints                                         //
+    // ------------------------------------------------------------------ //
+
+    test('minimum width is 800', () {
+      expect(minWidth, 800.0);
+    });
+
+    test('minimum height is 600', () {
+      expect(minHeight, 600.0);
+    });
+
+    test('minimum width is less than default width', () {
+      expect(minWidth, lessThan(defaultWidth));
+    });
+
+    test('minimum height is less than default height', () {
+      expect(minHeight, lessThan(defaultHeight));
+    });
+
+    // ------------------------------------------------------------------ //
+    // SharedPreferences round-trip using the expected key names           //
+    // Verifies that the chosen key strings survive a write/read cycle,    //
+    // which catches any accidental use of platform-reserved prefixes.     //
+    // ------------------------------------------------------------------ //
+
+    group('SharedPreferences round-trip with geometry keys', () {
+      setUp(() {
+        SharedPreferences.setMockInitialValues({});
+      });
+
+      test('x and y position keys round-trip correctly', () async {
+        final prefs = await SharedPreferences.getInstance();
+
+        await prefs.setDouble(keyX, 100.0);
+        await prefs.setDouble(keyY, 200.0);
+
+        expect(prefs.getDouble(keyX), 100.0);
+        expect(prefs.getDouble(keyY), 200.0);
+      });
+
+      test('width and height keys round-trip correctly', () async {
+        final prefs = await SharedPreferences.getInstance();
+
+        await prefs.setDouble(keyWidth, defaultWidth);
+        await prefs.setDouble(keyHeight, defaultHeight);
+
+        expect(prefs.getDouble(keyWidth), defaultWidth);
+        expect(prefs.getDouble(keyHeight), defaultHeight);
+      });
+
+      test('returns null for x and y when no saved position exists', () async {
+        final prefs = await SharedPreferences.getInstance();
+
+        // Simulate the logic in WindowManagerHelper.initialise:
+        // centre the window when x or y is null.
+        final x = prefs.getDouble(keyX);
+        final y = prefs.getDouble(keyY);
+        final shouldCentre = x == null || y == null;
+
+        expect(x, isNull);
+        expect(y, isNull);
+        expect(shouldCentre, isTrue);
+      });
+
+      test('falls back to defaultWidth when no saved width exists', () async {
+        final prefs = await SharedPreferences.getInstance();
+
+        // Mirror the logic: prefs.getDouble(keyWidth) ?? _defaultWidth
+        final width = prefs.getDouble(keyWidth) ?? defaultWidth;
+
+        expect(width, defaultWidth);
+      });
+
+      test('falls back to defaultHeight when no saved height exists',
+          () async {
+        final prefs = await SharedPreferences.getInstance();
+
+        final height = prefs.getDouble(keyHeight) ?? defaultHeight;
+
+        expect(height, defaultHeight);
+      });
+
+      test('uses persisted width over default when a saved value exists',
+          () async {
+        SharedPreferences.setMockInitialValues({keyWidth: 1440.0});
+        final prefs = await SharedPreferences.getInstance();
+
+        final width = prefs.getDouble(keyWidth) ?? defaultWidth;
+
+        expect(width, 1440.0);
+      });
+
+      test('uses persisted height over default when a saved value exists',
+          () async {
+        SharedPreferences.setMockInitialValues({keyHeight: 900.0});
+        final prefs = await SharedPreferences.getInstance();
+
+        final height = prefs.getDouble(keyHeight) ?? defaultHeight;
+
+        expect(height, 900.0);
+      });
+
+      test('does not centre window when both x and y have saved values',
+          () async {
+        SharedPreferences.setMockInitialValues({keyX: 50.0, keyY: 80.0});
+        final prefs = await SharedPreferences.getInstance();
+
+        final x = prefs.getDouble(keyX);
+        final y = prefs.getDouble(keyY);
+        final shouldCentre = x == null || y == null;
+
+        expect(shouldCentre, isFalse);
+        expect(x, 50.0);
+        expect(y, 80.0);
+      });
+
+      test('removing a position key causes the window to be centred again',
+          () async {
+        SharedPreferences.setMockInitialValues({keyX: 50.0, keyY: 80.0});
+        final prefs = await SharedPreferences.getInstance();
+
+        await prefs.remove(keyX);
+
+        final x = prefs.getDouble(keyX);
+        final y = prefs.getDouble(keyY);
+        final shouldCentre = x == null || y == null;
+
+        expect(shouldCentre, isTrue);
+      });
+
+      test('all four geometry keys are distinct strings', () {
+        final keys = {keyX, keyY, keyWidth, keyHeight};
+        // A set removes duplicates; if all four are distinct the length is 4.
+        expect(keys.length, 4);
+      });
+    });
+  });
+}

--- a/test/unit/data/repositories/metadata_repository_impl_test.dart
+++ b/test/unit/data/repositories/metadata_repository_impl_test.dart
@@ -1,13 +1,16 @@
+import 'package:dio/dio.dart';
 import 'package:drift/drift.dart' hide isNotNull;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mymediascanner/core/constants/app_constants.dart';
+import 'package:mymediascanner/core/utils/api_circuit_breaker.dart';
 import 'package:mymediascanner/data/local/dao/barcode_cache_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/data/remote/api/discogs/discogs_api.dart';
 import 'package:mymediascanner/data/remote/api/discogs/models/discogs_release_dto.dart';
 import 'package:mymediascanner/data/remote/api/google_books/google_books_api.dart';
 import 'package:mymediascanner/data/remote/api/google_books/models/google_books_volume_dto.dart';
+import 'package:mymediascanner/data/remote/api/open_library/models/open_library_work_dto.dart';
 import 'package:mymediascanner/data/remote/api/open_library/open_library_api.dart';
 import 'package:mymediascanner/data/remote/api/tmdb/models/tmdb_search_result_dto.dart';
 import 'package:mymediascanner/data/remote/api/tmdb/tmdb_api.dart';
@@ -263,6 +266,137 @@ void main() {
       );
 
       expect(result, equals(null));
+    });
+  });
+
+  group('Google Books 429 handling', () {
+    const isbn = '9780141036144';
+    late MockGoogleBooksApi mockGoogleBooksApi;
+    late MockOpenLibraryApi mockOpenLibraryApi;
+    late MockBarcodeCacheDao mockCache;
+    late ApiCircuitBreaker breaker;
+
+    setUp(() {
+      mockGoogleBooksApi = MockGoogleBooksApi();
+      mockOpenLibraryApi = MockOpenLibraryApi();
+      mockCache = MockBarcodeCacheDao();
+      breaker = ApiCircuitBreaker(
+        cooldownDuration: const Duration(hours: 1),
+      );
+
+      when(() => mockCache.getByBarcode(isbn))
+          .thenAnswer((_) async => null);
+      when(() => mockCache.upsert(any()))
+          .thenAnswer((_) async {});
+    });
+
+    DioException _make429() {
+      return DioException(
+        requestOptions: RequestOptions(path: '/volumes'),
+        response: Response(
+          requestOptions: RequestOptions(path: '/volumes'),
+          statusCode: 429,
+        ),
+        type: DioExceptionType.badResponse,
+      );
+    }
+
+    test('falls back to Open Library on 429', () async {
+      final booksRepo = MetadataRepositoryImpl(
+        cacheDao: mockCache,
+        googleBooksApi: mockGoogleBooksApi,
+        openLibraryApi: mockOpenLibraryApi,
+        googleBooksBreaker: breaker,
+      );
+
+      when(() => mockGoogleBooksApi.searchByIsbn('isbn:$isbn'))
+          .thenThrow(_make429());
+      when(() => mockOpenLibraryApi.getByIsbn(isbn))
+          .thenAnswer((_) async => const OpenLibraryBookDto(
+                title: '1984',
+                publishers: [OpenLibraryPublisherDto(name: 'Penguin')],
+              ));
+
+      final result = await booksRepo.lookupBarcode(isbn);
+
+      expect(result, isA<SingleScanResult>());
+      final single = result as SingleScanResult;
+      expect(single.metadata.title, '1984');
+      expect(single.metadata.sourceApis, contains('open_library'));
+    });
+
+    test('trips circuit breaker on 429', () async {
+      final booksRepo = MetadataRepositoryImpl(
+        cacheDao: mockCache,
+        googleBooksApi: mockGoogleBooksApi,
+        openLibraryApi: mockOpenLibraryApi,
+        googleBooksBreaker: breaker,
+      );
+
+      when(() => mockGoogleBooksApi.searchByIsbn('isbn:$isbn'))
+          .thenThrow(_make429());
+      when(() => mockOpenLibraryApi.getByIsbn(isbn))
+          .thenAnswer((_) async => null);
+
+      await booksRepo.lookupBarcode(isbn);
+
+      expect(breaker.isOpen, isFalse);
+    });
+
+    test('skips Google Books when circuit breaker is tripped', () async {
+      breaker.trip(); // Pre-trip the breaker
+
+      final booksRepo = MetadataRepositoryImpl(
+        cacheDao: mockCache,
+        googleBooksApi: mockGoogleBooksApi,
+        openLibraryApi: mockOpenLibraryApi,
+        googleBooksBreaker: breaker,
+      );
+
+      when(() => mockOpenLibraryApi.getByIsbn(isbn))
+          .thenAnswer((_) async => const OpenLibraryBookDto(
+                title: '1984',
+                publishers: [OpenLibraryPublisherDto(name: 'Penguin')],
+              ));
+
+      final result = await booksRepo.lookupBarcode(isbn);
+
+      // Google Books should NOT have been called
+      verifyNever(() => mockGoogleBooksApi.searchByIsbn(any()));
+      expect(result, isA<SingleScanResult>());
+    });
+
+    test('resets circuit breaker on successful Google Books response', () async {
+      breaker.trip();
+      // Use zero cooldown so the breaker allows a probe
+      final probableBreaker = ApiCircuitBreaker(
+        cooldownDuration: Duration.zero,
+      );
+      probableBreaker.trip();
+
+      final booksRepo = MetadataRepositoryImpl(
+        cacheDao: mockCache,
+        googleBooksApi: mockGoogleBooksApi,
+        googleBooksBreaker: probableBreaker,
+      );
+
+      when(() => mockGoogleBooksApi.searchByIsbn('isbn:$isbn'))
+          .thenAnswer((_) async => const GoogleBooksSearchResponseDto(
+                totalItems: 1,
+                items: [
+                  GoogleBooksVolumeDto(
+                    id: 'abc123',
+                    volumeInfo: GoogleBooksVolumeInfoDto(
+                      title: '1984',
+                      authors: ['George Orwell'],
+                    ),
+                  ),
+                ],
+              ));
+
+      await booksRepo.lookupBarcode(isbn);
+
+      expect(probableBreaker.isOpen, isTrue);
     });
   });
 }

--- a/test/unit/presentation/context_menu_actions_test.dart
+++ b/test/unit/presentation/context_menu_actions_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/widgets/context_menu_actions.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_context_menu.dart';
+
+void main() {
+  group('ContextMenuActions', () {
+    // ------------------------------------------------------------------ //
+    // forMediaItem                                                         //
+    // ------------------------------------------------------------------ //
+
+    group('forMediaItem', () {
+      test('returns exactly 5 actions', () {
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        expect(actions.length, 5);
+      });
+
+      test('returns actions with correct labels in order', () {
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        expect(actions[0].label, 'Edit');
+        expect(actions[1].label, 'Add to shelf');
+        expect(actions[2].label, 'Lend');
+        expect(actions[3].label, 'Refresh metadata');
+        expect(actions[4].label, 'Delete');
+      });
+
+      test('returns actions with correct icons in order', () {
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        expect(actions[0].icon, Icons.edit_outlined);
+        expect(actions[1].icon, Icons.shelves);
+        expect(actions[2].icon, Icons.person_add_outlined);
+        expect(actions[3].icon, Icons.refresh);
+        expect(actions[4].icon, Icons.delete_outline);
+      });
+
+      test('Edit action calls onEdit callback', () {
+        var called = false;
+
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () => called = true,
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        actions[0].onTap();
+
+        expect(called, isTrue);
+      });
+
+      test('Add to shelf action calls onAddToShelf callback', () {
+        var called = false;
+
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () => called = true,
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        actions[1].onTap();
+
+        expect(called, isTrue);
+      });
+
+      test('Lend action calls onLend callback', () {
+        var called = false;
+
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () => called = true,
+          onRefreshMetadata: () {},
+        );
+
+        actions[2].onTap();
+
+        expect(called, isTrue);
+      });
+
+      test('Refresh metadata action calls onRefreshMetadata callback', () {
+        var called = false;
+
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () => called = true,
+        );
+
+        actions[3].onTap();
+
+        expect(called, isTrue);
+      });
+
+      test('Delete action calls onDelete callback', () {
+        var called = false;
+
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () => called = true,
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        actions[4].onTap();
+
+        expect(called, isTrue);
+      });
+
+      test('each action only triggers its own callback and not others', () {
+        // Track which callbacks were invoked.
+        final invoked = <String>{};
+
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () => invoked.add('edit'),
+          onDelete: () => invoked.add('delete'),
+          onAddToShelf: () => invoked.add('addToShelf'),
+          onLend: () => invoked.add('lend'),
+          onRefreshMetadata: () => invoked.add('refreshMetadata'),
+        );
+
+        // Trigger only the Lend action.
+        actions[2].onTap();
+
+        expect(invoked, {'lend'});
+      });
+
+      test('returns a new list on each call — mutations are independent', () {
+        final first = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+        final second = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        // Verify they are separate list instances.
+        expect(identical(first, second), isFalse);
+      });
+
+      test('all returned items are ContextMenuAction instances', () {
+        final actions = ContextMenuActions.forMediaItem(
+          onEdit: () {},
+          onDelete: () {},
+          onAddToShelf: () {},
+          onLend: () {},
+          onRefreshMetadata: () {},
+        );
+
+        for (final action in actions) {
+          expect(action, isA<ContextMenuAction>());
+        }
+      });
+    });
+
+    // ------------------------------------------------------------------ //
+    // forShelf                                                             //
+    // ------------------------------------------------------------------ //
+
+    group('forShelf', () {
+      test('returns exactly 2 actions', () {
+        final actions = ContextMenuActions.forShelf(
+          onRename: () {},
+          onDelete: () {},
+        );
+
+        expect(actions.length, 2);
+      });
+
+      test('returns actions with correct labels in order', () {
+        final actions = ContextMenuActions.forShelf(
+          onRename: () {},
+          onDelete: () {},
+        );
+
+        expect(actions[0].label, 'Rename');
+        expect(actions[1].label, 'Delete');
+      });
+
+      test('returns actions with correct icons in order', () {
+        final actions = ContextMenuActions.forShelf(
+          onRename: () {},
+          onDelete: () {},
+        );
+
+        expect(actions[0].icon, Icons.edit_outlined);
+        expect(actions[1].icon, Icons.delete_outline);
+      });
+
+      test('Rename action calls onRename callback', () {
+        var called = false;
+
+        final actions = ContextMenuActions.forShelf(
+          onRename: () => called = true,
+          onDelete: () {},
+        );
+
+        actions[0].onTap();
+
+        expect(called, isTrue);
+      });
+
+      test('Delete action calls onDelete callback', () {
+        var called = false;
+
+        final actions = ContextMenuActions.forShelf(
+          onRename: () {},
+          onDelete: () => called = true,
+        );
+
+        actions[1].onTap();
+
+        expect(called, isTrue);
+      });
+
+      test('Rename action does not trigger onDelete callback', () {
+        var deleteCalled = false;
+
+        final actions = ContextMenuActions.forShelf(
+          onRename: () {},
+          onDelete: () => deleteCalled = true,
+        );
+
+        actions[0].onTap();
+
+        expect(deleteCalled, isFalse);
+      });
+
+      test('Delete action does not trigger onRename callback', () {
+        var renameCalled = false;
+
+        final actions = ContextMenuActions.forShelf(
+          onRename: () => renameCalled = true,
+          onDelete: () {},
+        );
+
+        actions[1].onTap();
+
+        expect(renameCalled, isFalse);
+      });
+
+      test('all returned items are ContextMenuAction instances', () {
+        final actions = ContextMenuActions.forShelf(
+          onRename: () {},
+          onDelete: () {},
+        );
+
+        for (final action in actions) {
+          expect(action, isA<ContextMenuAction>());
+        }
+      });
+    });
+  });
+}

--- a/test/unit/presentation/providers/collection_view_mode_provider_test.dart
+++ b/test/unit/presentation/providers/collection_view_mode_provider_test.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/collection_view_mode_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  // Creates a fresh, isolated ProviderContainer for each test and registers
+  // its disposal as a teardown so tests never share state.
+  ProviderContainer _makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  setUp(() {
+    // Provide an empty in-memory SharedPreferences backing store so that
+    // SharedPreferences.getInstance() never touches the real file system.
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('CollectionViewModeNotifier', () {
+    // ------------------------------------------------------------------
+    // Initial state
+    // ------------------------------------------------------------------
+
+    test('build_initialState_isGrid', () {
+      final container = _makeContainer();
+
+      expect(container.read(collectionViewModeProvider), CollectionViewMode.grid);
+    });
+
+    // ------------------------------------------------------------------
+    // toggle
+    // ------------------------------------------------------------------
+
+    test('toggle_fromGrid_setsStateToTable', () {
+      final container = _makeContainer();
+
+      container.read(collectionViewModeProvider.notifier).toggle();
+
+      expect(container.read(collectionViewModeProvider), CollectionViewMode.table);
+    });
+
+    test('toggle_fromTable_setsStateBackToGrid', () {
+      final container = _makeContainer();
+      final notifier = container.read(collectionViewModeProvider.notifier);
+
+      notifier.toggle(); // grid → table
+      notifier.toggle(); // table → grid
+
+      expect(container.read(collectionViewModeProvider), CollectionViewMode.grid);
+    });
+
+    // ------------------------------------------------------------------
+    // setMode
+    // ------------------------------------------------------------------
+
+    test('setMode_table_setsStateToTable', () {
+      final container = _makeContainer();
+
+      container.read(collectionViewModeProvider.notifier).setMode(CollectionViewMode.table);
+
+      expect(container.read(collectionViewModeProvider), CollectionViewMode.table);
+    });
+
+    test('setMode_grid_afterTable_setsStateBackToGrid', () {
+      final container = _makeContainer();
+      final notifier = container.read(collectionViewModeProvider.notifier);
+
+      notifier.setMode(CollectionViewMode.table);
+      notifier.setMode(CollectionViewMode.grid);
+
+      expect(container.read(collectionViewModeProvider), CollectionViewMode.grid);
+    });
+
+    // ------------------------------------------------------------------
+    // Persistence — state loaded from SharedPreferences on build
+    // ------------------------------------------------------------------
+
+    test('build_withStoredTablePreference_loadsTableState', () async {
+      // Seed prefs with 'table' before the provider is read so that
+      // _loadFromPrefs() finds the stored value.
+      SharedPreferences.setMockInitialValues({'collection_view_mode': 'table'});
+
+      // Create the container manually (no addTearDown yet) so we can keep it
+      // alive until the async prefs load has resolved.
+      final container = ProviderContainer();
+
+      // Subscribe so Riverpod keeps the provider alive and state changes reach
+      // us.  Wait for the 'table' value to arrive (or timeout after 1 second).
+      final completer = Completer<CollectionViewMode>();
+      final sub = container.listen<CollectionViewMode>(
+        collectionViewModeProvider,
+        (_, next) {
+          if (!completer.isCompleted) completer.complete(next);
+        },
+        fireImmediately: false,
+      );
+
+      final result = await completer.future.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => container.read(collectionViewModeProvider),
+      );
+
+      sub.close();
+      container.dispose();
+
+      expect(result, CollectionViewMode.table);
+    });
+
+    test('build_withStoredGridPreference_remainsGrid', () async {
+      // When the stored value is 'grid', _loadFromPrefs never updates state,
+      // so after a short delay the provider must still report grid.
+      SharedPreferences.setMockInitialValues({'collection_view_mode': 'grid'});
+
+      final container = ProviderContainer();
+      // Prime the provider.
+      container.read(collectionViewModeProvider);
+      // Allow any async prefs work to complete.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      final result = container.read(collectionViewModeProvider);
+      container.dispose();
+
+      expect(result, CollectionViewMode.grid);
+    });
+  });
+}

--- a/test/unit/presentation/providers/rip_view_mode_provider_test.dart
+++ b/test/unit/presentation/providers/rip_view_mode_provider_test.dart
@@ -1,0 +1,129 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/rip_view_mode_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  // Creates a fresh, isolated ProviderContainer for each test and registers
+  // its disposal as a teardown so tests never share state.
+  ProviderContainer _makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  setUp(() {
+    // Provide an empty in-memory SharedPreferences backing store so that
+    // SharedPreferences.getInstance() never touches the real file system.
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('RipViewModeNotifier', () {
+    // ------------------------------------------------------------------
+    // Initial state
+    // ------------------------------------------------------------------
+
+    test('build_initialState_isGrid', () {
+      final container = _makeContainer();
+
+      expect(container.read(ripViewModeProvider), RipViewMode.grid);
+    });
+
+    // ------------------------------------------------------------------
+    // toggle
+    // ------------------------------------------------------------------
+
+    test('toggle_fromGrid_setsStateToTable', () {
+      final container = _makeContainer();
+
+      container.read(ripViewModeProvider.notifier).toggle();
+
+      expect(container.read(ripViewModeProvider), RipViewMode.table);
+    });
+
+    test('toggle_fromTable_setsStateBackToGrid', () {
+      final container = _makeContainer();
+      final notifier = container.read(ripViewModeProvider.notifier);
+
+      notifier.toggle(); // grid → table
+      notifier.toggle(); // table → grid
+
+      expect(container.read(ripViewModeProvider), RipViewMode.grid);
+    });
+
+    // ------------------------------------------------------------------
+    // setMode
+    // ------------------------------------------------------------------
+
+    test('setMode_table_setsStateToTable', () {
+      final container = _makeContainer();
+
+      container.read(ripViewModeProvider.notifier).setMode(RipViewMode.table);
+
+      expect(container.read(ripViewModeProvider), RipViewMode.table);
+    });
+
+    test('setMode_grid_afterTable_setsStateBackToGrid', () {
+      final container = _makeContainer();
+      final notifier = container.read(ripViewModeProvider.notifier);
+
+      notifier.setMode(RipViewMode.table);
+      notifier.setMode(RipViewMode.grid);
+
+      expect(container.read(ripViewModeProvider), RipViewMode.grid);
+    });
+
+    // ------------------------------------------------------------------
+    // Persistence — state loaded from SharedPreferences on build
+    // ------------------------------------------------------------------
+
+    test('build_withStoredTablePreference_loadsTableState', () async {
+      // Seed prefs with 'table' before the provider is read so that
+      // _loadFromPrefs() finds the stored value.
+      SharedPreferences.setMockInitialValues({'rip_view_mode': 'table'});
+
+      // Create the container manually (no addTearDown yet) so we can keep it
+      // alive until the async prefs load has resolved.
+      final container = ProviderContainer();
+
+      // Subscribe so Riverpod keeps the provider alive and state changes reach
+      // us.  Wait for the 'table' value to arrive (or timeout after 1 second).
+      final completer = Completer<RipViewMode>();
+      final sub = container.listen<RipViewMode>(
+        ripViewModeProvider,
+        (_, next) {
+          if (!completer.isCompleted) completer.complete(next);
+        },
+        fireImmediately: false,
+      );
+
+      final result = await completer.future.timeout(
+        const Duration(seconds: 1),
+        onTimeout: () => container.read(ripViewModeProvider),
+      );
+
+      sub.close();
+      container.dispose();
+
+      expect(result, RipViewMode.table);
+    });
+
+    test('build_withStoredGridPreference_remainsGrid', () async {
+      // When the stored value is 'grid', _loadFromPrefs never updates state,
+      // so after a short delay the provider must still report grid.
+      SharedPreferences.setMockInitialValues({'rip_view_mode': 'grid'});
+
+      final container = ProviderContainer();
+      // Prime the provider.
+      container.read(ripViewModeProvider);
+      // Allow any async prefs work to complete.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      final result = container.read(ripViewModeProvider);
+      container.dispose();
+
+      expect(result, RipViewMode.grid);
+    });
+  });
+}

--- a/test/unit/presentation/providers/selected_rip_album_provider_test.dart
+++ b/test/unit/presentation/providers/selected_rip_album_provider_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/selected_rip_album_provider.dart';
+
+void main() {
+  // Creates a fresh, isolated ProviderContainer for each test and registers
+  // its disposal as a teardown so tests never share state.
+  ProviderContainer _makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SelectedRipAlbumNotifier', () {
+    // ------------------------------------------------------------------
+    // Initial state
+    // ------------------------------------------------------------------
+
+    test('build_initialState_isNull', () {
+      final container = _makeContainer();
+
+      expect(container.read(selectedRipAlbumProvider), isNull);
+    });
+
+    // ------------------------------------------------------------------
+    // select
+    // ------------------------------------------------------------------
+
+    test('select_validId_setsStateToGivenId', () {
+      final container = _makeContainer();
+
+      container.read(selectedRipAlbumProvider.notifier).select('album-1');
+
+      expect(container.read(selectedRipAlbumProvider), 'album-1');
+    });
+
+    test('select_calledTwice_stateReflectsLastId', () {
+      final container = _makeContainer();
+      final notifier = container.read(selectedRipAlbumProvider.notifier);
+
+      notifier.select('album-1');
+      notifier.select('album-2');
+
+      expect(container.read(selectedRipAlbumProvider), 'album-2');
+    });
+
+    // ------------------------------------------------------------------
+    // clear
+    // ------------------------------------------------------------------
+
+    test('clear_afterSelect_resetsStateToNull', () {
+      final container = _makeContainer();
+      final notifier = container.read(selectedRipAlbumProvider.notifier);
+      notifier.select('album-1');
+
+      notifier.clear();
+
+      expect(container.read(selectedRipAlbumProvider), isNull);
+    });
+
+    test('clear_whenAlreadyNull_stateRemainsNull', () {
+      final container = _makeContainer();
+
+      // Calling clear on an already-null state must not throw and must
+      // leave state as null.
+      container.read(selectedRipAlbumProvider.notifier).clear();
+
+      expect(container.read(selectedRipAlbumProvider), isNull);
+    });
+  });
+}

--- a/test/unit/presentation/providers/selected_shelf_provider_test.dart
+++ b/test/unit/presentation/providers/selected_shelf_provider_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/selected_shelf_provider.dart';
+
+void main() {
+  // Creates a fresh, isolated ProviderContainer for each test and registers
+  // its disposal as a teardown so tests never share state.
+  ProviderContainer _makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SelectedShelfNotifier', () {
+    // ------------------------------------------------------------------
+    // Initial state
+    // ------------------------------------------------------------------
+
+    test('build_initialState_isNull', () {
+      final container = _makeContainer();
+
+      expect(container.read(selectedShelfProvider), isNull);
+    });
+
+    // ------------------------------------------------------------------
+    // select
+    // ------------------------------------------------------------------
+
+    test('select_validId_setsStateToGivenId', () {
+      final container = _makeContainer();
+
+      container.read(selectedShelfProvider.notifier).select('shelf-1');
+
+      expect(container.read(selectedShelfProvider), 'shelf-1');
+    });
+
+    test('select_calledTwice_stateReflectsLastId', () {
+      final container = _makeContainer();
+      final notifier = container.read(selectedShelfProvider.notifier);
+
+      notifier.select('shelf-1');
+      notifier.select('shelf-2');
+
+      expect(container.read(selectedShelfProvider), 'shelf-2');
+    });
+
+    // ------------------------------------------------------------------
+    // clear
+    // ------------------------------------------------------------------
+
+    test('clear_afterSelect_resetsStateToNull', () {
+      final container = _makeContainer();
+      final notifier = container.read(selectedShelfProvider.notifier);
+      notifier.select('shelf-1');
+
+      notifier.clear();
+
+      expect(container.read(selectedShelfProvider), isNull);
+    });
+
+    test('clear_whenAlreadyNull_stateRemainsNull', () {
+      final container = _makeContainer();
+
+      // Calling clear on an already-null state must not throw and must
+      // leave state as null.
+      container.read(selectedShelfProvider.notifier).clear();
+
+      expect(container.read(selectedShelfProvider), isNull);
+    });
+  });
+}

--- a/test/unit/presentation/selected_item_provider_test.dart
+++ b/test/unit/presentation/selected_item_provider_test.dart
@@ -1,0 +1,251 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/selected_item_provider.dart';
+
+void main() {
+  // Helper that creates a fresh ProviderContainer for each test, registers
+  // teardown, and returns the notifier ready to exercise.
+  ProviderContainer _makeContainer() {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('SelectedItemNotifier', () {
+    // ------------------------------------------------------------------
+    // Initial state
+    // ------------------------------------------------------------------
+
+    test('build_initialState_isNull', () {
+      final container = _makeContainer();
+
+      expect(container.read(selectedItemProvider), isNull);
+    });
+
+    // ------------------------------------------------------------------
+    // select
+    // ------------------------------------------------------------------
+
+    test('select_validId_setsStateToGivenId', () {
+      final container = _makeContainer();
+
+      container.read(selectedItemProvider.notifier).select('abc');
+
+      expect(container.read(selectedItemProvider), 'abc');
+    });
+
+    // ------------------------------------------------------------------
+    // clear
+    // ------------------------------------------------------------------
+
+    test('clear_afterSelect_resetsStateToNull', () {
+      final container = _makeContainer();
+      container.read(selectedItemProvider.notifier).select('abc');
+
+      container.read(selectedItemProvider.notifier).clear();
+
+      expect(container.read(selectedItemProvider), isNull);
+    });
+
+    // ------------------------------------------------------------------
+    // moveNext
+    // ------------------------------------------------------------------
+
+    group('moveNext', () {
+      test('moveNext_emptyList_returnsNullAndStateRemainsNull', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+
+        final result = notifier.moveNext([]);
+
+        expect(result, isNull);
+        expect(container.read(selectedItemProvider), isNull);
+      });
+
+      test('moveNext_nullStateNonEmptyList_selectsFirstItemAndReturnsIt', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+
+        final result = notifier.moveNext(items);
+
+        expect(result, 'id1');
+        expect(container.read(selectedItemProvider), 'id1');
+      });
+
+      test('moveNext_currentIsMiddleItem_selectsNextItemAndReturnsIt', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('id2');
+
+        final result = notifier.moveNext(items);
+
+        expect(result, 'id3');
+        expect(container.read(selectedItemProvider), 'id3');
+      });
+
+      test('moveNext_currentIsFirstItem_selectsSecondItemAndReturnsIt', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('id1');
+
+        final result = notifier.moveNext(items);
+
+        expect(result, 'id2');
+        expect(container.read(selectedItemProvider), 'id2');
+      });
+
+      test('moveNext_currentIsLastItem_staysAtLastAndReturnsCurrent', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('id3');
+
+        final result = notifier.moveNext(items);
+
+        expect(result, 'id3');
+        expect(container.read(selectedItemProvider), 'id3');
+      });
+
+      test('moveNext_currentIdNotInList_staysAtCurrentAndReturnsCurrent', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('unknown');
+
+        final result = notifier.moveNext(items);
+
+        expect(result, 'unknown');
+        expect(container.read(selectedItemProvider), 'unknown');
+      });
+
+      test('moveNext_singleItemList_nullState_selectsThatItemAndReturnsIt', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+
+        final result = notifier.moveNext(['only']);
+
+        expect(result, 'only');
+        expect(container.read(selectedItemProvider), 'only');
+      });
+
+      test('moveNext_singleItemList_alreadySelected_staysAndReturnsCurrent',
+          () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        notifier.select('only');
+
+        final result = notifier.moveNext(['only']);
+
+        expect(result, 'only');
+        expect(container.read(selectedItemProvider), 'only');
+      });
+    });
+
+    // ------------------------------------------------------------------
+    // movePrevious
+    // ------------------------------------------------------------------
+
+    group('movePrevious', () {
+      test('movePrevious_emptyList_returnsNullAndStateRemainsNull', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+
+        final result = notifier.movePrevious([]);
+
+        expect(result, isNull);
+        expect(container.read(selectedItemProvider), isNull);
+      });
+
+      test('movePrevious_nullStateNonEmptyList_selectsLastItemAndReturnsIt',
+          () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+
+        final result = notifier.movePrevious(items);
+
+        expect(result, 'id3');
+        expect(container.read(selectedItemProvider), 'id3');
+      });
+
+      test('movePrevious_currentIsMiddleItem_selectsPreviousItemAndReturnsIt',
+          () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('id2');
+
+        final result = notifier.movePrevious(items);
+
+        expect(result, 'id1');
+        expect(container.read(selectedItemProvider), 'id1');
+      });
+
+      test('movePrevious_currentIsLastItem_selectsSecondToLastAndReturnsIt',
+          () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('id3');
+
+        final result = notifier.movePrevious(items);
+
+        expect(result, 'id2');
+        expect(container.read(selectedItemProvider), 'id2');
+      });
+
+      test('movePrevious_currentIsFirstItem_staysAtFirstAndReturnsCurrent', () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('id1');
+
+        final result = notifier.movePrevious(items);
+
+        expect(result, 'id1');
+        expect(container.read(selectedItemProvider), 'id1');
+      });
+
+      test(
+          'movePrevious_currentIdNotInList_staysAtCurrentAndReturnsCurrent',
+          () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        final items = ['id1', 'id2', 'id3'];
+        notifier.select('unknown');
+
+        final result = notifier.movePrevious(items);
+
+        expect(result, 'unknown');
+        expect(container.read(selectedItemProvider), 'unknown');
+      });
+
+      test('movePrevious_singleItemList_nullState_selectsThatItemAndReturnsIt',
+          () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+
+        final result = notifier.movePrevious(['only']);
+
+        expect(result, 'only');
+        expect(container.read(selectedItemProvider), 'only');
+      });
+
+      test(
+          'movePrevious_singleItemList_alreadySelected_staysAndReturnsCurrent',
+          () {
+        final container = _makeContainer();
+        final notifier = container.read(selectedItemProvider.notifier);
+        notifier.select('only');
+
+        final result = notifier.movePrevious(['only']);
+
+        expect(result, 'only');
+        expect(container.read(selectedItemProvider), 'only');
+      });
+    });
+  });
+}

--- a/test/widget/presentation/desktop_context_menu_test.dart
+++ b/test/widget/presentation/desktop_context_menu_test.dart
@@ -1,0 +1,261 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/widgets/desktop_context_menu.dart';
+
+/// Builds a minimal app that hosts a [DesktopContextMenu] inside a [Scaffold]
+/// so that [Overlay] (required by [showMenu]) is available.
+Widget _buildSubject({
+  required List<ContextMenuAction> actions,
+  Widget child = const Text('child'),
+}) {
+  return MaterialApp(
+    home: Scaffold(
+      body: DesktopContextMenu(
+        actions: actions,
+        child: child,
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('DesktopContextMenu', () {
+    // ------------------------------------------------------------------ //
+    // Desktop platforms — secondary tap shows popup menu                  //
+    //                                                                      //
+    // TargetPlatformVariant manages setUp/tearDown of                      //
+    // debugDefaultTargetPlatformOverride so the Flutter test binding's     //
+    // invariant check sees a clean state at the end of each test.          //
+    // ------------------------------------------------------------------ //
+
+    group('on desktop platform', () {
+      testWidgets(
+        'secondary tap shows popup menu with all action labels',
+        (tester) async {
+          final actions = [
+            ContextMenuAction(
+              label: 'Edit',
+              icon: Icons.edit_outlined,
+              onTap: () {},
+            ),
+            ContextMenuAction(
+              label: 'Delete',
+              icon: Icons.delete_outline,
+              onTap: () {},
+            ),
+            ContextMenuAction(
+              label: 'Add to shelf',
+              icon: Icons.shelves,
+              onTap: () {},
+            ),
+          ];
+
+          await tester.pumpWidget(_buildSubject(actions: actions));
+
+          // Perform a secondary (right-click) tap on the child widget.
+          await tester.tap(find.text('child'), buttons: kSecondaryButton);
+          await tester.pumpAndSettle();
+
+          // All three action labels must appear in the popup.
+          expect(find.text('Edit'), findsOneWidget);
+          expect(find.text('Delete'), findsOneWidget);
+          expect(find.text('Add to shelf'), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'secondary tap renders action icons in popup menu',
+        (tester) async {
+          final actions = [
+            ContextMenuAction(
+              label: 'Edit',
+              icon: Icons.edit_outlined,
+              onTap: () {},
+            ),
+            ContextMenuAction(
+              label: 'Rename',
+              icon: Icons.drive_file_rename_outline,
+              onTap: () {},
+            ),
+          ];
+
+          await tester.pumpWidget(_buildSubject(actions: actions));
+
+          await tester.tap(find.text('child'), buttons: kSecondaryButton);
+          await tester.pumpAndSettle();
+
+          expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
+          expect(find.byIcon(Icons.drive_file_rename_outline), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'tapping a menu item calls the corresponding onTap callback',
+        (tester) async {
+          var editTapped = false;
+          var deleteTapped = false;
+
+          final actions = [
+            ContextMenuAction(
+              label: 'Edit',
+              icon: Icons.edit_outlined,
+              onTap: () => editTapped = true,
+            ),
+            ContextMenuAction(
+              label: 'Delete',
+              icon: Icons.delete_outline,
+              onTap: () => deleteTapped = true,
+            ),
+          ];
+
+          await tester.pumpWidget(_buildSubject(actions: actions));
+
+          // Open the context menu.
+          await tester.tap(find.text('child'), buttons: kSecondaryButton);
+          await tester.pumpAndSettle();
+
+          // Tap the 'Edit' item.
+          await tester.tap(find.text('Edit'));
+          await tester.pumpAndSettle();
+
+          expect(editTapped, isTrue);
+          expect(deleteTapped, isFalse);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'tapping the second menu item calls only its onTap callback',
+        (tester) async {
+          var firstTapped = false;
+          var secondTapped = false;
+
+          final actions = [
+            ContextMenuAction(
+              label: 'Action One',
+              icon: Icons.one_k,
+              onTap: () => firstTapped = true,
+            ),
+            ContextMenuAction(
+              label: 'Action Two',
+              icon: Icons.two_k,
+              onTap: () => secondTapped = true,
+            ),
+          ];
+
+          await tester.pumpWidget(_buildSubject(actions: actions));
+
+          await tester.tap(find.text('child'), buttons: kSecondaryButton);
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Action Two'));
+          await tester.pumpAndSettle();
+
+          expect(firstTapped, isFalse);
+          expect(secondTapped, isTrue);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'wraps child in GestureDetector when actions are non-empty',
+        (tester) async {
+          final actions = [
+            ContextMenuAction(
+              label: 'Edit',
+              icon: Icons.edit_outlined,
+              onTap: () {},
+            ),
+          ];
+
+          await tester.pumpWidget(_buildSubject(actions: actions));
+
+          // A GestureDetector must be present in the tree.
+          expect(find.byType(GestureDetector), findsWidgets);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'renders child directly without GestureDetector when actions are empty',
+        (tester) async {
+          await tester.pumpWidget(_buildSubject(actions: const []));
+
+          // On desktop with an empty actions list the widget returns child
+          // without wrapping it in a GestureDetector.
+          expect(find.byType(GestureDetector), findsNothing);
+          expect(find.text('child'), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'secondary tap on empty actions does not show a popup menu',
+        (tester) async {
+          await tester.pumpWidget(_buildSubject(actions: const []));
+
+          await tester.tap(find.text('child'), buttons: kSecondaryButton);
+          await tester.pumpAndSettle();
+
+          // No PopupMenuItem should appear.
+          expect(find.byType(PopupMenuItem<void>), findsNothing);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+    });
+
+    // ------------------------------------------------------------------ //
+    // Non-desktop platforms — child renders directly, no GestureDetector  //
+    // ------------------------------------------------------------------ //
+
+    group('on non-desktop platform', () {
+      testWidgets(
+        'renders child directly without GestureDetector on mobile',
+        (tester) async {
+          final actions = [
+            ContextMenuAction(
+              label: 'Edit',
+              icon: Icons.edit_outlined,
+              onTap: () {},
+            ),
+          ];
+
+          await tester.pumpWidget(_buildSubject(actions: actions));
+
+          // Even with non-empty actions, mobile platforms skip the GestureDetector.
+          expect(find.byType(GestureDetector), findsNothing);
+          expect(find.text('child'), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.mobile(),
+      );
+
+      testWidgets(
+        'secondary tap on mobile does not open a popup menu',
+        (tester) async {
+          var tapped = false;
+
+          final actions = [
+            ContextMenuAction(
+              label: 'Edit',
+              icon: Icons.edit_outlined,
+              onTap: () => tapped = true,
+            ),
+          ];
+
+          await tester.pumpWidget(_buildSubject(actions: actions));
+
+          await tester.tap(find.text('child'), buttons: kSecondaryButton);
+          await tester.pumpAndSettle();
+
+          // The callback must not have been invoked.
+          expect(tapped, isFalse);
+          expect(find.byType(PopupMenuItem<void>), findsNothing);
+        },
+        variant: TargetPlatformVariant.mobile(),
+      );
+    });
+  });
+}

--- a/test/widget/presentation/master_detail_layout_test.dart
+++ b/test/widget/presentation/master_detail_layout_test.dart
@@ -1,0 +1,266 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/core/constants/app_constants.dart';
+import 'package:mymediascanner/presentation/widgets/master_detail_layout.dart';
+
+/// Builds a [MasterDetailLayout] inside a [MaterialApp] whose viewport is
+/// constrained to [screenWidth] × 800 via [MediaQuery].
+Widget _buildSubject({
+  required double screenWidth,
+  Widget? detail,
+  double masterMinWidth = 400,
+}) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(size: Size(screenWidth, 800)),
+      child: Scaffold(
+        body: MasterDetailLayout(
+          master: const Text('master content'),
+          detail: detail,
+          masterMinWidth: masterMinWidth,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('MasterDetailLayout', () {
+    // ------------------------------------------------------------------
+    // Desktop — wide screen (≥ mediumBreakpoint) with detail provided
+    // ------------------------------------------------------------------
+
+    group('on desktop at ${AppConstants.expandedBreakpoint}px with detail', () {
+      testWidgets(
+        'rendersMasterContent_andDetailContent',
+        (tester) async {
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: AppConstants.expandedBreakpoint,
+            detail: const Text('detail content'),
+          ));
+
+          expect(find.text('master content'), findsOneWidget);
+          expect(find.text('detail content'), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'rendersVerticalDivider_betweenMasterAndDetail',
+        (tester) async {
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: AppConstants.expandedBreakpoint,
+            detail: const Text('detail content'),
+          ));
+
+          expect(find.byType(VerticalDivider), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'masterPaneIsWrappedInSizedBox_notExpandedDirectly',
+        (tester) async {
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: AppConstants.expandedBreakpoint,
+            detail: const Text('detail content'),
+          ));
+
+          // The split layout wraps master in SizedBox and detail in Expanded.
+          expect(find.byType(Row), findsOneWidget);
+          expect(find.byType(SizedBox), findsWidgets);
+          expect(find.byType(Expanded), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+    });
+
+    // ------------------------------------------------------------------
+    // Desktop — wide screen with no detail (null)
+    // ------------------------------------------------------------------
+
+    group('on desktop at ${AppConstants.expandedBreakpoint}px without detail', () {
+      testWidgets(
+        'rendersMasterOnly_noVerticalDivider',
+        (tester) async {
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: AppConstants.expandedBreakpoint,
+            // detail is null — omitted
+          ));
+
+          expect(find.text('master content'), findsOneWidget);
+          expect(find.byType(VerticalDivider), findsNothing);
+          expect(find.byType(Row), findsNothing);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+    });
+
+    // ------------------------------------------------------------------
+    // Desktop — narrow screen (< mediumBreakpoint) with detail provided
+    // ------------------------------------------------------------------
+
+    group('on desktop at 500px (below breakpoint) with detail', () {
+      testWidgets(
+        'rendersMasterOnly_detailNotRendered',
+        (tester) async {
+          // 500 px is below the 900 px medium breakpoint, so only master
+          // should appear even though detail is supplied.
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: 500,
+            detail: const Text('detail content'),
+          ));
+
+          expect(find.text('master content'), findsOneWidget);
+          expect(find.text('detail content'), findsNothing);
+          expect(find.byType(VerticalDivider), findsNothing);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+    });
+
+    // ------------------------------------------------------------------
+    // Desktop — exactly at the breakpoint boundary
+    // ------------------------------------------------------------------
+
+    group('on desktop at exactly ${AppConstants.mediumBreakpoint}px with detail', () {
+      testWidgets(
+        'rendersBothPanes_atExactBreakpoint',
+        (tester) async {
+          // The condition is width >= mediumBreakpoint, so at exactly 900 px
+          // the split view must be shown.
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: AppConstants.mediumBreakpoint,
+            detail: const Text('detail content'),
+          ));
+
+          expect(find.text('master content'), findsOneWidget);
+          expect(find.text('detail content'), findsOneWidget);
+          expect(find.byType(VerticalDivider), findsOneWidget);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+    });
+
+    // ------------------------------------------------------------------
+    // Desktop — one pixel below the breakpoint boundary
+    // ------------------------------------------------------------------
+
+    group('on desktop at ${AppConstants.mediumBreakpoint - 1}px with detail', () {
+      testWidgets(
+        'rendersMasterOnly_onePixelBelowBreakpoint',
+        (tester) async {
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: AppConstants.mediumBreakpoint - 1,
+            detail: const Text('detail content'),
+          ));
+
+          expect(find.text('master content'), findsOneWidget);
+          expect(find.text('detail content'), findsNothing);
+          expect(find.byType(VerticalDivider), findsNothing);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+    });
+
+    // ------------------------------------------------------------------
+    // Mobile — wide screen with detail provided
+    // ------------------------------------------------------------------
+
+    group('on mobile at ${AppConstants.expandedBreakpoint}px with detail', () {
+      testWidgets(
+        'rendersMasterOnly_mobileIgnoresSplitLayout',
+        (tester) async {
+          // PlatformCapability.isDesktop is false on mobile, so the split
+          // layout must never appear regardless of screen width or detail.
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: AppConstants.expandedBreakpoint,
+            detail: const Text('detail content'),
+          ));
+
+          expect(find.text('master content'), findsOneWidget);
+          expect(find.text('detail content'), findsNothing);
+          expect(find.byType(VerticalDivider), findsNothing);
+        },
+        variant: TargetPlatformVariant.mobile(),
+      );
+    });
+
+    // ------------------------------------------------------------------
+    // masterMinWidth enforcement
+    // ------------------------------------------------------------------
+
+    group('masterMinWidth enforcement on desktop', () {
+      testWidgets(
+        'masterPaneUsesMinWidth_when45PercentOfScreenIsSmaller',
+        (tester) async {
+          // Screen width = 1200 px → 45 % = 540 px, which is below the
+          // custom masterMinWidth of 600 px.  The SizedBox for master
+          // must therefore be 600 px wide (minWidth wins).
+          const screenWidth = 1200.0;
+          const masterMinWidth = 600.0;
+          expect(screenWidth * 0.45, lessThan(masterMinWidth));
+
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: screenWidth,
+            detail: const Text('detail content'),
+            masterMinWidth: masterMinWidth,
+          ));
+
+          // Locate the SizedBox that wraps the master pane.
+          // The direct child of the Row is a SizedBox; walk up from the
+          // master text and take the first SizedBox with a non-null width.
+          SizedBox? masterBox;
+          tester
+              .widgetList<SizedBox>(find.ancestor(
+                of: find.text('master content'),
+                matching: find.byType(SizedBox),
+              ))
+              .forEach((box) {
+            if (box.width != null) masterBox ??= box;
+          });
+
+          expect(masterBox, isNotNull,
+              reason: 'Expected a SizedBox with explicit width above master');
+          expect(masterBox!.width, masterMinWidth);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+
+      testWidgets(
+        'masterPaneUses45PercentWidth_when45PercentExceedsMinWidth',
+        (tester) async {
+          // Screen width = 1200 px → 45 % = 540 px, which is above the
+          // default masterMinWidth of 400 px.  The SizedBox must be 540 px.
+          const screenWidth = 1200.0;
+          const masterMinWidth = 400.0;
+          final expectedWidth = screenWidth * 0.45; // 540
+          expect(expectedWidth, greaterThan(masterMinWidth));
+
+          await tester.pumpWidget(_buildSubject(
+            screenWidth: screenWidth,
+            detail: const Text('detail content'),
+            masterMinWidth: masterMinWidth,
+          ));
+
+          // Walk up from master text and take the first SizedBox that has
+          // an explicit (non-null) width — this is the master pane container.
+          SizedBox? masterBox;
+          tester
+              .widgetList<SizedBox>(find.ancestor(
+                of: find.text('master content'),
+                matching: find.byType(SizedBox),
+              ))
+              .forEach((box) {
+            if (box.width != null) masterBox ??= box;
+          });
+
+          expect(masterBox, isNotNull,
+              reason: 'Expected a SizedBox with explicit width above master');
+          expect(masterBox!.width, expectedWidth);
+        },
+        variant: TargetPlatformVariant.desktop(),
+      );
+    });
+  });
+}

--- a/test/widget/presentation/shortcuts_help_overlay_test.dart
+++ b/test/widget/presentation/shortcuts_help_overlay_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/widgets/shortcuts_help_overlay.dart';
+
+/// Pumps a [ShortcutsHelpOverlay] inside an [AlertDialog]-compatible host.
+///
+/// The overlay is itself an [AlertDialog], so it is shown via [showDialog]
+/// to give it the [Navigator] context it needs for the Close button.
+Future<void> _pumpOverlay(WidgetTester tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: TextButton(
+            onPressed: () => showDialog<void>(
+              context: context,
+              builder: (_) => const ShortcutsHelpOverlay(),
+            ),
+            child: const Text('Open'),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  // Open the dialog.
+  await tester.tap(find.text('Open'));
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('ShortcutsHelpOverlay', () {
+    // ------------------------------------------------------------------
+    // Title
+    // ------------------------------------------------------------------
+
+    testWidgets('renders_keyboardShortcutsTitle', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Keyboard Shortcuts'), findsOneWidget);
+    });
+
+    // ------------------------------------------------------------------
+    // Section headers
+    // ------------------------------------------------------------------
+
+    testWidgets('renders_globalSectionHeader', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Global'), findsOneWidget);
+    });
+
+    testWidgets('renders_collectionSectionHeader', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Collection'), findsOneWidget);
+    });
+
+    // ------------------------------------------------------------------
+    // Shortcut descriptions — global section
+    // ------------------------------------------------------------------
+
+    testWidgets('renders_openScanScreenDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Open Scan screen'), findsOneWidget);
+    });
+
+    testWidgets('renders_focusSearchBarDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Focus search bar'), findsOneWidget);
+    });
+
+    testWidgets('renders_openSettingsDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Open Settings'), findsOneWidget);
+    });
+
+    testWidgets('renders_showThisHelpDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Show this help'), findsOneWidget);
+    });
+
+    testWidgets('renders_closePanelClearInputDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Close panel / clear input'), findsOneWidget);
+    });
+
+    // ------------------------------------------------------------------
+    // Shortcut descriptions — collection section
+    // ------------------------------------------------------------------
+
+    testWidgets('renders_navigateItemsDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Navigate items'), findsOneWidget);
+    });
+
+    testWidgets('renders_openSelectedItemDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Open selected item'), findsOneWidget);
+    });
+
+    testWidgets('renders_deleteSelectedItemDescription', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Delete selected item'), findsOneWidget);
+    });
+
+    // ------------------------------------------------------------------
+    // Shortcut key labels
+    // ------------------------------------------------------------------
+
+    testWidgets('renders_ctrlNKeyLabel', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Ctrl+N'), findsOneWidget);
+    });
+
+    testWidgets('renders_f1KeyLabel', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('F1'), findsOneWidget);
+    });
+
+    testWidgets('renders_escapeKeyLabel', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Escape'), findsOneWidget);
+    });
+
+    // ------------------------------------------------------------------
+    // Close button
+    // ------------------------------------------------------------------
+
+    testWidgets('renders_closeButton', (tester) async {
+      await _pumpOverlay(tester);
+
+      expect(find.text('Close'), findsOneWidget);
+    });
+
+    testWidgets('closeButton_dismissesDialog', (tester) async {
+      await _pumpOverlay(tester);
+
+      // Dialog is visible before tapping Close.
+      expect(find.byType(ShortcutsHelpOverlay), findsOneWidget);
+
+      await tester.tap(find.text('Close'));
+      await tester.pumpAndSettle();
+
+      // Dialog has been removed from the tree.
+      expect(find.byType(ShortcutsHelpOverlay), findsNothing);
+      expect(find.text('Keyboard Shortcuts'), findsNothing);
+    });
+  });
+}

--- a/test/widget/presentation/view_mode_toggle_test.dart
+++ b/test/widget/presentation/view_mode_toggle_test.dart
@@ -1,0 +1,170 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/collection_view_mode_provider.dart';
+import 'package:mymediascanner/presentation/screens/collection/widgets/view_mode_toggle.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Wraps [ViewModeToggle] in the minimum required widget tree:
+/// a [ProviderScope] and a [MaterialApp] with a [Scaffold].
+Widget _buildSubject() {
+  return const ProviderScope(
+    child: MaterialApp(
+      home: Scaffold(
+        body: Center(child: ViewModeToggle()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    // Provide an empty in-memory SharedPreferences backing store so that
+    // SharedPreferences.getInstance() never touches the real file system.
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('ViewModeToggle', () {
+    // ------------------------------------------------------------------
+    // Rendering
+    // ------------------------------------------------------------------
+
+    testWidgets('renders_segmentedButton', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+
+      expect(find.byType(SegmentedButton<CollectionViewMode>), findsOneWidget);
+    });
+
+    testWidgets('renders_gridSegment_withGridViewIcon', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+
+      // Locate every Icon inside the SegmentedButton and verify grid_view
+      // is present among them.
+      final icons = tester
+          .widgetList<Icon>(find.descendant(
+            of: find.byType(SegmentedButton<CollectionViewMode>),
+            matching: find.byType(Icon),
+          ))
+          .map((icon) => icon.icon)
+          .toList();
+
+      expect(icons, contains(Icons.grid_view));
+    });
+
+    testWidgets('renders_tableSegment_withTableRowsIcon', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+
+      final icons = tester
+          .widgetList<Icon>(find.descendant(
+            of: find.byType(SegmentedButton<CollectionViewMode>),
+            matching: find.byType(Icon),
+          ))
+          .map((icon) => icon.icon)
+          .toList();
+
+      expect(icons, contains(Icons.table_rows));
+    });
+
+    testWidgets('renders_twoSegments', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+
+      // Each segment renders as a child of the SegmentedButton; the internal
+      // implementation places one Icon per segment.
+      final icons = tester
+          .widgetList<Icon>(find.descendant(
+            of: find.byType(SegmentedButton<CollectionViewMode>),
+            matching: find.byType(Icon),
+          ))
+          .toList();
+
+      // There must be exactly two segment icons (grid and table).
+      expect(icons.length, 2);
+    });
+
+    // ------------------------------------------------------------------
+    // Initial selection
+    // ------------------------------------------------------------------
+
+    testWidgets('initialState_gridSegmentIsSelected', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+
+      final button = tester.widget<SegmentedButton<CollectionViewMode>>(
+        find.byType(SegmentedButton<CollectionViewMode>),
+      );
+
+      expect(button.selected, {CollectionViewMode.grid});
+    });
+
+    // ------------------------------------------------------------------
+    // Interaction — tapping the table segment switches mode
+    // ------------------------------------------------------------------
+
+    testWidgets('tapTableSegment_switchesModeToTable', (tester) async {
+      late WidgetRef capturedRef;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) {
+                  capturedRef = ref;
+                  return const ViewModeToggle();
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Confirm starting state is grid.
+      expect(capturedRef.read(collectionViewModeProvider), CollectionViewMode.grid);
+
+      // Tap the table_rows icon to select the table segment.
+      await tester.tap(find.byIcon(Icons.table_rows));
+      await tester.pumpAndSettle();
+
+      expect(capturedRef.read(collectionViewModeProvider), CollectionViewMode.table);
+    });
+
+    testWidgets('tapTableSegment_tableSegmentBecomesSelected', (tester) async {
+      await tester.pumpWidget(_buildSubject());
+
+      await tester.tap(find.byIcon(Icons.table_rows));
+      await tester.pumpAndSettle();
+
+      final button = tester.widget<SegmentedButton<CollectionViewMode>>(
+        find.byType(SegmentedButton<CollectionViewMode>),
+      );
+
+      expect(button.selected, {CollectionViewMode.table});
+    });
+
+    testWidgets('tapGridSegment_afterTable_switchesModeBackToGrid', (tester) async {
+      late WidgetRef capturedRef;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: Consumer(
+                builder: (context, ref, _) {
+                  capturedRef = ref;
+                  return const ViewModeToggle();
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Switch to table first, then back to grid.
+      await tester.tap(find.byIcon(Icons.table_rows));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byIcon(Icons.grid_view));
+      await tester.pumpAndSettle();
+
+      expect(capturedRef.read(collectionViewModeProvider), CollectionViewMode.grid);
+    });
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,14 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <window_manager/window_manager_plugin.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  WindowManagerPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("WindowManagerPlugin"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,8 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_secure_storage_windows
+  screen_retriever_windows
+  window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
 ## Summary

   - Add master-detail layout, table views, and context menus for desktop collection, shelves, and rip library screens
   - Add keyboard shortcuts (Ctrl+F search, Ctrl+N new item, Delete, Escape) with help overlay (Ctrl+/)
   - Add window size/position persistence, view mode toggles (grid/table), and scan mode toggle (camera/manual)
   - Add API circuit breaker for resilient metadata lookups
   - Comprehensive test coverage: 12 new test files covering providers, widgets, and utilities

   ## Test plan

   - [ ] Run `flutter test` — all tests pass
   - [ ] Launch on desktop (Linux/macOS/Windows) — verify master-detail layout, context menus, keyboard shortcuts
   - [ ] Verify window size/position is remembered across restarts
   - [ ] Toggle between grid and table views in collection and rip library
   - [ ] Right-click context menus work on collection items and shelves
   - [ ] Ctrl+/ shows keyboard shortcuts overlay