### PR TITLE
feat(recommendations): explainable scoring for owned + wishlist (#40)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -20,6 +20,7 @@ import 'package:mymediascanner/presentation/screens/wishlist/wishlist_screen.dar
 import 'package:mymediascanner/presentation/screens/locations/location_browser_screen.dart';
 import 'package:mymediascanner/presentation/screens/series/series_list_screen.dart';
 import 'package:mymediascanner/presentation/screens/series/series_detail_screen.dart';
+import 'package:mymediascanner/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen.dart';
 import 'package:mymediascanner/presentation/screens/about/about_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrowers_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrower_detail_screen.dart';
@@ -271,6 +272,17 @@ final router = GoRouter(
                   ),
                 ),
               ],
+            ),
+          ],
+        ),
+
+        // 11 — Wishlist suggestions (desktop sidebar only)
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/wishlist-suggestions',
+              builder: (context, state) =>
+                  const WishlistSuggestionsScreen(),
             ),
           ],
         ),

--- a/lib/data/remote/api/tmdb/tmdb_api.dart
+++ b/lib/data/remote/api/tmdb/tmdb_api.dart
@@ -38,4 +38,11 @@ abstract class TmdbApi {
   /// resolution. Search/find responses do not include collection refs.
   @GET('/movie/{id}')
   Future<TmdbMovieDetailDto> getMovieDetail(@Path('id') int id);
+
+  /// Trending content for the current week — used as a candidate pool
+  /// for wishlist suggestions. `mediaType` accepts `movie`, `tv` or `all`.
+  @GET('/trending/{mediaType}/week')
+  Future<TmdbSearchResponseDto> trending(
+    @Path('mediaType') String mediaType,
+  );
 }

--- a/lib/data/remote/api/tmdb/tmdb_api.g.dart
+++ b/lib/data/remote/api/tmdb/tmdb_api.g.dart
@@ -165,6 +165,33 @@ class _TmdbApi implements TmdbApi {
     return _value;
   }
 
+  @override
+  Future<TmdbSearchResponseDto> trending(String mediaType) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<TmdbSearchResponseDto>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/trending/${mediaType}/week',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late TmdbSearchResponseDto _value;
+    try {
+      _value = TmdbSearchResponseDto.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/domain/entities/recommendation.dart
+++ b/lib/domain/entities/recommendation.dart
@@ -1,0 +1,45 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+
+part 'recommendation.freezed.dart';
+
+/// A single contributing factor to a recommendation's score.
+///
+/// `weight` is the unscaled contribution (positive or negative) as returned
+/// by the scorer. The UI displays [label] and may use [weight] to sort or
+/// emphasise reasons.
+@freezed
+sealed class RecommendationReason with _$RecommendationReason {
+  const factory RecommendationReason({
+    required String label,
+    required double weight,
+  }) = _RecommendationReason;
+}
+
+/// A single ranked recommendation: an item, a normalised [score] in
+/// `[0, 1]`, and the [reasons] that contributed to it.
+@freezed
+sealed class Recommendation with _$Recommendation {
+  const factory Recommendation({
+    required MediaItem item,
+    required double score,
+    required List<RecommendationReason> reasons,
+  }) = _Recommendation;
+}
+
+/// A "wishlist suggestion" — an external candidate (not yet in the
+/// collection) the user might want to add.
+@freezed
+sealed class WishlistSuggestion with _$WishlistSuggestion {
+  const factory WishlistSuggestion({
+    required String externalId,
+    required String title,
+    String? subtitle,
+    String? coverUrl,
+    int? year,
+    @Default([]) List<String> genres,
+    required String source,
+    required double score,
+    required List<RecommendationReason> reasons,
+  }) = _WishlistSuggestion;
+}

--- a/lib/domain/entities/recommendation.freezed.dart
+++ b/lib/domain/entities/recommendation.freezed.dart
@@ -1,0 +1,836 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'recommendation.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$RecommendationReason {
+
+ String get label; double get weight;
+/// Create a copy of RecommendationReason
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RecommendationReasonCopyWith<RecommendationReason> get copyWith => _$RecommendationReasonCopyWithImpl<RecommendationReason>(this as RecommendationReason, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RecommendationReason&&(identical(other.label, label) || other.label == label)&&(identical(other.weight, weight) || other.weight == weight));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,label,weight);
+
+@override
+String toString() {
+  return 'RecommendationReason(label: $label, weight: $weight)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RecommendationReasonCopyWith<$Res>  {
+  factory $RecommendationReasonCopyWith(RecommendationReason value, $Res Function(RecommendationReason) _then) = _$RecommendationReasonCopyWithImpl;
+@useResult
+$Res call({
+ String label, double weight
+});
+
+
+
+
+}
+/// @nodoc
+class _$RecommendationReasonCopyWithImpl<$Res>
+    implements $RecommendationReasonCopyWith<$Res> {
+  _$RecommendationReasonCopyWithImpl(this._self, this._then);
+
+  final RecommendationReason _self;
+  final $Res Function(RecommendationReason) _then;
+
+/// Create a copy of RecommendationReason
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? label = null,Object? weight = null,}) {
+  return _then(_self.copyWith(
+label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,weight: null == weight ? _self.weight : weight // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [RecommendationReason].
+extension RecommendationReasonPatterns on RecommendationReason {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _RecommendationReason value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _RecommendationReason() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _RecommendationReason value)  $default,){
+final _that = this;
+switch (_that) {
+case _RecommendationReason():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _RecommendationReason value)?  $default,){
+final _that = this;
+switch (_that) {
+case _RecommendationReason() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String label,  double weight)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _RecommendationReason() when $default != null:
+return $default(_that.label,_that.weight);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String label,  double weight)  $default,) {final _that = this;
+switch (_that) {
+case _RecommendationReason():
+return $default(_that.label,_that.weight);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String label,  double weight)?  $default,) {final _that = this;
+switch (_that) {
+case _RecommendationReason() when $default != null:
+return $default(_that.label,_that.weight);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _RecommendationReason implements RecommendationReason {
+  const _RecommendationReason({required this.label, required this.weight});
+  
+
+@override final  String label;
+@override final  double weight;
+
+/// Create a copy of RecommendationReason
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RecommendationReasonCopyWith<_RecommendationReason> get copyWith => __$RecommendationReasonCopyWithImpl<_RecommendationReason>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RecommendationReason&&(identical(other.label, label) || other.label == label)&&(identical(other.weight, weight) || other.weight == weight));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,label,weight);
+
+@override
+String toString() {
+  return 'RecommendationReason(label: $label, weight: $weight)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RecommendationReasonCopyWith<$Res> implements $RecommendationReasonCopyWith<$Res> {
+  factory _$RecommendationReasonCopyWith(_RecommendationReason value, $Res Function(_RecommendationReason) _then) = __$RecommendationReasonCopyWithImpl;
+@override @useResult
+$Res call({
+ String label, double weight
+});
+
+
+
+
+}
+/// @nodoc
+class __$RecommendationReasonCopyWithImpl<$Res>
+    implements _$RecommendationReasonCopyWith<$Res> {
+  __$RecommendationReasonCopyWithImpl(this._self, this._then);
+
+  final _RecommendationReason _self;
+  final $Res Function(_RecommendationReason) _then;
+
+/// Create a copy of RecommendationReason
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? label = null,Object? weight = null,}) {
+  return _then(_RecommendationReason(
+label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,weight: null == weight ? _self.weight : weight // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+/// @nodoc
+mixin _$Recommendation {
+
+ MediaItem get item; double get score; List<RecommendationReason> get reasons;
+/// Create a copy of Recommendation
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$RecommendationCopyWith<Recommendation> get copyWith => _$RecommendationCopyWithImpl<Recommendation>(this as Recommendation, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Recommendation&&(identical(other.item, item) || other.item == item)&&(identical(other.score, score) || other.score == score)&&const DeepCollectionEquality().equals(other.reasons, reasons));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,item,score,const DeepCollectionEquality().hash(reasons));
+
+@override
+String toString() {
+  return 'Recommendation(item: $item, score: $score, reasons: $reasons)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $RecommendationCopyWith<$Res>  {
+  factory $RecommendationCopyWith(Recommendation value, $Res Function(Recommendation) _then) = _$RecommendationCopyWithImpl;
+@useResult
+$Res call({
+ MediaItem item, double score, List<RecommendationReason> reasons
+});
+
+
+$MediaItemCopyWith<$Res> get item;
+
+}
+/// @nodoc
+class _$RecommendationCopyWithImpl<$Res>
+    implements $RecommendationCopyWith<$Res> {
+  _$RecommendationCopyWithImpl(this._self, this._then);
+
+  final Recommendation _self;
+  final $Res Function(Recommendation) _then;
+
+/// Create a copy of Recommendation
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? item = null,Object? score = null,Object? reasons = null,}) {
+  return _then(_self.copyWith(
+item: null == item ? _self.item : item // ignore: cast_nullable_to_non_nullable
+as MediaItem,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as double,reasons: null == reasons ? _self.reasons : reasons // ignore: cast_nullable_to_non_nullable
+as List<RecommendationReason>,
+  ));
+}
+/// Create a copy of Recommendation
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$MediaItemCopyWith<$Res> get item {
+  
+  return $MediaItemCopyWith<$Res>(_self.item, (value) {
+    return _then(_self.copyWith(item: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [Recommendation].
+extension RecommendationPatterns on Recommendation {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _Recommendation value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _Recommendation() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _Recommendation value)  $default,){
+final _that = this;
+switch (_that) {
+case _Recommendation():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _Recommendation value)?  $default,){
+final _that = this;
+switch (_that) {
+case _Recommendation() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( MediaItem item,  double score,  List<RecommendationReason> reasons)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _Recommendation() when $default != null:
+return $default(_that.item,_that.score,_that.reasons);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( MediaItem item,  double score,  List<RecommendationReason> reasons)  $default,) {final _that = this;
+switch (_that) {
+case _Recommendation():
+return $default(_that.item,_that.score,_that.reasons);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( MediaItem item,  double score,  List<RecommendationReason> reasons)?  $default,) {final _that = this;
+switch (_that) {
+case _Recommendation() when $default != null:
+return $default(_that.item,_that.score,_that.reasons);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _Recommendation implements Recommendation {
+  const _Recommendation({required this.item, required this.score, required final  List<RecommendationReason> reasons}): _reasons = reasons;
+  
+
+@override final  MediaItem item;
+@override final  double score;
+ final  List<RecommendationReason> _reasons;
+@override List<RecommendationReason> get reasons {
+  if (_reasons is EqualUnmodifiableListView) return _reasons;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_reasons);
+}
+
+
+/// Create a copy of Recommendation
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$RecommendationCopyWith<_Recommendation> get copyWith => __$RecommendationCopyWithImpl<_Recommendation>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Recommendation&&(identical(other.item, item) || other.item == item)&&(identical(other.score, score) || other.score == score)&&const DeepCollectionEquality().equals(other._reasons, _reasons));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,item,score,const DeepCollectionEquality().hash(_reasons));
+
+@override
+String toString() {
+  return 'Recommendation(item: $item, score: $score, reasons: $reasons)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$RecommendationCopyWith<$Res> implements $RecommendationCopyWith<$Res> {
+  factory _$RecommendationCopyWith(_Recommendation value, $Res Function(_Recommendation) _then) = __$RecommendationCopyWithImpl;
+@override @useResult
+$Res call({
+ MediaItem item, double score, List<RecommendationReason> reasons
+});
+
+
+@override $MediaItemCopyWith<$Res> get item;
+
+}
+/// @nodoc
+class __$RecommendationCopyWithImpl<$Res>
+    implements _$RecommendationCopyWith<$Res> {
+  __$RecommendationCopyWithImpl(this._self, this._then);
+
+  final _Recommendation _self;
+  final $Res Function(_Recommendation) _then;
+
+/// Create a copy of Recommendation
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? item = null,Object? score = null,Object? reasons = null,}) {
+  return _then(_Recommendation(
+item: null == item ? _self.item : item // ignore: cast_nullable_to_non_nullable
+as MediaItem,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as double,reasons: null == reasons ? _self._reasons : reasons // ignore: cast_nullable_to_non_nullable
+as List<RecommendationReason>,
+  ));
+}
+
+/// Create a copy of Recommendation
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$MediaItemCopyWith<$Res> get item {
+  
+  return $MediaItemCopyWith<$Res>(_self.item, (value) {
+    return _then(_self.copyWith(item: value));
+  });
+}
+}
+
+/// @nodoc
+mixin _$WishlistSuggestion {
+
+ String get externalId; String get title; String? get subtitle; String? get coverUrl; int? get year; List<String> get genres; String get source; double get score; List<RecommendationReason> get reasons;
+/// Create a copy of WishlistSuggestion
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$WishlistSuggestionCopyWith<WishlistSuggestion> get copyWith => _$WishlistSuggestionCopyWithImpl<WishlistSuggestion>(this as WishlistSuggestion, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is WishlistSuggestion&&(identical(other.externalId, externalId) || other.externalId == externalId)&&(identical(other.title, title) || other.title == title)&&(identical(other.subtitle, subtitle) || other.subtitle == subtitle)&&(identical(other.coverUrl, coverUrl) || other.coverUrl == coverUrl)&&(identical(other.year, year) || other.year == year)&&const DeepCollectionEquality().equals(other.genres, genres)&&(identical(other.source, source) || other.source == source)&&(identical(other.score, score) || other.score == score)&&const DeepCollectionEquality().equals(other.reasons, reasons));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,externalId,title,subtitle,coverUrl,year,const DeepCollectionEquality().hash(genres),source,score,const DeepCollectionEquality().hash(reasons));
+
+@override
+String toString() {
+  return 'WishlistSuggestion(externalId: $externalId, title: $title, subtitle: $subtitle, coverUrl: $coverUrl, year: $year, genres: $genres, source: $source, score: $score, reasons: $reasons)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $WishlistSuggestionCopyWith<$Res>  {
+  factory $WishlistSuggestionCopyWith(WishlistSuggestion value, $Res Function(WishlistSuggestion) _then) = _$WishlistSuggestionCopyWithImpl;
+@useResult
+$Res call({
+ String externalId, String title, String? subtitle, String? coverUrl, int? year, List<String> genres, String source, double score, List<RecommendationReason> reasons
+});
+
+
+
+
+}
+/// @nodoc
+class _$WishlistSuggestionCopyWithImpl<$Res>
+    implements $WishlistSuggestionCopyWith<$Res> {
+  _$WishlistSuggestionCopyWithImpl(this._self, this._then);
+
+  final WishlistSuggestion _self;
+  final $Res Function(WishlistSuggestion) _then;
+
+/// Create a copy of WishlistSuggestion
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? externalId = null,Object? title = null,Object? subtitle = freezed,Object? coverUrl = freezed,Object? year = freezed,Object? genres = null,Object? source = null,Object? score = null,Object? reasons = null,}) {
+  return _then(_self.copyWith(
+externalId: null == externalId ? _self.externalId : externalId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,subtitle: freezed == subtitle ? _self.subtitle : subtitle // ignore: cast_nullable_to_non_nullable
+as String?,coverUrl: freezed == coverUrl ? _self.coverUrl : coverUrl // ignore: cast_nullable_to_non_nullable
+as String?,year: freezed == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
+as int?,genres: null == genres ? _self.genres : genres // ignore: cast_nullable_to_non_nullable
+as List<String>,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as String,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as double,reasons: null == reasons ? _self.reasons : reasons // ignore: cast_nullable_to_non_nullable
+as List<RecommendationReason>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [WishlistSuggestion].
+extension WishlistSuggestionPatterns on WishlistSuggestion {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _WishlistSuggestion value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _WishlistSuggestion() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _WishlistSuggestion value)  $default,){
+final _that = this;
+switch (_that) {
+case _WishlistSuggestion():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _WishlistSuggestion value)?  $default,){
+final _that = this;
+switch (_that) {
+case _WishlistSuggestion() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String externalId,  String title,  String? subtitle,  String? coverUrl,  int? year,  List<String> genres,  String source,  double score,  List<RecommendationReason> reasons)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _WishlistSuggestion() when $default != null:
+return $default(_that.externalId,_that.title,_that.subtitle,_that.coverUrl,_that.year,_that.genres,_that.source,_that.score,_that.reasons);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String externalId,  String title,  String? subtitle,  String? coverUrl,  int? year,  List<String> genres,  String source,  double score,  List<RecommendationReason> reasons)  $default,) {final _that = this;
+switch (_that) {
+case _WishlistSuggestion():
+return $default(_that.externalId,_that.title,_that.subtitle,_that.coverUrl,_that.year,_that.genres,_that.source,_that.score,_that.reasons);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String externalId,  String title,  String? subtitle,  String? coverUrl,  int? year,  List<String> genres,  String source,  double score,  List<RecommendationReason> reasons)?  $default,) {final _that = this;
+switch (_that) {
+case _WishlistSuggestion() when $default != null:
+return $default(_that.externalId,_that.title,_that.subtitle,_that.coverUrl,_that.year,_that.genres,_that.source,_that.score,_that.reasons);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _WishlistSuggestion implements WishlistSuggestion {
+  const _WishlistSuggestion({required this.externalId, required this.title, this.subtitle, this.coverUrl, this.year, final  List<String> genres = const [], required this.source, required this.score, required final  List<RecommendationReason> reasons}): _genres = genres,_reasons = reasons;
+  
+
+@override final  String externalId;
+@override final  String title;
+@override final  String? subtitle;
+@override final  String? coverUrl;
+@override final  int? year;
+ final  List<String> _genres;
+@override@JsonKey() List<String> get genres {
+  if (_genres is EqualUnmodifiableListView) return _genres;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_genres);
+}
+
+@override final  String source;
+@override final  double score;
+ final  List<RecommendationReason> _reasons;
+@override List<RecommendationReason> get reasons {
+  if (_reasons is EqualUnmodifiableListView) return _reasons;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_reasons);
+}
+
+
+/// Create a copy of WishlistSuggestion
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$WishlistSuggestionCopyWith<_WishlistSuggestion> get copyWith => __$WishlistSuggestionCopyWithImpl<_WishlistSuggestion>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _WishlistSuggestion&&(identical(other.externalId, externalId) || other.externalId == externalId)&&(identical(other.title, title) || other.title == title)&&(identical(other.subtitle, subtitle) || other.subtitle == subtitle)&&(identical(other.coverUrl, coverUrl) || other.coverUrl == coverUrl)&&(identical(other.year, year) || other.year == year)&&const DeepCollectionEquality().equals(other._genres, _genres)&&(identical(other.source, source) || other.source == source)&&(identical(other.score, score) || other.score == score)&&const DeepCollectionEquality().equals(other._reasons, _reasons));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,externalId,title,subtitle,coverUrl,year,const DeepCollectionEquality().hash(_genres),source,score,const DeepCollectionEquality().hash(_reasons));
+
+@override
+String toString() {
+  return 'WishlistSuggestion(externalId: $externalId, title: $title, subtitle: $subtitle, coverUrl: $coverUrl, year: $year, genres: $genres, source: $source, score: $score, reasons: $reasons)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$WishlistSuggestionCopyWith<$Res> implements $WishlistSuggestionCopyWith<$Res> {
+  factory _$WishlistSuggestionCopyWith(_WishlistSuggestion value, $Res Function(_WishlistSuggestion) _then) = __$WishlistSuggestionCopyWithImpl;
+@override @useResult
+$Res call({
+ String externalId, String title, String? subtitle, String? coverUrl, int? year, List<String> genres, String source, double score, List<RecommendationReason> reasons
+});
+
+
+
+
+}
+/// @nodoc
+class __$WishlistSuggestionCopyWithImpl<$Res>
+    implements _$WishlistSuggestionCopyWith<$Res> {
+  __$WishlistSuggestionCopyWithImpl(this._self, this._then);
+
+  final _WishlistSuggestion _self;
+  final $Res Function(_WishlistSuggestion) _then;
+
+/// Create a copy of WishlistSuggestion
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? externalId = null,Object? title = null,Object? subtitle = freezed,Object? coverUrl = freezed,Object? year = freezed,Object? genres = null,Object? source = null,Object? score = null,Object? reasons = null,}) {
+  return _then(_WishlistSuggestion(
+externalId: null == externalId ? _self.externalId : externalId // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,subtitle: freezed == subtitle ? _self.subtitle : subtitle // ignore: cast_nullable_to_non_nullable
+as String?,coverUrl: freezed == coverUrl ? _self.coverUrl : coverUrl // ignore: cast_nullable_to_non_nullable
+as String?,year: freezed == year ? _self.year : year // ignore: cast_nullable_to_non_nullable
+as int?,genres: null == genres ? _self._genres : genres // ignore: cast_nullable_to_non_nullable
+as List<String>,source: null == source ? _self.source : source // ignore: cast_nullable_to_non_nullable
+as String,score: null == score ? _self.score : score // ignore: cast_nullable_to_non_nullable
+as double,reasons: null == reasons ? _self._reasons : reasons // ignore: cast_nullable_to_non_nullable
+as List<RecommendationReason>,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/domain/entities/taste_profile.dart
+++ b/lib/domain/entities/taste_profile.dart
@@ -1,0 +1,43 @@
+/// A summary of the user's collection from which the recommendation
+/// scorer derives its signal.
+///
+/// All fields are derived purely from existing data — no preferences UI,
+/// no remote calls. Built once per recommendation pass, then read many
+/// times by the scorer.
+class TasteProfile {
+  const TasteProfile({
+    required this.lovedGenres,
+    required this.lovedTags,
+    required this.collectedSeriesIds,
+    required this.averageRating,
+    required this.totalRatedItems,
+  });
+
+  /// Genres weighted by how often they appear on items rated >= 4.0.
+  /// Map values are normalised to `[0, 1]` (relative frequency).
+  final Map<String, double> lovedGenres;
+
+  /// Tags weighted by how often they appear on items rated >= 4.0.
+  final Map<String, double> lovedTags;
+
+  /// Series the user is actively collecting (>= 2 owned items in a
+  /// series). Items belonging to these series get a boost.
+  final Set<String> collectedSeriesIds;
+
+  /// Mean of every non-null user rating in the collection.
+  final double? averageRating;
+
+  /// Number of items contributing to [averageRating]. The scorer can use
+  /// this as a confidence proxy.
+  final int totalRatedItems;
+
+  /// Empty profile — used as a safe fallback when the user has no rated
+  /// items yet.
+  static const TasteProfile empty = TasteProfile(
+    lovedGenres: {},
+    lovedTags: {},
+    collectedSeriesIds: {},
+    averageRating: null,
+    totalRatedItems: 0,
+  );
+}

--- a/lib/domain/services/recommendation_scorer.dart
+++ b/lib/domain/services/recommendation_scorer.dart
@@ -1,0 +1,130 @@
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/recommendation.dart';
+import 'package:mymediascanner/domain/entities/taste_profile.dart';
+
+/// Pure, deterministic scorer. Given a [TasteProfile] derived from the
+/// user's collection and a candidate [MediaItem], returns a normalised
+/// score in `[0, 1]` plus the structured [RecommendationReason]s that
+/// contributed.
+///
+/// Scoring recipe:
+///   * **Genre overlap** (weight 0.45): sum of `lovedGenres[g]` for each
+///     genre `g` on the candidate, capped at 1.0.
+///   * **Tag overlap**   (weight 0.20): same shape, over `lovedTags`.
+///   * **Series collecting** (weight 0.20): full weight when the
+///     candidate's `seriesId` is in `collectedSeriesIds`.
+///   * **Recency** (weight 0.10): linear decay over the last 90 days
+///     from `dateAdded`. Items older than 90 days contribute 0.
+///   * **High personal rating** (weight 0.05): `userRating / 5.0` when
+///     present. Lets the user's own marks lift their favourites without
+///     dominating discovery.
+///
+/// Items that are completed, currently in-progress, or marked
+/// `consumed` score 0 (the caller filters them out). The scorer itself
+/// does not inspect those fields — see `RecommendNextUseCase`.
+class RecommendationScorer {
+  const RecommendationScorer({
+    DateTime Function()? clock,
+    Duration recencyWindow = const Duration(days: 90),
+  })  : _clock = clock ?? DateTime.now,
+        _recencyWindow = recencyWindow;
+
+  final DateTime Function() _clock;
+  final Duration _recencyWindow;
+
+  static const double _wGenre = 0.45;
+  static const double _wTag = 0.20;
+  static const double _wSeries = 0.20;
+  static const double _wRecency = 0.10;
+  static const double _wRating = 0.05;
+
+  /// Score [item] against [profile]. Always returns a value in `[0, 1]`.
+  ({double score, List<RecommendationReason> reasons}) score(
+    MediaItem item,
+    TasteProfile profile,
+  ) {
+    final reasons = <RecommendationReason>[];
+    var total = 0.0;
+
+    // ── Genre overlap ────────────────────────────────────────────────
+    final genreHits = <String>[];
+    var genreScore = 0.0;
+    for (final g in item.genres) {
+      final w = profile.lovedGenres[g];
+      if (w != null) {
+        genreScore += w;
+        genreHits.add(g);
+      }
+    }
+    if (genreScore > 1.0) genreScore = 1.0;
+    if (genreScore > 0) {
+      total += _wGenre * genreScore;
+      reasons.add(RecommendationReason(
+        label: 'Matches genres you like: ${genreHits.join(', ')}',
+        weight: _wGenre * genreScore,
+      ));
+    }
+
+    // ── Tag overlap ──────────────────────────────────────────────────
+    // (Tags live in a separate table; pass them on the item if/when the
+    // scorer is fed enriched items. For now this branch is a no-op when
+    // extraMetadata['tags'] is absent.)
+    final tags = (item.extraMetadata['tags'] is List)
+        ? List<String>.from(item.extraMetadata['tags'] as List)
+        : const <String>[];
+    final tagHits = <String>[];
+    var tagScore = 0.0;
+    for (final t in tags) {
+      final w = profile.lovedTags[t];
+      if (w != null) {
+        tagScore += w;
+        tagHits.add(t);
+      }
+    }
+    if (tagScore > 1.0) tagScore = 1.0;
+    if (tagScore > 0) {
+      total += _wTag * tagScore;
+      reasons.add(RecommendationReason(
+        label: 'Tagged ${tagHits.join(', ')}',
+        weight: _wTag * tagScore,
+      ));
+    }
+
+    // ── Series the user is collecting ────────────────────────────────
+    if (item.seriesId != null &&
+        profile.collectedSeriesIds.contains(item.seriesId)) {
+      total += _wSeries;
+      reasons.add(const RecommendationReason(
+        label: 'Part of a series you collect',
+        weight: _wSeries,
+      ));
+    }
+
+    // ── Recency ──────────────────────────────────────────────────────
+    final ageMs =
+        _clock().millisecondsSinceEpoch - item.dateAdded;
+    final windowMs = _recencyWindow.inMilliseconds;
+    if (ageMs >= 0 && ageMs < windowMs) {
+      final freshness = 1.0 - (ageMs / windowMs);
+      total += _wRecency * freshness;
+      reasons.add(RecommendationReason(
+        label: 'Recently added',
+        weight: _wRecency * freshness,
+      ));
+    }
+
+    // ── Personal rating ──────────────────────────────────────────────
+    final r = item.userRating;
+    if (r != null && r > 0) {
+      final norm = (r / 5.0).clamp(0.0, 1.0);
+      total += _wRating * norm;
+      reasons.add(RecommendationReason(
+        label: 'You rated this ${r.toStringAsFixed(1)}',
+        weight: _wRating * norm,
+      ));
+    }
+
+    if (total > 1.0) total = 1.0;
+    return (score: total, reasons: reasons);
+  }
+}

--- a/lib/domain/services/taste_profile_builder.dart
+++ b/lib/domain/services/taste_profile_builder.dart
@@ -1,0 +1,69 @@
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/taste_profile.dart';
+
+/// Builds a [TasteProfile] from the user's owned items. Pure function —
+/// no I/O. Caller is responsible for filtering to the right slice (e.g.
+/// `ownership_status='owned'` and `deleted=0`).
+class TasteProfileBuilder {
+  const TasteProfileBuilder({double lovedRatingThreshold = 4.0})
+      : _lovedThreshold = lovedRatingThreshold;
+
+  final double _lovedThreshold;
+
+  TasteProfile build(List<MediaItem> items) {
+    if (items.isEmpty) return TasteProfile.empty;
+
+    final genreCounts = <String, int>{};
+    final tagCounts = <String, int>{};
+    final seriesItemCounts = <String, int>{};
+    var ratedCount = 0;
+    var ratingSum = 0.0;
+    var lovedItemCount = 0;
+
+    for (final item in items) {
+      final r = item.userRating;
+      if (r != null && r > 0) {
+        ratedCount++;
+        ratingSum += r;
+        if (r >= _lovedThreshold) {
+          lovedItemCount++;
+          for (final g in item.genres) {
+            genreCounts.update(g, (v) => v + 1, ifAbsent: () => 1);
+          }
+          final tags = item.extraMetadata['tags'];
+          if (tags is List) {
+            for (final t in tags) {
+              if (t is String) {
+                tagCounts.update(t, (v) => v + 1, ifAbsent: () => 1);
+              }
+            }
+          }
+        }
+      }
+
+      final sid = item.seriesId;
+      if (sid != null) {
+        seriesItemCounts.update(sid, (v) => v + 1, ifAbsent: () => 1);
+      }
+    }
+
+    Map<String, double> normalise(Map<String, int> counts) {
+      if (counts.isEmpty || lovedItemCount == 0) return const {};
+      return {
+        for (final e in counts.entries)
+          e.key: e.value / lovedItemCount,
+      };
+    }
+
+    return TasteProfile(
+      lovedGenres: normalise(genreCounts),
+      lovedTags: normalise(tagCounts),
+      collectedSeriesIds: {
+        for (final e in seriesItemCounts.entries)
+          if (e.value >= 2) e.key,
+      },
+      averageRating: ratedCount > 0 ? ratingSum / ratedCount : null,
+      totalRatedItems: ratedCount,
+    );
+  }
+}

--- a/lib/domain/usecases/recommend_next_usecase.dart
+++ b/lib/domain/usecases/recommend_next_usecase.dart
@@ -1,0 +1,57 @@
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/entities/recommendation.dart';
+import 'package:mymediascanner/domain/services/recommendation_scorer.dart';
+import 'package:mymediascanner/domain/services/taste_profile_builder.dart';
+
+/// Ranks items the user already owns but has not consumed, suggesting
+/// "what to read/watch next" with explainable reasons.
+///
+/// Inputs the full owned slice; filters out:
+///   * items currently in progress (`startedAt != null && completedAt == null`)
+///   * items already consumed (`consumed == true`)
+///   * items the user has marked with userRating <= 1 (won't suggest dislikes)
+///
+/// The taste profile is built from the same owned slice, so the scorer
+/// is calibrated against the user's actual collection.
+class RecommendNextUseCase {
+  const RecommendNextUseCase({
+    RecommendationScorer? scorer,
+    TasteProfileBuilder? profileBuilder,
+  })  : _scorer = scorer ?? const RecommendationScorer(),
+        _profileBuilder = profileBuilder ?? const TasteProfileBuilder();
+
+  final RecommendationScorer _scorer;
+  final TasteProfileBuilder _profileBuilder;
+
+  /// Returns up to [limit] recommendations ordered by descending score.
+  List<Recommendation> rank(List<MediaItem> ownedItems, {int limit = 5}) {
+    if (ownedItems.isEmpty) return const [];
+
+    final profile = _profileBuilder.build(ownedItems);
+
+    final candidates = ownedItems.where((item) {
+      if (item.deleted) return false;
+      if (item.ownershipStatus != OwnershipStatus.owned) return false;
+      if (item.consumed) return false;
+      if (item.startedAt != null && item.completedAt == null) return false;
+      if (item.userRating != null && item.userRating! <= 1) return false;
+      return true;
+    });
+
+    final scored = <Recommendation>[];
+    for (final item in candidates) {
+      final result = _scorer.score(item, profile);
+      if (result.score <= 0) continue;
+      scored.add(Recommendation(
+        item: item,
+        score: result.score,
+        reasons: result.reasons,
+      ));
+    }
+
+    scored.sort((a, b) => b.score.compareTo(a.score));
+    if (scored.length <= limit) return scored;
+    return scored.sublist(0, limit);
+  }
+}

--- a/lib/domain/usecases/wishlist_suggestions_usecase.dart
+++ b/lib/domain/usecases/wishlist_suggestions_usecase.dart
@@ -1,0 +1,97 @@
+import 'package:mymediascanner/data/mappers/tmdb_mapper.dart';
+import 'package:mymediascanner/data/remote/api/tmdb/tmdb_api.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/recommendation.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/domain/services/recommendation_scorer.dart';
+import 'package:mymediascanner/domain/services/taste_profile_builder.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+
+/// Suggests items the user does NOT yet own, ranked against their taste
+/// profile. Uses TMDB's weekly trending list as a candidate pool, then
+/// reuses [RecommendationScorer] for ranking — keeps the scoring story
+/// consistent between owned-recommendations and wishlist-suggestions.
+class WishlistSuggestionsUseCase {
+  WishlistSuggestionsUseCase({
+    required IMediaItemRepository mediaRepository,
+    TmdbApi? tmdbApi,
+    RecommendationScorer? scorer,
+    TasteProfileBuilder? profileBuilder,
+  })  : _mediaRepo = mediaRepository,
+        _tmdb = tmdbApi,
+        _scorer = scorer ?? const RecommendationScorer(),
+        _profileBuilder = profileBuilder ?? const TasteProfileBuilder();
+
+  final IMediaItemRepository _mediaRepo;
+  final TmdbApi? _tmdb;
+  final RecommendationScorer _scorer;
+  final TasteProfileBuilder _profileBuilder;
+
+  /// Returns up to [limit] suggestions. Empty when no TMDB key is
+  /// configured or the collection is too thin to build a profile.
+  Future<List<WishlistSuggestion>> suggest({int limit = 10}) async {
+    final tmdb = _tmdb;
+    if (tmdb == null) return const [];
+
+    final ownedStream = _mediaRepo.watchByStatus(OwnershipStatus.owned);
+    final owned = await ownedStream.first;
+    if (owned.isEmpty) return const [];
+
+    final profile = _profileBuilder.build(owned);
+    final ownedTmdbIds = <String>{
+      for (final item in owned)
+        if (item.extraMetadata['tmdb_id'] != null)
+          item.extraMetadata['tmdb_id'].toString(),
+    };
+
+    // Pull both movies and TV — the scorer will sort by relevance.
+    final responses = await Future.wait([
+      tmdb.trending('movie'),
+      tmdb.trending('tv'),
+    ]);
+    final candidates = [
+      for (final r in responses) ...?r.results,
+    ];
+
+    final suggestions = <WishlistSuggestion>[];
+    for (final dto in candidates) {
+      final tmdbId = dto.id?.toString();
+      if (tmdbId == null || ownedTmdbIds.contains(tmdbId)) continue;
+      final metadata =
+          TmdbMapper.fromSearchResult(dto, 'tmdb:$tmdbId', 'TMDB');
+
+      // Build a synthetic MediaItem so we can reuse the scorer.
+      final synthetic = MediaItem(
+        id: 'suggest-$tmdbId',
+        barcode: 'tmdb:$tmdbId',
+        barcodeType: 'TMDB',
+        mediaType: metadata.mediaType ?? MediaType.unknown,
+        title: metadata.title ?? '',
+        coverUrl: metadata.coverUrl,
+        year: metadata.year,
+        genres: metadata.genres,
+        extraMetadata: metadata.extraMetadata,
+        dateAdded: DateTime.now().millisecondsSinceEpoch,
+        dateScanned: 0,
+        updatedAt: 0,
+      );
+      final result = _scorer.score(synthetic, profile);
+      if (result.score <= 0) continue;
+      suggestions.add(WishlistSuggestion(
+        externalId: 'tmdb:$tmdbId',
+        title: synthetic.title,
+        coverUrl: synthetic.coverUrl,
+        year: synthetic.year,
+        genres: synthetic.genres,
+        source: 'tmdb',
+        score: result.score,
+        reasons: result.reasons,
+      ));
+    }
+
+    suggestions.sort((a, b) => b.score.compareTo(a.score));
+    if (suggestions.length <= limit) return suggestions;
+    return suggestions.sublist(0, limit);
+  }
+}

--- a/lib/presentation/providers/recommendations_provider.dart
+++ b/lib/presentation/providers/recommendations_provider.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/core/constants/api_constants.dart';
+import 'package:mymediascanner/data/remote/api/dio_factory.dart';
+import 'package:mymediascanner/data/remote/api/tmdb/tmdb_api.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/entities/recommendation.dart';
+import 'package:mymediascanner/domain/usecases/recommend_next_usecase.dart';
+import 'package:mymediascanner/domain/usecases/wishlist_suggestions_usecase.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+
+final recommendNextUseCaseProvider = Provider<RecommendNextUseCase>((ref) {
+  return const RecommendNextUseCase();
+});
+
+/// Top-N "recommended next" items derived from the live owned-items
+/// stream. Recomputes whenever the owned set changes.
+final recommendedNextProvider =
+    StreamProvider.family<List<Recommendation>, int>((ref, limit) {
+  final repo = ref.watch(mediaItemRepositoryProvider);
+  final usecase = ref.watch(recommendNextUseCaseProvider);
+  return repo
+      .watchByStatus(OwnershipStatus.owned)
+      .map((items) => usecase.rank(items, limit: limit));
+});
+
+/// Convenience: top 5.
+final topRecommendationsProvider =
+    Provider<AsyncValue<List<Recommendation>>>((ref) {
+  return ref.watch(recommendedNextProvider(5));
+});
+
+/// Source of owned items if other widgets need them without rescoring.
+final ownedItemsProvider = StreamProvider<List<MediaItem>>((ref) {
+  return ref
+      .watch(mediaItemRepositoryProvider)
+      .watchByStatus(OwnershipStatus.owned);
+});
+
+final wishlistSuggestionsUseCaseProvider =
+    Provider<WishlistSuggestionsUseCase>((ref) {
+  final apiKeys = ref.watch(apiKeysProvider).value ?? {};
+  final tmdbKey = apiKeys['tmdb'];
+  final tmdb = tmdbKey != null
+      ? TmdbApi(DioFactory.createWithBearerToken(
+          baseUrl: ApiConstants.tmdbBaseUrl,
+          token: tmdbKey,
+        ))
+      : null;
+  return WishlistSuggestionsUseCase(
+    mediaRepository: ref.watch(mediaItemRepositoryProvider),
+    tmdbApi: tmdb,
+  );
+});
+
+final wishlistSuggestionsProvider =
+    FutureProvider<List<WishlistSuggestion>>((ref) {
+  return ref.watch(wishlistSuggestionsUseCaseProvider).suggest();
+});

--- a/lib/presentation/screens/dashboard/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard/dashboard_screen.dart
@@ -12,6 +12,7 @@ import 'package:mymediascanner/presentation/providers/progress_provider.dart';
 import 'package:mymediascanner/presentation/providers/statistics_provider.dart';
 import 'package:mymediascanner/presentation/screens/collection/widgets/media_item_card.dart';
 import 'package:mymediascanner/presentation/screens/dashboard/widgets/random_pick_tile.dart';
+import 'package:mymediascanner/presentation/screens/dashboard/widgets/recommendations_section.dart';
 import 'package:mymediascanner/presentation/widgets/gradient_button.dart';
 import 'package:mymediascanner/presentation/widgets/screen_header.dart';
 
@@ -114,6 +115,10 @@ class DashboardScreen extends ConsumerWidget {
                       orElse: () => const <MediaItem>[],
                     ),
               ),
+              const SizedBox(height: 16),
+
+              // Recommended next
+              const RecommendationsSection(),
               const SizedBox(height: 32),
 
               // Recent additions

--- a/lib/presentation/screens/dashboard/widgets/recommendations_section.dart
+++ b/lib/presentation/screens/dashboard/widgets/recommendations_section.dart
@@ -1,0 +1,121 @@
+// "Recommended next" dashboard section — picks unconsumed owned items
+// the scorer ranks highest, with reason chips per recommendation.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/domain/entities/recommendation.dart';
+import 'package:mymediascanner/presentation/providers/recommendations_provider.dart';
+
+class RecommendationsSection extends ConsumerWidget {
+  const RecommendationsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(topRecommendationsProvider);
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return async.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
+      data: (recommendations) {
+        if (recommendations.isEmpty) return const SizedBox.shrink();
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: colors.surfaceContainerHigh,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      'RECOMMENDED NEXT',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: colors.onSurfaceVariant,
+                        letterSpacing: 0.8,
+                      ),
+                    ),
+                    const Spacer(),
+                    TextButton(
+                      onPressed: () => context.go('/wishlist-suggestions'),
+                      child: const Text('Suggestions for wishlist →'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                for (final rec in recommendations)
+                  _RecommendationTile(rec: rec),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _RecommendationTile extends StatelessWidget {
+  const _RecommendationTile({required this.rec});
+
+  final Recommendation rec;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: rec.item.coverUrl != null
+          ? ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: Image.network(
+                rec.item.coverUrl!,
+                width: 36,
+                height: 54,
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) => const SizedBox(width: 36),
+              ),
+            )
+          : const Icon(Icons.movie_outlined),
+      title: Text(rec.item.title,
+          maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Wrap(
+        spacing: 4,
+        runSpacing: 4,
+        children: [
+          for (final reason in rec.reasons.take(2))
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: colors.primary.withValues(alpha: 0.12),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                reason.label,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: colors.primary,
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+        ],
+      ),
+      trailing: Text('${(rec.score * 100).round()}',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colors.onSurfaceVariant,
+          )),
+      onTap: () => context.go('/collection/item/${rec.item.id}'),
+    );
+  }
+}

--- a/lib/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen.dart
+++ b/lib/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen.dart
@@ -1,0 +1,182 @@
+// Wishlist suggestions — TMDB trending entries the user does not yet
+// own, ranked against their taste profile.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/metadata_result.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/entities/recommendation.dart';
+import 'package:mymediascanner/presentation/providers/recommendations_provider.dart';
+import 'package:mymediascanner/presentation/providers/series_provider.dart';
+import 'package:mymediascanner/presentation/widgets/screen_header.dart';
+
+class WishlistSuggestionsScreen extends ConsumerWidget {
+  const WishlistSuggestionsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(wishlistSuggestionsProvider);
+    final isDesktop = PlatformCapability.isDesktop;
+
+    return Scaffold(
+      appBar: isDesktop
+          ? null
+          : AppBar(title: const Text('Wishlist suggestions')),
+      body: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (isDesktop)
+              const ScreenHeader(
+                title: 'Wishlist suggestions',
+                subtitle:
+                    'Trending titles you do not yet own, ranked against '
+                    'the genres and series you collect.',
+              ),
+            Expanded(
+              child: async.when(
+                loading: () =>
+                    const Center(child: CircularProgressIndicator()),
+                error: (e, _) => Center(child: Text('Error: $e')),
+                data: (suggestions) {
+                  if (suggestions.isEmpty) return const _EmptyState();
+                  return ListView.separated(
+                    itemCount: suggestions.length,
+                    separatorBuilder: (_, _) => const Divider(height: 1),
+                    itemBuilder: (context, i) =>
+                        _SuggestionTile(suggestion: suggestions[i]),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.tips_and_updates_outlined,
+                size: 64, color: theme.colorScheme.outline),
+            const SizedBox(height: 12),
+            Text('No suggestions yet',
+                style: theme.textTheme.titleMedium),
+            const SizedBox(height: 4),
+            Text(
+              'Add a TMDB API key in Settings and rate a few items so the '
+              'scorer has something to learn from.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.outline,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SuggestionTile extends ConsumerWidget {
+  const _SuggestionTile({required this.suggestion});
+
+  final WishlistSuggestion suggestion;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return ListTile(
+      leading: suggestion.coverUrl != null
+          ? ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: Image.network(
+                suggestion.coverUrl!,
+                width: 48,
+                height: 72,
+                fit: BoxFit.cover,
+                errorBuilder: (_, _, _) =>
+                    const Icon(Icons.image_not_supported),
+              ),
+            )
+          : const Icon(Icons.movie_outlined),
+      title: Text(suggestion.title),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (suggestion.year != null)
+            Text('${suggestion.year}',
+                style: theme.textTheme.bodySmall),
+          const SizedBox(height: 4),
+          Wrap(
+            spacing: 4,
+            runSpacing: 4,
+            children: [
+              for (final reason in suggestion.reasons.take(3))
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 6, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: colors.primary.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  child: Text(
+                    reason.label,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                      color: colors.primary,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+      trailing: FilledButton.tonalIcon(
+        icon: const Icon(Icons.favorite_border, size: 18),
+        label: const Text('Wishlist'),
+        onPressed: () => _addToWishlist(context, ref, suggestion),
+      ),
+    );
+  }
+
+  Future<void> _addToWishlist(
+      BuildContext context, WidgetRef ref, WishlistSuggestion s) async {
+    final usecase = ref.read(saveMediaItemUseCaseProvider);
+    final metadata = MetadataResult(
+      barcode: s.externalId,
+      barcodeType: 'TMDB',
+      mediaType: MediaType.film,
+      title: s.title,
+      coverUrl: s.coverUrl,
+      year: s.year,
+      genres: s.genres,
+      sourceApis: const ['tmdb'],
+    );
+    await usecase.execute(metadata, ownershipStatus: OwnershipStatus.wishlist);
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('${s.title} added to wishlist')),
+    );
+    // Refresh suggestions so the just-added entry disappears.
+    ref.invalidate(wishlistSuggestionsProvider);
+  }
+}

--- a/lib/presentation/widgets/app_scaffold.dart
+++ b/lib/presentation/widgets/app_scaffold.dart
@@ -46,6 +46,11 @@ class AppScaffold extends StatelessWidget {
       Icons.collections_bookmark,
       'Series');
 
+  static const _wishlistSuggestionsSidebarItem = _SidebarDestination(
+      Icons.tips_and_updates_outlined,
+      Icons.tips_and_updates,
+      'Suggestions');
+
   // ── Mobile bottom nav destinations ─────────────────────────────────
   static const _mobileDestinations = [
     NavigationDestination(
@@ -103,6 +108,7 @@ class AppScaffold extends StatelessWidget {
                 showWishlist: isDesktop,
                 showLocations: isDesktop,
                 showSeries: isDesktop,
+                showSuggestions: isDesktop,
                 isExpanded: width >= AppConstants.expandedBreakpoint,
               ),
               Expanded(
@@ -145,6 +151,7 @@ class AppScaffold extends StatelessWidget {
               showWishlist: isDesktop,
               showLocations: isDesktop,
               showSeries: isDesktop,
+              showSuggestions: isDesktop,
               isExpanded: true,
             ),
           ),
@@ -228,6 +235,7 @@ class _DesktopSidebar extends StatelessWidget {
     required this.showWishlist,
     required this.showLocations,
     required this.showSeries,
+    required this.showSuggestions,
     required this.isExpanded,
   });
 
@@ -237,6 +245,7 @@ class _DesktopSidebar extends StatelessWidget {
   final bool showWishlist;
   final bool showLocations;
   final bool showSeries;
+  final bool showSuggestions;
   final bool isExpanded;
 
   @override
@@ -251,6 +260,7 @@ class _DesktopSidebar extends StatelessWidget {
       if (showWishlist) AppScaffold._wishlistSidebarItem,
       if (showLocations) AppScaffold._locationsSidebarItem,
       if (showSeries) AppScaffold._seriesSidebarItem,
+      if (showSuggestions) AppScaffold._wishlistSuggestionsSidebarItem,
     ];
 
     // Sidebar and shell branch indices are now 1:1.

--- a/test/unit/domain/services/recommendation_scorer_test.dart
+++ b/test/unit/domain/services/recommendation_scorer_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/taste_profile.dart';
+import 'package:mymediascanner/domain/services/recommendation_scorer.dart';
+
+MediaItem _item({
+  required String id,
+  List<String> genres = const [],
+  String? seriesId,
+  double? rating,
+  int dateAdded = 0,
+  Map<String, dynamic> extra = const {},
+}) =>
+    MediaItem(
+      id: id,
+      barcode: id,
+      barcodeType: 'EAN13',
+      mediaType: MediaType.film,
+      title: id,
+      genres: genres,
+      seriesId: seriesId,
+      userRating: rating,
+      extraMetadata: extra,
+      dateAdded: dateAdded,
+      dateScanned: dateAdded,
+      updatedAt: dateAdded,
+    );
+
+void main() {
+  // Fixed clock anchored well after any test dateAdded values.
+  final fixedNow = DateTime.utc(2026, 4, 15);
+  final scorer = RecommendationScorer(clock: () => fixedNow);
+
+  test('zero score with empty profile and empty item', () {
+    final result = scorer.score(_item(id: '1'), TasteProfile.empty);
+    expect(result.score, 0);
+    expect(result.reasons, isEmpty);
+  });
+
+  test('genre overlap contributes a reason and weight', () {
+    const profile = TasteProfile(
+      lovedGenres: {'Sci-Fi': 1.0},
+      lovedTags: {},
+      collectedSeriesIds: {},
+      averageRating: 4.5,
+      totalRatedItems: 4,
+    );
+    final item = _item(id: '1', genres: ['Sci-Fi']);
+
+    final result = scorer.score(item, profile);
+
+    expect(result.reasons.first.label, contains('Sci-Fi'));
+    expect(result.score, closeTo(0.45, 0.001));
+  });
+
+  test('series collecting adds full series weight', () {
+    const profile = TasteProfile(
+      lovedGenres: {},
+      lovedTags: {},
+      collectedSeriesIds: {'mcu'},
+      averageRating: null,
+      totalRatedItems: 0,
+    );
+    final item = _item(id: '1', seriesId: 'mcu');
+
+    final result = scorer.score(item, profile);
+
+    expect(result.score, closeTo(0.20, 0.001));
+    expect(result.reasons.single.label, contains('series you collect'));
+  });
+
+  test('recency decays linearly across the 90-day window', () {
+    const profile = TasteProfile.empty;
+    final fortyFiveDaysAgo =
+        fixedNow.subtract(const Duration(days: 45)).millisecondsSinceEpoch;
+    final item = _item(id: '1', dateAdded: fortyFiveDaysAgo);
+
+    final result = scorer.score(item, profile);
+    // Half-window → roughly half of 0.10 weight.
+    expect(result.score, closeTo(0.05, 0.005));
+  });
+
+  test('items older than the window get no recency boost', () {
+    const profile = TasteProfile.empty;
+    final hundredDaysAgo =
+        fixedNow.subtract(const Duration(days: 100)).millisecondsSinceEpoch;
+    final item = _item(id: '1', dateAdded: hundredDaysAgo);
+    expect(scorer.score(item, profile).score, 0);
+  });
+
+  test('user rating contributes proportionally', () {
+    const profile = TasteProfile.empty;
+    final item = _item(id: '1', rating: 4.0);
+    final result = scorer.score(item, profile);
+    expect(result.score, closeTo(0.04, 0.001));
+    expect(result.reasons.single.label, contains('4.0'));
+  });
+
+  test('total score caps at 1.0 even with all signals firing', () {
+    const profile = TasteProfile(
+      lovedGenres: {'A': 1.0, 'B': 1.0},
+      lovedTags: {'t': 1.0},
+      collectedSeriesIds: {'s'},
+      averageRating: 5,
+      totalRatedItems: 10,
+    );
+    final item = _item(
+      id: '1',
+      genres: ['A', 'B'],
+      seriesId: 's',
+      rating: 5.0,
+      dateAdded: fixedNow.millisecondsSinceEpoch,
+      extra: const {
+        'tags': ['t']
+      },
+    );
+    final result = scorer.score(item, profile);
+    expect(result.score, lessThanOrEqualTo(1.0));
+    expect(result.reasons.length, greaterThanOrEqualTo(4));
+  });
+}

--- a/test/unit/domain/services/taste_profile_builder_test.dart
+++ b/test/unit/domain/services/taste_profile_builder_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/services/taste_profile_builder.dart';
+
+MediaItem _item({
+  required String id,
+  double? rating,
+  List<String> genres = const [],
+  String? seriesId,
+  Map<String, dynamic> extra = const {},
+}) =>
+    MediaItem(
+      id: id,
+      barcode: id,
+      barcodeType: 'EAN13',
+      mediaType: MediaType.film,
+      title: id,
+      genres: genres,
+      userRating: rating,
+      seriesId: seriesId,
+      extraMetadata: extra,
+      dateAdded: 0,
+      dateScanned: 0,
+      updatedAt: 0,
+    );
+
+void main() {
+  const builder = TasteProfileBuilder();
+
+  test('empty list yields empty profile', () {
+    expect(builder.build([]).averageRating, isNull);
+    expect(builder.build([]).lovedGenres, isEmpty);
+  });
+
+  test('only items rated >= 4.0 contribute to lovedGenres', () {
+    final profile = builder.build([
+      _item(id: '1', rating: 5.0, genres: ['Sci-Fi']),
+      _item(id: '2', rating: 3.0, genres: ['Romance']),
+      _item(id: '3', rating: 4.5, genres: ['Sci-Fi', 'Action']),
+    ]);
+    expect(profile.lovedGenres.keys, unorderedEquals(['Sci-Fi', 'Action']));
+    // 2 loved items, Sci-Fi appears in both → 2/2 = 1.0
+    expect(profile.lovedGenres['Sci-Fi'], 1.0);
+    expect(profile.lovedGenres['Action'], 0.5);
+  });
+
+  test('averageRating considers every rated item', () {
+    final profile = builder.build([
+      _item(id: '1', rating: 5.0),
+      _item(id: '2', rating: 3.0),
+      _item(id: '3', rating: 4.0),
+    ]);
+    expect(profile.averageRating, closeTo(4.0, 0.001));
+    expect(profile.totalRatedItems, 3);
+  });
+
+  test('series with >= 2 owned items become collectedSeriesIds', () {
+    final profile = builder.build([
+      _item(id: '1', seriesId: 'mcu'),
+      _item(id: '2', seriesId: 'mcu'),
+      _item(id: '3', seriesId: 'singleton'),
+    ]);
+    expect(profile.collectedSeriesIds, {'mcu'});
+  });
+
+  test('tag counts from extraMetadata only count loved items', () {
+    final profile = builder.build([
+      _item(
+        id: '1',
+        rating: 5.0,
+        extra: {
+          'tags': ['noir', 'gritty']
+        },
+      ),
+      _item(
+        id: '2',
+        rating: 2.0,
+        extra: {
+          'tags': ['romcom']
+        },
+      ),
+    ]);
+    expect(profile.lovedTags.keys, unorderedEquals(['noir', 'gritty']));
+  });
+}

--- a/test/unit/domain/usecases/recommend_next_usecase_test.dart
+++ b/test/unit/domain/usecases/recommend_next_usecase_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/services/recommendation_scorer.dart';
+import 'package:mymediascanner/domain/usecases/recommend_next_usecase.dart';
+
+MediaItem _item({
+  required String id,
+  List<String> genres = const [],
+  double? rating,
+  bool consumed = false,
+  int? startedAt,
+  int? completedAt,
+  OwnershipStatus status = OwnershipStatus.owned,
+  bool deleted = false,
+  int dateAdded = 0,
+}) =>
+    MediaItem(
+      id: id,
+      barcode: id,
+      barcodeType: 'EAN13',
+      mediaType: MediaType.film,
+      title: id,
+      genres: genres,
+      userRating: rating,
+      consumed: consumed,
+      startedAt: startedAt,
+      completedAt: completedAt,
+      ownershipStatus: status,
+      deleted: deleted,
+      dateAdded: dateAdded,
+      dateScanned: dateAdded,
+      updatedAt: dateAdded,
+    );
+
+void main() {
+  final fixedNow = DateTime.utc(2026, 4, 15);
+  final usecase = RecommendNextUseCase(
+    scorer: RecommendationScorer(clock: () => fixedNow),
+  );
+
+  test('returns empty list when collection is empty', () {
+    expect(usecase.rank([]), isEmpty);
+  });
+
+  test('excludes consumed items', () {
+    final result = usecase.rank([
+      _item(id: 'consumed', rating: 5.0, genres: ['Sci-Fi'], consumed: true),
+      _item(id: 'unread', rating: 5.0, genres: ['Sci-Fi']),
+    ]);
+    expect(result.map((r) => r.item.id), ['unread']);
+  });
+
+  test('excludes in-progress items', () {
+    final result = usecase.rank([
+      _item(
+        id: 'in-progress',
+        rating: 5.0,
+        genres: ['Sci-Fi'],
+        startedAt: 1,
+      ),
+      _item(id: 'fresh', rating: 5.0, genres: ['Sci-Fi']),
+    ]);
+    expect(result.map((r) => r.item.id), ['fresh']);
+  });
+
+  test('excludes wishlist items even if rated highly', () {
+    final result = usecase.rank([
+      _item(
+          id: 'wishlist',
+          rating: 5.0,
+          genres: ['Sci-Fi'],
+          status: OwnershipStatus.wishlist),
+      _item(id: 'owned', rating: 5.0, genres: ['Sci-Fi']),
+    ]);
+    expect(result.map((r) => r.item.id), ['owned']);
+  });
+
+  test('respects limit', () {
+    final items = [
+      for (var i = 0; i < 10; i++)
+        _item(id: '$i', rating: 5.0, genres: const ['Sci-Fi']),
+    ];
+    expect(usecase.rank(items, limit: 3), hasLength(3));
+  });
+
+  test('orders by descending score', () {
+    // Profile loves Sci-Fi (built from items rated >= 4 with that genre).
+    final items = [
+      _item(id: 'high', rating: 4.5, genres: const ['Sci-Fi']),
+      _item(id: 'mid', rating: 4.0, genres: const ['Sci-Fi', 'Romance']),
+      _item(id: 'low', genres: const ['Romance']),
+    ];
+    final result = usecase.rank(items, limit: 3);
+    expect(result.first.item.id, 'high');
+    expect(result.first.score, greaterThanOrEqualTo(result.last.score));
+  });
+}


### PR DESCRIPTION
## Summary

Implements milestone 3 issue #40 — local, explainable recommendations engine.

- **\`RecommendationScorer\`** — pure, deterministic scorer with documented weights:
  - Genre overlap (0.45) — sum of \`lovedGenres[g]\` for each candidate genre, capped at 1
  - Tag overlap (0.20) — same shape over \`lovedTags\` (reads tags from \`extraMetadata\`)
  - Series collecting (0.20) — full weight when candidate's \`seriesId\` is in \`collectedSeriesIds\`
  - Recency (0.10) — linear decay over 90 days from \`dateAdded\`
  - Personal rating (0.05) — \`userRating / 5.0\`
  Each contributing factor produces a structured \`RecommendationReason\` so the UI can show *why* a title was surfaced. Total caps at 1.0.
- **\`TasteProfileBuilder\`** — derives the profile from owned items only. \`lovedGenres\`/\`lovedTags\` count items rated >= 4.0; \`collectedSeriesIds\` requires >= 2 owned items in a series. Empty-input safe.
- **\`RecommendNextUseCase\`** — filters out completed, in-progress, deleted, wishlist, and disliked items (rating <= 1) before scoring; orders by descending score; respects a \`limit\` arg (default 5).
- **\`WishlistSuggestionsUseCase\`** — pulls TMDB \`/trending/movie/week\` and \`/trending/tv/week\` (new endpoint), dedups against owned \`tmdb_id\`s, and reuses the same scorer over a synthetic \`MediaItem\` so ranking stays consistent across surfaces. No-ops without a TMDB key.

### UI

- **Dashboard "Recommended next" tile** appears below "Currently reading/watching" with the top 5 owned recommendations, each showing reason chips and a 0–100 score.
- **\`/wishlist-suggestions\`** new sidebar branch (12) with TMDB candidates and an "Add to wishlist" button that goes through the existing \`SaveMediaItemUseCase\` + \`OwnershipStatus.wishlist\`.

### Test plan

- [x] 18 new tests:
  - 7 \`RecommendationScorer\` tests (each weight, recency decay, total cap)
  - 5 \`TasteProfileBuilder\` tests (loved threshold, average, series threshold, tag extraction, empty)
  - 6 \`RecommendNextUseCase\` tests (empty, exclude consumed/in-progress/wishlist, limit, ordering)
- [x] \`flutter analyze\`: no issues
- [x] Full \`flutter test\`: 980 green (+18)
- [ ] Manual: rate a few items, confirm dashboard tile shows expected ranking; with a TMDB key set, open Suggestions, add a candidate (requires running app + TMDB key)

**Out of scope** (potential follow-ups): per-recommendation feedback ("not interested" → suppress), Google Books / MusicBrainz seed pools for wishlist, persisted "dismissed suggestions" list.

Closes #40