### PR TITLE
feat: address code review suggestions

### DIFF
--- a/lib/data/local/dao/playlist_dao.dart
+++ b/lib/data/local/dao/playlist_dao.dart
@@ -70,6 +70,20 @@ class PlaylistDao extends DatabaseAccessor<AppDatabase>
         .go();
   }
 
+  /// Atomically reorders tracks in a playlist by clearing and re-inserting
+  /// within a single transaction.
+  Future<void> reorderTracks(
+      String playlistId, List<PlaylistTracksTableCompanion> companions) {
+    return transaction(() async {
+      await (delete(playlistTracksTable)
+            ..where((t) => t.playlistId.equals(playlistId)))
+          .go();
+      await batch((b) {
+        b.insertAll(playlistTracksTable, companions);
+      });
+    });
+  }
+
   /// Get rip tracks for a playlist via join, ordered by sort order.
   Future<List<RipTracksTableData>> getRipTracksForPlaylist(String playlistId) {
     final query = select(ripTracksTable).join([

--- a/lib/data/local/dao/rip_library_dao.dart
+++ b/lib/data/local/dao/rip_library_dao.dart
@@ -154,4 +154,16 @@ class RipLibraryDao extends DatabaseAccessor<AppDatabase>
   Future<List<RipAlbumsTableData>> getAllNonDeleted() {
     return (select(ripAlbumsTable)..where((t) => t.deleted.equals(0))).get();
   }
+
+  /// Returns IDs of non-deleted albums that have at least one track
+  /// without a quality check.
+  Future<List<String>> getUnanalysedAlbumIds() async {
+    final query = customSelect(
+      'SELECT DISTINCT ra.id FROM rip_albums ra '
+      'INNER JOIN rip_tracks rt ON rt.rip_album_id = ra.id '
+      'WHERE ra.deleted = 0 AND rt.quality_checked_at IS NULL',
+    );
+    final rows = await query.get();
+    return rows.map((row) => row.read<String>('id')).toList();
+  }
 }

--- a/lib/presentation/providers/batch_analysis_provider.dart
+++ b/lib/presentation/providers/batch_analysis_provider.dart
@@ -1,27 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+
+part 'batch_analysis_provider.freezed.dart';
 
 enum BatchStatus { idle, running, complete }
 
 enum AlbumAnalysisStatus { queued, analysing, done, error }
 
-class BatchAnalysisState {
-  const BatchAnalysisState({
-    this.status = BatchStatus.idle,
-    this.albumStatuses = const {},
-  });
-
-  final BatchStatus status;
-  final Map<String, AlbumAnalysisStatus> albumStatuses;
-
-  BatchAnalysisState copyWith({
-    BatchStatus? status,
-    Map<String, AlbumAnalysisStatus>? albumStatuses,
-  }) =>
-      BatchAnalysisState(
-        status: status ?? this.status,
-        albumStatuses: albumStatuses ?? this.albumStatuses,
-      );
+@freezed
+sealed class BatchAnalysisState with _$BatchAnalysisState {
+  const factory BatchAnalysisState({
+    @Default(BatchStatus.idle) BatchStatus status,
+    @Default({}) Map<String, AlbumAnalysisStatus> albumStatuses,
+  }) = _BatchAnalysisState;
 }
 
 class BatchAnalysisNotifier extends Notifier<BatchAnalysisState> {

--- a/lib/presentation/providers/batch_analysis_provider.freezed.dart
+++ b/lib/presentation/providers/batch_analysis_provider.freezed.dart
@@ -1,0 +1,274 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'batch_analysis_provider.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$BatchAnalysisState {
+
+ BatchStatus get status; Map<String, AlbumAnalysisStatus> get albumStatuses;
+/// Create a copy of BatchAnalysisState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BatchAnalysisStateCopyWith<BatchAnalysisState> get copyWith => _$BatchAnalysisStateCopyWithImpl<BatchAnalysisState>(this as BatchAnalysisState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BatchAnalysisState&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other.albumStatuses, albumStatuses));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,status,const DeepCollectionEquality().hash(albumStatuses));
+
+@override
+String toString() {
+  return 'BatchAnalysisState(status: $status, albumStatuses: $albumStatuses)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BatchAnalysisStateCopyWith<$Res>  {
+  factory $BatchAnalysisStateCopyWith(BatchAnalysisState value, $Res Function(BatchAnalysisState) _then) = _$BatchAnalysisStateCopyWithImpl;
+@useResult
+$Res call({
+ BatchStatus status, Map<String, AlbumAnalysisStatus> albumStatuses
+});
+
+
+
+
+}
+/// @nodoc
+class _$BatchAnalysisStateCopyWithImpl<$Res>
+    implements $BatchAnalysisStateCopyWith<$Res> {
+  _$BatchAnalysisStateCopyWithImpl(this._self, this._then);
+
+  final BatchAnalysisState _self;
+  final $Res Function(BatchAnalysisState) _then;
+
+/// Create a copy of BatchAnalysisState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? albumStatuses = null,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as BatchStatus,albumStatuses: null == albumStatuses ? _self.albumStatuses : albumStatuses // ignore: cast_nullable_to_non_nullable
+as Map<String, AlbumAnalysisStatus>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BatchAnalysisState].
+extension BatchAnalysisStatePatterns on BatchAnalysisState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BatchAnalysisState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BatchAnalysisState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BatchAnalysisState value)  $default,){
+final _that = this;
+switch (_that) {
+case _BatchAnalysisState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BatchAnalysisState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BatchAnalysisState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( BatchStatus status,  Map<String, AlbumAnalysisStatus> albumStatuses)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BatchAnalysisState() when $default != null:
+return $default(_that.status,_that.albumStatuses);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( BatchStatus status,  Map<String, AlbumAnalysisStatus> albumStatuses)  $default,) {final _that = this;
+switch (_that) {
+case _BatchAnalysisState():
+return $default(_that.status,_that.albumStatuses);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( BatchStatus status,  Map<String, AlbumAnalysisStatus> albumStatuses)?  $default,) {final _that = this;
+switch (_that) {
+case _BatchAnalysisState() when $default != null:
+return $default(_that.status,_that.albumStatuses);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _BatchAnalysisState implements BatchAnalysisState {
+  const _BatchAnalysisState({this.status = BatchStatus.idle, final  Map<String, AlbumAnalysisStatus> albumStatuses = const {}}): _albumStatuses = albumStatuses;
+  
+
+@override@JsonKey() final  BatchStatus status;
+ final  Map<String, AlbumAnalysisStatus> _albumStatuses;
+@override@JsonKey() Map<String, AlbumAnalysisStatus> get albumStatuses {
+  if (_albumStatuses is EqualUnmodifiableMapView) return _albumStatuses;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_albumStatuses);
+}
+
+
+/// Create a copy of BatchAnalysisState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BatchAnalysisStateCopyWith<_BatchAnalysisState> get copyWith => __$BatchAnalysisStateCopyWithImpl<_BatchAnalysisState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BatchAnalysisState&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._albumStatuses, _albumStatuses));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,status,const DeepCollectionEquality().hash(_albumStatuses));
+
+@override
+String toString() {
+  return 'BatchAnalysisState(status: $status, albumStatuses: $albumStatuses)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BatchAnalysisStateCopyWith<$Res> implements $BatchAnalysisStateCopyWith<$Res> {
+  factory _$BatchAnalysisStateCopyWith(_BatchAnalysisState value, $Res Function(_BatchAnalysisState) _then) = __$BatchAnalysisStateCopyWithImpl;
+@override @useResult
+$Res call({
+ BatchStatus status, Map<String, AlbumAnalysisStatus> albumStatuses
+});
+
+
+
+
+}
+/// @nodoc
+class __$BatchAnalysisStateCopyWithImpl<$Res>
+    implements _$BatchAnalysisStateCopyWith<$Res> {
+  __$BatchAnalysisStateCopyWithImpl(this._self, this._then);
+
+  final _BatchAnalysisState _self;
+  final $Res Function(_BatchAnalysisState) _then;
+
+/// Create a copy of BatchAnalysisState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? albumStatuses = null,}) {
+  return _then(_BatchAnalysisState(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as BatchStatus,albumStatuses: null == albumStatuses ? _self._albumStatuses : albumStatuses // ignore: cast_nullable_to_non_nullable
+as Map<String, AlbumAnalysisStatus>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/presentation/providers/batch_metadata_edit_provider.dart
+++ b/lib/presentation/providers/batch_metadata_edit_provider.dart
@@ -7,60 +7,40 @@
 /// Since: 0.0.0
 library;
 
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mymediascanner/domain/entities/rip_track.dart';
 import 'package:mymediascanner/domain/usecases/edit_rip_metadata_usecase.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 
+part 'batch_metadata_edit_provider.freezed.dart';
+
 /// Lifecycle status for a batch metadata edit operation.
 enum BatchEditStatus { idle, previewing, applying, applied, error }
 
 /// Holds state for a batch metadata edit operation.
-class BatchMetadataEditState {
-  const BatchMetadataEditState({
-    this.status = BatchEditStatus.idle,
-    this.pendingChanges = const {},
-    this.originalValues = const {},
-    this.affectedTrackCount = 0,
-    this.affectedAlbumCount = 0,
-    this.error,
-  });
+@freezed
+sealed class BatchMetadataEditState with _$BatchMetadataEditState {
+  const factory BatchMetadataEditState({
+    /// Current lifecycle status.
+    @Default(BatchEditStatus.idle) BatchEditStatus status,
 
-  /// Current lifecycle status.
-  final BatchEditStatus status;
+    /// Map of trackId → (tagKey → newValue) for changes to be applied.
+    @Default({}) Map<String, Map<String, String>> pendingChanges,
 
-  /// Map of trackId → (tagKey → newValue) for changes to be applied.
-  final Map<String, Map<String, String>> pendingChanges;
+    /// Map of trackId → (tagKey → oldValue) for undo support.
+    @Default({}) Map<String, Map<String, String>> originalValues,
 
-  /// Map of trackId → (tagKey → oldValue) for undo support.
-  final Map<String, Map<String, String>> originalValues;
+    /// Number of individual tracks affected.
+    @Default(0) int affectedTrackCount,
 
-  /// Number of individual tracks affected.
-  final int affectedTrackCount;
+    /// Number of albums affected.
+    @Default(0) int affectedAlbumCount,
 
-  /// Number of albums affected.
-  final int affectedAlbumCount;
-
-  /// Error message if status is [BatchEditStatus.error].
-  final String? error;
-
-  BatchMetadataEditState copyWith({
-    BatchEditStatus? status,
-    Map<String, Map<String, String>>? pendingChanges,
-    Map<String, Map<String, String>>? originalValues,
-    int? affectedTrackCount,
-    int? affectedAlbumCount,
+    /// Error message if status is [BatchEditStatus.error].
     String? error,
-  }) =>
-      BatchMetadataEditState(
-        status: status ?? this.status,
-        pendingChanges: pendingChanges ?? this.pendingChanges,
-        originalValues: originalValues ?? this.originalValues,
-        affectedTrackCount: affectedTrackCount ?? this.affectedTrackCount,
-        affectedAlbumCount: affectedAlbumCount ?? this.affectedAlbumCount,
-        error: error,
-      );
+  }) = _BatchMetadataEditState;
 }
 
 /// Notifier managing the batch metadata edit lifecycle.

--- a/lib/presentation/providers/batch_metadata_edit_provider.freezed.dart
+++ b/lib/presentation/providers/batch_metadata_edit_provider.freezed.dart
@@ -1,0 +1,306 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'batch_metadata_edit_provider.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$BatchMetadataEditState {
+
+/// Current lifecycle status.
+ BatchEditStatus get status;/// Map of trackId → (tagKey → newValue) for changes to be applied.
+ Map<String, Map<String, String>> get pendingChanges;/// Map of trackId → (tagKey → oldValue) for undo support.
+ Map<String, Map<String, String>> get originalValues;/// Number of individual tracks affected.
+ int get affectedTrackCount;/// Number of albums affected.
+ int get affectedAlbumCount;/// Error message if status is [BatchEditStatus.error].
+ String? get error;
+/// Create a copy of BatchMetadataEditState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$BatchMetadataEditStateCopyWith<BatchMetadataEditState> get copyWith => _$BatchMetadataEditStateCopyWithImpl<BatchMetadataEditState>(this as BatchMetadataEditState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BatchMetadataEditState&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other.pendingChanges, pendingChanges)&&const DeepCollectionEquality().equals(other.originalValues, originalValues)&&(identical(other.affectedTrackCount, affectedTrackCount) || other.affectedTrackCount == affectedTrackCount)&&(identical(other.affectedAlbumCount, affectedAlbumCount) || other.affectedAlbumCount == affectedAlbumCount)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,status,const DeepCollectionEquality().hash(pendingChanges),const DeepCollectionEquality().hash(originalValues),affectedTrackCount,affectedAlbumCount,error);
+
+@override
+String toString() {
+  return 'BatchMetadataEditState(status: $status, pendingChanges: $pendingChanges, originalValues: $originalValues, affectedTrackCount: $affectedTrackCount, affectedAlbumCount: $affectedAlbumCount, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $BatchMetadataEditStateCopyWith<$Res>  {
+  factory $BatchMetadataEditStateCopyWith(BatchMetadataEditState value, $Res Function(BatchMetadataEditState) _then) = _$BatchMetadataEditStateCopyWithImpl;
+@useResult
+$Res call({
+ BatchEditStatus status, Map<String, Map<String, String>> pendingChanges, Map<String, Map<String, String>> originalValues, int affectedTrackCount, int affectedAlbumCount, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class _$BatchMetadataEditStateCopyWithImpl<$Res>
+    implements $BatchMetadataEditStateCopyWith<$Res> {
+  _$BatchMetadataEditStateCopyWithImpl(this._self, this._then);
+
+  final BatchMetadataEditState _self;
+  final $Res Function(BatchMetadataEditState) _then;
+
+/// Create a copy of BatchMetadataEditState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? status = null,Object? pendingChanges = null,Object? originalValues = null,Object? affectedTrackCount = null,Object? affectedAlbumCount = null,Object? error = freezed,}) {
+  return _then(_self.copyWith(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as BatchEditStatus,pendingChanges: null == pendingChanges ? _self.pendingChanges : pendingChanges // ignore: cast_nullable_to_non_nullable
+as Map<String, Map<String, String>>,originalValues: null == originalValues ? _self.originalValues : originalValues // ignore: cast_nullable_to_non_nullable
+as Map<String, Map<String, String>>,affectedTrackCount: null == affectedTrackCount ? _self.affectedTrackCount : affectedTrackCount // ignore: cast_nullable_to_non_nullable
+as int,affectedAlbumCount: null == affectedAlbumCount ? _self.affectedAlbumCount : affectedAlbumCount // ignore: cast_nullable_to_non_nullable
+as int,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [BatchMetadataEditState].
+extension BatchMetadataEditStatePatterns on BatchMetadataEditState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _BatchMetadataEditState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _BatchMetadataEditState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _BatchMetadataEditState value)  $default,){
+final _that = this;
+switch (_that) {
+case _BatchMetadataEditState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _BatchMetadataEditState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _BatchMetadataEditState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( BatchEditStatus status,  Map<String, Map<String, String>> pendingChanges,  Map<String, Map<String, String>> originalValues,  int affectedTrackCount,  int affectedAlbumCount,  String? error)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _BatchMetadataEditState() when $default != null:
+return $default(_that.status,_that.pendingChanges,_that.originalValues,_that.affectedTrackCount,_that.affectedAlbumCount,_that.error);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( BatchEditStatus status,  Map<String, Map<String, String>> pendingChanges,  Map<String, Map<String, String>> originalValues,  int affectedTrackCount,  int affectedAlbumCount,  String? error)  $default,) {final _that = this;
+switch (_that) {
+case _BatchMetadataEditState():
+return $default(_that.status,_that.pendingChanges,_that.originalValues,_that.affectedTrackCount,_that.affectedAlbumCount,_that.error);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( BatchEditStatus status,  Map<String, Map<String, String>> pendingChanges,  Map<String, Map<String, String>> originalValues,  int affectedTrackCount,  int affectedAlbumCount,  String? error)?  $default,) {final _that = this;
+switch (_that) {
+case _BatchMetadataEditState() when $default != null:
+return $default(_that.status,_that.pendingChanges,_that.originalValues,_that.affectedTrackCount,_that.affectedAlbumCount,_that.error);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _BatchMetadataEditState implements BatchMetadataEditState {
+  const _BatchMetadataEditState({this.status = BatchEditStatus.idle, final  Map<String, Map<String, String>> pendingChanges = const {}, final  Map<String, Map<String, String>> originalValues = const {}, this.affectedTrackCount = 0, this.affectedAlbumCount = 0, this.error}): _pendingChanges = pendingChanges,_originalValues = originalValues;
+  
+
+/// Current lifecycle status.
+@override@JsonKey() final  BatchEditStatus status;
+/// Map of trackId → (tagKey → newValue) for changes to be applied.
+ final  Map<String, Map<String, String>> _pendingChanges;
+/// Map of trackId → (tagKey → newValue) for changes to be applied.
+@override@JsonKey() Map<String, Map<String, String>> get pendingChanges {
+  if (_pendingChanges is EqualUnmodifiableMapView) return _pendingChanges;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_pendingChanges);
+}
+
+/// Map of trackId → (tagKey → oldValue) for undo support.
+ final  Map<String, Map<String, String>> _originalValues;
+/// Map of trackId → (tagKey → oldValue) for undo support.
+@override@JsonKey() Map<String, Map<String, String>> get originalValues {
+  if (_originalValues is EqualUnmodifiableMapView) return _originalValues;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_originalValues);
+}
+
+/// Number of individual tracks affected.
+@override@JsonKey() final  int affectedTrackCount;
+/// Number of albums affected.
+@override@JsonKey() final  int affectedAlbumCount;
+/// Error message if status is [BatchEditStatus.error].
+@override final  String? error;
+
+/// Create a copy of BatchMetadataEditState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$BatchMetadataEditStateCopyWith<_BatchMetadataEditState> get copyWith => __$BatchMetadataEditStateCopyWithImpl<_BatchMetadataEditState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BatchMetadataEditState&&(identical(other.status, status) || other.status == status)&&const DeepCollectionEquality().equals(other._pendingChanges, _pendingChanges)&&const DeepCollectionEquality().equals(other._originalValues, _originalValues)&&(identical(other.affectedTrackCount, affectedTrackCount) || other.affectedTrackCount == affectedTrackCount)&&(identical(other.affectedAlbumCount, affectedAlbumCount) || other.affectedAlbumCount == affectedAlbumCount)&&(identical(other.error, error) || other.error == error));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,status,const DeepCollectionEquality().hash(_pendingChanges),const DeepCollectionEquality().hash(_originalValues),affectedTrackCount,affectedAlbumCount,error);
+
+@override
+String toString() {
+  return 'BatchMetadataEditState(status: $status, pendingChanges: $pendingChanges, originalValues: $originalValues, affectedTrackCount: $affectedTrackCount, affectedAlbumCount: $affectedAlbumCount, error: $error)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$BatchMetadataEditStateCopyWith<$Res> implements $BatchMetadataEditStateCopyWith<$Res> {
+  factory _$BatchMetadataEditStateCopyWith(_BatchMetadataEditState value, $Res Function(_BatchMetadataEditState) _then) = __$BatchMetadataEditStateCopyWithImpl;
+@override @useResult
+$Res call({
+ BatchEditStatus status, Map<String, Map<String, String>> pendingChanges, Map<String, Map<String, String>> originalValues, int affectedTrackCount, int affectedAlbumCount, String? error
+});
+
+
+
+
+}
+/// @nodoc
+class __$BatchMetadataEditStateCopyWithImpl<$Res>
+    implements _$BatchMetadataEditStateCopyWith<$Res> {
+  __$BatchMetadataEditStateCopyWithImpl(this._self, this._then);
+
+  final _BatchMetadataEditState _self;
+  final $Res Function(_BatchMetadataEditState) _then;
+
+/// Create a copy of BatchMetadataEditState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? status = null,Object? pendingChanges = null,Object? originalValues = null,Object? affectedTrackCount = null,Object? affectedAlbumCount = null,Object? error = freezed,}) {
+  return _then(_BatchMetadataEditState(
+status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as BatchEditStatus,pendingChanges: null == pendingChanges ? _self._pendingChanges : pendingChanges // ignore: cast_nullable_to_non_nullable
+as Map<String, Map<String, String>>,originalValues: null == originalValues ? _self._originalValues : originalValues // ignore: cast_nullable_to_non_nullable
+as Map<String, Map<String, String>>,affectedTrackCount: null == affectedTrackCount ? _self.affectedTrackCount : affectedTrackCount // ignore: cast_nullable_to_non_nullable
+as int,affectedAlbumCount: null == affectedAlbumCount ? _self.affectedAlbumCount : affectedAlbumCount // ignore: cast_nullable_to_non_nullable
+as int,error: freezed == error ? _self.error : error // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/presentation/providers/playlist_provider.dart
+++ b/lib/presentation/providers/playlist_provider.dart
@@ -153,8 +153,7 @@ class PlaylistCrudNotifier extends Notifier<void> {
     final byId = {for (final t in existing) t.id: t};
     final now = DateTime.now().millisecondsSinceEpoch;
 
-    // Remove all current tracks then re-insert in the desired order.
-    await _dao.clearPlaylistTracks(playlistId);
+    // Build companions in the desired order then atomically clear + re-insert.
     final companions = orderedPlaylistTrackIds.indexed.map((entry) {
       final (index, ptId) = entry;
       final original = byId[ptId]!;
@@ -166,7 +165,7 @@ class PlaylistCrudNotifier extends Notifier<void> {
         addedAt: now,
       );
     }).toList();
-    await _dao.insertPlaylistTracks(companions);
+    await _dao.reorderTracks(playlistId, companions);
     ref.invalidate(playlistTracksProvider(playlistId));
   }
 }

--- a/lib/presentation/providers/queue_provider.dart
+++ b/lib/presentation/providers/queue_provider.dart
@@ -9,45 +9,32 @@
 /// Since: 0.0.0
 library;
 
+import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mymediascanner/domain/entities/queue_item.dart';
 import 'package:mymediascanner/domain/entities/rip_album.dart';
 import 'package:mymediascanner/domain/entities/rip_track.dart';
+
+part 'queue_provider.freezed.dart';
 
 // ---------------------------------------------------------------------------
 // QueueState
 // ---------------------------------------------------------------------------
 
 /// Immutable state for the play queue.
-class QueueState {
+@freezed
+sealed class QueueState with _$QueueState {
   /// Creates a [QueueState].
-  const QueueState({
-    this.items = const [],
-    this.currentIndex = -1,
-    this.history = const [],
-  });
+  const factory QueueState({
+    /// The ordered list of items in the queue.
+    @Default([]) List<QueueItem> items,
 
-  /// The ordered list of items in the queue.
-  final List<QueueItem> items;
+    /// Index of the currently playing item, or -1 if nothing is playing.
+    @Default(-1) int currentIndex,
 
-  /// Index of the currently playing item, or -1 if nothing is playing.
-  final int currentIndex;
-
-  /// Previously played items (most recent last), capped at 50.
-  final List<QueueItem> history;
-
-  /// Returns a copy of this state with the given fields replaced.
-  QueueState copyWith({
-    List<QueueItem>? items,
-    int? currentIndex,
-    List<QueueItem>? history,
-  }) {
-    return QueueState(
-      items: items ?? this.items,
-      currentIndex: currentIndex ?? this.currentIndex,
-      history: history ?? this.history,
-    );
-  }
+    /// Previously played items (most recent last), capped at 50.
+    @Default([]) List<QueueItem> history,
+  }) = _QueueState;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/presentation/providers/queue_provider.freezed.dart
+++ b/lib/presentation/providers/queue_provider.freezed.dart
@@ -1,0 +1,291 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'queue_provider.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$QueueState {
+
+/// The ordered list of items in the queue.
+ List<QueueItem> get items;/// Index of the currently playing item, or -1 if nothing is playing.
+ int get currentIndex;/// Previously played items (most recent last), capped at 50.
+ List<QueueItem> get history;
+/// Create a copy of QueueState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$QueueStateCopyWith<QueueState> get copyWith => _$QueueStateCopyWithImpl<QueueState>(this as QueueState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is QueueState&&const DeepCollectionEquality().equals(other.items, items)&&(identical(other.currentIndex, currentIndex) || other.currentIndex == currentIndex)&&const DeepCollectionEquality().equals(other.history, history));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(items),currentIndex,const DeepCollectionEquality().hash(history));
+
+@override
+String toString() {
+  return 'QueueState(items: $items, currentIndex: $currentIndex, history: $history)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $QueueStateCopyWith<$Res>  {
+  factory $QueueStateCopyWith(QueueState value, $Res Function(QueueState) _then) = _$QueueStateCopyWithImpl;
+@useResult
+$Res call({
+ List<QueueItem> items, int currentIndex, List<QueueItem> history
+});
+
+
+
+
+}
+/// @nodoc
+class _$QueueStateCopyWithImpl<$Res>
+    implements $QueueStateCopyWith<$Res> {
+  _$QueueStateCopyWithImpl(this._self, this._then);
+
+  final QueueState _self;
+  final $Res Function(QueueState) _then;
+
+/// Create a copy of QueueState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? items = null,Object? currentIndex = null,Object? history = null,}) {
+  return _then(_self.copyWith(
+items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+as List<QueueItem>,currentIndex: null == currentIndex ? _self.currentIndex : currentIndex // ignore: cast_nullable_to_non_nullable
+as int,history: null == history ? _self.history : history // ignore: cast_nullable_to_non_nullable
+as List<QueueItem>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [QueueState].
+extension QueueStatePatterns on QueueState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _QueueState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _QueueState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _QueueState value)  $default,){
+final _that = this;
+switch (_that) {
+case _QueueState():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _QueueState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _QueueState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<QueueItem> items,  int currentIndex,  List<QueueItem> history)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _QueueState() when $default != null:
+return $default(_that.items,_that.currentIndex,_that.history);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<QueueItem> items,  int currentIndex,  List<QueueItem> history)  $default,) {final _that = this;
+switch (_that) {
+case _QueueState():
+return $default(_that.items,_that.currentIndex,_that.history);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<QueueItem> items,  int currentIndex,  List<QueueItem> history)?  $default,) {final _that = this;
+switch (_that) {
+case _QueueState() when $default != null:
+return $default(_that.items,_that.currentIndex,_that.history);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _QueueState implements QueueState {
+  const _QueueState({final  List<QueueItem> items = const [], this.currentIndex = -1, final  List<QueueItem> history = const []}): _items = items,_history = history;
+  
+
+/// The ordered list of items in the queue.
+ final  List<QueueItem> _items;
+/// The ordered list of items in the queue.
+@override@JsonKey() List<QueueItem> get items {
+  if (_items is EqualUnmodifiableListView) return _items;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_items);
+}
+
+/// Index of the currently playing item, or -1 if nothing is playing.
+@override@JsonKey() final  int currentIndex;
+/// Previously played items (most recent last), capped at 50.
+ final  List<QueueItem> _history;
+/// Previously played items (most recent last), capped at 50.
+@override@JsonKey() List<QueueItem> get history {
+  if (_history is EqualUnmodifiableListView) return _history;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_history);
+}
+
+
+/// Create a copy of QueueState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$QueueStateCopyWith<_QueueState> get copyWith => __$QueueStateCopyWithImpl<_QueueState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _QueueState&&const DeepCollectionEquality().equals(other._items, _items)&&(identical(other.currentIndex, currentIndex) || other.currentIndex == currentIndex)&&const DeepCollectionEquality().equals(other._history, _history));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_items),currentIndex,const DeepCollectionEquality().hash(_history));
+
+@override
+String toString() {
+  return 'QueueState(items: $items, currentIndex: $currentIndex, history: $history)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$QueueStateCopyWith<$Res> implements $QueueStateCopyWith<$Res> {
+  factory _$QueueStateCopyWith(_QueueState value, $Res Function(_QueueState) _then) = __$QueueStateCopyWithImpl;
+@override @useResult
+$Res call({
+ List<QueueItem> items, int currentIndex, List<QueueItem> history
+});
+
+
+
+
+}
+/// @nodoc
+class __$QueueStateCopyWithImpl<$Res>
+    implements _$QueueStateCopyWith<$Res> {
+  __$QueueStateCopyWithImpl(this._self, this._then);
+
+  final _QueueState _self;
+  final $Res Function(_QueueState) _then;
+
+/// Create a copy of QueueState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? items = null,Object? currentIndex = null,Object? history = null,}) {
+  return _then(_QueueState(
+items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
+as List<QueueItem>,currentIndex: null == currentIndex ? _self.currentIndex : currentIndex // ignore: cast_nullable_to_non_nullable
+as int,history: null == history ? _self._history : history // ignore: cast_nullable_to_non_nullable
+as List<QueueItem>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/presentation/screens/rips/widgets/rip_album_detail_dialog.dart
+++ b/lib/presentation/screens/rips/widgets/rip_album_detail_dialog.dart
@@ -6,7 +6,10 @@ import 'package:mymediascanner/domain/entities/media_item.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/rip_album.dart';
 import 'package:mymediascanner/domain/entities/rip_track.dart';
+import 'package:mymediascanner/domain/entities/queue_item.dart';
 import 'package:mymediascanner/presentation/providers/audio_player_provider.dart';
+import 'package:mymediascanner/presentation/providers/playlist_provider.dart';
+import 'package:mymediascanner/presentation/providers/queue_provider.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 import 'package:mymediascanner/presentation/screens/rips/widgets/playback_widgets.dart';
@@ -474,6 +477,8 @@ class _MusicItemPickerDialogState extends State<_MusicItemPickerDialog> {
   }
 }
 
+enum _TrackAction { playNext, addToQueue, addToPlaylist }
+
 class _TrackTile extends ConsumerStatefulWidget {
   const _TrackTile({
     required this.track,
@@ -507,6 +512,83 @@ class _TrackTileState extends ConsumerState<_TrackTile> {
     'TOTALDISCS': 'Total Discs', 'BARCODE': 'Barcode', 'ISRC': 'ISRC',
     'LYRICS': 'Lyrics',
   };
+
+  void _handleTrackAction(_TrackAction action, BuildContext context) {
+    final track = widget.track;
+    final album = widget.album;
+    switch (action) {
+      case _TrackAction.playNext:
+        ref.read(queueProvider.notifier).playNext(
+              QueueItem(
+                album: album,
+                track: track,
+                source: QueueItemSource.manual,
+              ),
+            );
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+                '"${track.title ?? 'Track ${track.trackNumber}'}" will play next'),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      case _TrackAction.addToQueue:
+        ref.read(queueProvider.notifier).addAlbumToQueue(album, [track]);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+                '"${track.title ?? 'Track ${track.trackNumber}'}" added to queue'),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      case _TrackAction.addToPlaylist:
+        _showAddToPlaylistDialog(context, track);
+    }
+  }
+
+  Future<void> _showAddToPlaylistDialog(
+      BuildContext context, RipTrack track) async {
+    final playlists = ref.read(allPlaylistsProvider).value;
+    if (playlists == null || playlists.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('No playlists found. Create a playlist first.'),
+          duration: Duration(seconds: 2),
+        ),
+      );
+      return;
+    }
+
+    if (!context.mounted) return;
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) => SimpleDialog(
+        title: const Text('Add to Playlist'),
+        children: [
+          for (final playlist in playlists)
+            SimpleDialogOption(
+              onPressed: () async {
+                Navigator.of(dialogContext).pop();
+                await ref
+                    .read(playlistCrudProvider.notifier)
+                    .addTracksToPlaylist(playlist.id, [track.id]);
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: Text(
+                          '"${track.title ?? 'Track ${track.trackNumber}'}" added to "${playlist.name}"'),
+                      duration: const Duration(seconds: 2),
+                    ),
+                  );
+                }
+              },
+              child: Text(playlist.name),
+            ),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -571,6 +653,26 @@ class _TrackTileState extends ConsumerState<_TrackTile> {
                       style: theme.textTheme.bodySmall,
                     ),
                   ),
+                PopupMenuButton<_TrackAction>(
+                  icon: const Icon(Icons.more_vert, size: 20),
+                  tooltip: 'Track actions',
+                  onSelected: (action) =>
+                      _handleTrackAction(action, context),
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(
+                      value: _TrackAction.playNext,
+                      child: Text('Play Next'),
+                    ),
+                    PopupMenuItem(
+                      value: _TrackAction.addToQueue,
+                      child: Text('Add to Queue'),
+                    ),
+                    PopupMenuItem(
+                      value: _TrackAction.addToPlaylist,
+                      child: Text('Add to Playlist...'),
+                    ),
+                  ],
+                ),
                 IconButton(
                   icon: Icon(
                     _expanded ? Icons.expand_less : Icons.expand_more,

--- a/lib/presentation/screens/rips/widgets/rip_library_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_library_view.dart
@@ -10,6 +10,7 @@ import 'package:mymediascanner/domain/entities/rip_track.dart';
 import 'package:mymediascanner/presentation/providers/album_selection_provider.dart';
 import 'package:mymediascanner/presentation/providers/audio_player_provider.dart';
 import 'package:mymediascanner/presentation/providers/batch_analysis_provider.dart';
+import 'package:mymediascanner/presentation/providers/database_provider.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 import 'package:mymediascanner/presentation/providers/selected_rip_album_provider.dart';
 import 'package:mymediascanner/presentation/providers/rip_view_mode_provider.dart';
@@ -113,6 +114,10 @@ class _RipLibraryViewState extends ConsumerState<RipLibraryView> {
                     : 'Scan Library'),
               ),
               const SizedBox(width: 8),
+              if (!isSelecting)
+                _AnalyseAllButton(),
+              if (!isSelecting)
+                const SizedBox(width: 8),
               SegmentedButton<RipViewMode>(
                 showSelectedIcon: false,
                 segments: const [
@@ -304,6 +309,36 @@ class _RipLibraryViewState extends ConsumerState<RipLibraryView> {
       return;
     }
     unawaited(ref.read(ripScanNotifierProvider.notifier).startScan(path));
+  }
+}
+
+class _AnalyseAllButton extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final batchState = ref.watch(batchAnalysisProvider);
+    final isRunning = batchState.status == BatchStatus.running;
+
+    return FilledButton.tonal(
+      onPressed: isRunning ? null : () => _analyseAll(context, ref),
+      child: const Text('Analyse All'),
+    );
+  }
+
+  Future<void> _analyseAll(BuildContext context, WidgetRef ref) async {
+    final dao = ref.read(ripLibraryDaoProvider);
+    final ids = await dao.getUnanalysedAlbumIds();
+
+    if (!context.mounted) return;
+
+    if (ids.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('All albums already analysed')),
+      );
+      return;
+    }
+
+    ref.read(batchAnalysisProvider.notifier).queueAlbums(ids);
+    unawaited(ref.read(batchAnalysisProvider.notifier).startAnalysis());
   }
 }
 

--- a/test/unit/data/dao/playlist_dao_test.dart
+++ b/test/unit/data/dao/playlist_dao_test.dart
@@ -155,6 +155,89 @@ void main() {
       expect(playlist!.name, 'Updated Name');
     });
 
+    test('reorderTracks atomically clears and re-inserts', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final albumId = uuid.v4();
+      final trackAId = uuid.v4();
+      final trackBId = uuid.v4();
+      final trackCId = uuid.v4();
+      final playlistId = uuid.v4();
+      final ptAId = uuid.v4();
+      final ptBId = uuid.v4();
+      final ptCId = uuid.v4();
+
+      await insertRipAlbum(albumId);
+      await insertRipTrack(trackAId, albumId, 1);
+      await insertRipTrack(trackBId, albumId, 2);
+      await insertRipTrack(trackCId, albumId, 3);
+
+      await dao.insertPlaylist(PlaylistsTableCompanion(
+        id: Value(playlistId),
+        name: const Value('Reorder Test'),
+        createdAt: Value(now),
+        updatedAt: Value(now),
+      ));
+
+      // Insert tracks in order A, B, C.
+      await dao.insertPlaylistTracks([
+        PlaylistTracksTableCompanion(
+          id: Value(ptAId),
+          playlistId: Value(playlistId),
+          ripTrackId: Value(trackAId),
+          sortOrder: const Value(1),
+          addedAt: Value(now),
+        ),
+        PlaylistTracksTableCompanion(
+          id: Value(ptBId),
+          playlistId: Value(playlistId),
+          ripTrackId: Value(trackBId),
+          sortOrder: const Value(2),
+          addedAt: Value(now),
+        ),
+        PlaylistTracksTableCompanion(
+          id: Value(ptCId),
+          playlistId: Value(playlistId),
+          ripTrackId: Value(trackCId),
+          sortOrder: const Value(3),
+          addedAt: Value(now),
+        ),
+      ]);
+
+      // Reorder to C, B, A.
+      final reordered = [
+        PlaylistTracksTableCompanion.insert(
+          id: ptCId,
+          playlistId: playlistId,
+          ripTrackId: trackCId,
+          sortOrder: 1,
+          addedAt: now,
+        ),
+        PlaylistTracksTableCompanion.insert(
+          id: ptBId,
+          playlistId: playlistId,
+          ripTrackId: trackBId,
+          sortOrder: 2,
+          addedAt: now,
+        ),
+        PlaylistTracksTableCompanion.insert(
+          id: ptAId,
+          playlistId: playlistId,
+          ripTrackId: trackAId,
+          sortOrder: 3,
+          addedAt: now,
+        ),
+      ];
+
+      await dao.reorderTracks(playlistId, reordered);
+
+      final tracks = await dao.getTracksForPlaylist(playlistId);
+      expect(tracks.length, 3);
+      // Verify new order: C, B, A.
+      expect(tracks[0].ripTrackId, trackCId);
+      expect(tracks[1].ripTrackId, trackBId);
+      expect(tracks[2].ripTrackId, trackAId);
+    });
+
     test('removeTrackFromPlaylist removes specific track', () async {
       final now = DateTime.now().millisecondsSinceEpoch;
       final albumId = uuid.v4();

--- a/test/unit/data/dao/rip_library_dao_test.dart
+++ b/test/unit/data/dao/rip_library_dao_test.dart
@@ -239,5 +239,145 @@ void main() {
       final noResult = await dao.getByLibraryPath('Nonexistent/Path');
       expect(noResult, isNull);
     });
+
+    group('getUnanalysedAlbumIds', () {
+      test('returns albums with at least one unchecked track', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+
+        // Album with one unchecked track
+        await dao.insertAlbum(RipAlbumsTableCompanion(
+          id: const Value('rip-1'),
+          libraryPath: const Value('Artist/Album1'),
+          trackCount: const Value(1),
+          totalSizeBytes: const Value(50000000),
+          lastScannedAt: Value(now),
+          updatedAt: Value(now),
+        ));
+        await dao.insertTracks([
+          RipTracksTableCompanion(
+            id: const Value('track-1'),
+            ripAlbumId: const Value('rip-1'),
+            trackNumber: const Value(1),
+            filePath: const Value('/music/track1.flac'),
+            fileSizeBytes: const Value(50000000),
+            updatedAt: Value(now),
+            // qualityCheckedAt not set — null
+          ),
+        ]);
+
+        final ids = await dao.getUnanalysedAlbumIds();
+        expect(ids, contains('rip-1'));
+        expect(ids.length, 1);
+      });
+
+      test('excludes albums where all tracks are quality-checked', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+
+        await dao.insertAlbum(RipAlbumsTableCompanion(
+          id: const Value('rip-1'),
+          libraryPath: const Value('Artist/Album1'),
+          trackCount: const Value(1),
+          totalSizeBytes: const Value(50000000),
+          lastScannedAt: Value(now),
+          updatedAt: Value(now),
+        ));
+        await dao.insertTracks([
+          RipTracksTableCompanion(
+            id: const Value('track-1'),
+            ripAlbumId: const Value('rip-1'),
+            trackNumber: const Value(1),
+            filePath: const Value('/music/track1.flac'),
+            fileSizeBytes: const Value(50000000),
+            updatedAt: Value(now),
+          ),
+        ]);
+
+        // Mark the track as quality-checked
+        await dao.updateTrackQuality('track-1', qualityCheckedAt: now);
+
+        final ids = await dao.getUnanalysedAlbumIds();
+        expect(ids, isEmpty);
+      });
+
+      test('excludes soft-deleted albums', () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+
+        await dao.insertAlbum(RipAlbumsTableCompanion(
+          id: const Value('rip-1'),
+          libraryPath: const Value('Artist/Album1'),
+          trackCount: const Value(1),
+          totalSizeBytes: const Value(50000000),
+          lastScannedAt: Value(now),
+          updatedAt: Value(now),
+        ));
+        await dao.insertTracks([
+          RipTracksTableCompanion(
+            id: const Value('track-1'),
+            ripAlbumId: const Value('rip-1'),
+            trackNumber: const Value(1),
+            filePath: const Value('/music/track1.flac'),
+            fileSizeBytes: const Value(50000000),
+            updatedAt: Value(now),
+          ),
+        ]);
+
+        // Soft-delete the album
+        await dao.softDeleteAlbum('rip-1', now + 1000);
+
+        final ids = await dao.getUnanalysedAlbumIds();
+        expect(ids, isEmpty);
+      });
+
+      test('returns only albums with at least one unchecked track when mixed',
+          () async {
+        final now = DateTime.now().millisecondsSinceEpoch;
+
+        // Album with one unchecked track
+        await dao.insertAlbum(RipAlbumsTableCompanion(
+          id: const Value('rip-unanalysed'),
+          libraryPath: const Value('Artist/Unanalysed'),
+          trackCount: const Value(1),
+          totalSizeBytes: const Value(50000000),
+          lastScannedAt: Value(now),
+          updatedAt: Value(now),
+        ));
+        await dao.insertTracks([
+          RipTracksTableCompanion(
+            id: const Value('track-unchecked'),
+            ripAlbumId: const Value('rip-unanalysed'),
+            trackNumber: const Value(1),
+            filePath: const Value('/music/unchecked.flac'),
+            fileSizeBytes: const Value(50000000),
+            updatedAt: Value(now),
+          ),
+        ]);
+
+        // Album fully analysed
+        await dao.insertAlbum(RipAlbumsTableCompanion(
+          id: const Value('rip-analysed'),
+          libraryPath: const Value('Artist/Analysed'),
+          trackCount: const Value(1),
+          totalSizeBytes: const Value(50000000),
+          lastScannedAt: Value(now),
+          updatedAt: Value(now),
+        ));
+        await dao.insertTracks([
+          RipTracksTableCompanion(
+            id: const Value('track-checked'),
+            ripAlbumId: const Value('rip-analysed'),
+            trackNumber: const Value(1),
+            filePath: const Value('/music/checked.flac'),
+            fileSizeBytes: const Value(50000000),
+            updatedAt: Value(now),
+          ),
+        ]);
+        await dao.updateTrackQuality('track-checked', qualityCheckedAt: now);
+
+        final ids = await dao.getUnanalysedAlbumIds();
+        expect(ids, contains('rip-unanalysed'));
+        expect(ids, isNot(contains('rip-analysed')));
+        expect(ids.length, 1);
+      });
+    });
   });
 }

--- a/test/unit/presentation/providers/collection_rip_status_provider_test.dart
+++ b/test/unit/presentation/providers/collection_rip_status_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mymediascanner/presentation/providers/collection_rip_status_provider.dart';
 
@@ -46,6 +47,99 @@ void main() {
 
     test('verified is distinct from qualityIssues', () {
       expect(RipStatusFilter.verified, isNot(RipStatusFilter.qualityIssues));
+    });
+  });
+
+  group('RipStatusFilterNotifier', () {
+    test('initial state is all', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(ripStatusFilterProvider), RipStatusFilter.all);
+    });
+
+    test('setFilter updates state', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container
+          .read(ripStatusFilterProvider.notifier)
+          .setFilter(RipStatusFilter.hasRip);
+      expect(container.read(ripStatusFilterProvider), RipStatusFilter.hasRip);
+    });
+
+    test('setFilter to same value is idempotent', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      container
+          .read(ripStatusFilterProvider.notifier)
+          .setFilter(RipStatusFilter.noRip);
+      container
+          .read(ripStatusFilterProvider.notifier)
+          .setFilter(RipStatusFilter.noRip);
+      expect(container.read(ripStatusFilterProvider), RipStatusFilter.noRip);
+    });
+
+    test('setFilter cycles through all values', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      for (final filter in RipStatusFilter.values) {
+        container.read(ripStatusFilterProvider.notifier).setFilter(filter);
+        expect(container.read(ripStatusFilterProvider), filter);
+      }
+    });
+  });
+
+  group('CollectionRipStats', () {
+    test('coveragePercentage (noRip getter) is 0 when no items', () {
+      const stats = CollectionRipStats(
+        total: 0,
+        ripped: 0,
+        verified: 0,
+        qualityIssues: 0,
+      );
+      expect(stats.noRip, 0);
+    });
+
+    test('noRip calculates correctly', () {
+      const stats = CollectionRipStats(
+        total: 10,
+        ripped: 3,
+        verified: 2,
+        qualityIssues: 1,
+      );
+      expect(stats.noRip, 7);
+    });
+
+    test('noRip is 0 when all items are ripped', () {
+      const stats = CollectionRipStats(
+        total: 5,
+        ripped: 5,
+        verified: 5,
+        qualityIssues: 0,
+      );
+      expect(stats.noRip, 0);
+    });
+
+    test('default constructor sets all fields to 0', () {
+      const stats = CollectionRipStats();
+      expect(stats.total, 0);
+      expect(stats.ripped, 0);
+      expect(stats.verified, 0);
+      expect(stats.qualityIssues, 0);
+      expect(stats.noRip, 0);
+    });
+
+    test('fields are accessible and correct', () {
+      const stats = CollectionRipStats(
+        total: 20,
+        ripped: 12,
+        verified: 8,
+        qualityIssues: 4,
+      );
+      expect(stats.total, 20);
+      expect(stats.ripped, 12);
+      expect(stats.verified, 8);
+      expect(stats.qualityIssues, 4);
+      expect(stats.noRip, 8);
     });
   });
 }


### PR DESCRIPTION
## Summary

Addresses 5 code review suggestions from the rips/player enhancements PR:

- **Context menu actions** — Play Next, Add to Queue, and Add to Playlist popup menu on track tiles in album detail dialog
- **Analyse All button** — new DAO method to find un-analysed albums + toolbar button that queues and auto-starts batch analysis
- **Freezed state classes** — converted QueueState, BatchAnalysisState, and BatchMetadataEditState from manual copyWith to @freezed
- **Deeper rip status tests** — functional tests for RipStatusFilterNotifier and CollectionRipStats (17 total, up from 8)
- **Transaction safety** — playlist reorder now uses Drift transaction() to atomically clear + re-insert tracks

**Stats:** 860 tests passing (up from 846)

## Test plan

- [x] `flutter test` — 860 tests pass
- [x] `flutter analyze` — no errors
- [x] DAO test: getUnanalysedAlbumIds returns correct albums
- [x] DAO test: reorderTracks atomically clears and re-inserts
- [x] Provider tests: RipStatusFilterNotifier state transitions
- [x] Provider tests: CollectionRipStats calculations