### PR TITLE
feat(labels): QR label printing for shelves, boxes, items (#42)

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -21,6 +21,7 @@ import 'package:mymediascanner/presentation/screens/locations/location_browser_s
 import 'package:mymediascanner/presentation/screens/series/series_list_screen.dart';
 import 'package:mymediascanner/presentation/screens/series/series_detail_screen.dart';
 import 'package:mymediascanner/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen.dart';
+import 'package:mymediascanner/presentation/screens/labels/label_print_screen.dart';
 import 'package:mymediascanner/presentation/screens/about/about_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrowers_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrower_detail_screen.dart';
@@ -222,6 +223,12 @@ final router = GoRouter(
                   parentNavigatorKey: _rootNavigatorKey,
                   pageBuilder: (context, state) =>
                       _fadeSlideTransition(state, const ImportScreen()),
+                ),
+                GoRoute(
+                  path: 'labels',
+                  parentNavigatorKey: _rootNavigatorKey,
+                  pageBuilder: (context, state) =>
+                      _fadeSlideTransition(state, const LabelPrintScreen()),
                 ),
               ],
             ),

--- a/lib/domain/entities/label_sheet_preset.dart
+++ b/lib/domain/entities/label_sheet_preset.dart
@@ -1,0 +1,86 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'label_sheet_preset.freezed.dart';
+
+/// Physical label sheet layout. All dimensions are in PostScript points
+/// (1 pt = 1/72 inch). A4 = 595.28 x 841.89 pt; US Letter = 612 x 792 pt.
+///
+/// [columns] x [rows] gives the labels per page. Margins and gutter
+/// determine how much of the sheet is usable.
+@freezed
+sealed class LabelSheetPreset with _$LabelSheetPreset {
+  const factory LabelSheetPreset({
+    required String id,
+    required String name,
+    required double pageWidthPt,
+    required double pageHeightPt,
+    required int columns,
+    required int rows,
+    required double marginLeftPt,
+    required double marginTopPt,
+    required double gutterXPt,
+    required double gutterYPt,
+  }) = _LabelSheetPreset;
+}
+
+/// Curated set of built-in presets. Custom presets can be added later.
+abstract final class LabelSheetPresets {
+  /// 3 x 8 = 24 labels on A4. Roughly matches Avery L7159 / L7160.
+  static const a4_24 = LabelSheetPreset(
+    id: 'a4-24',
+    name: 'A4 — 24 labels (3x8)',
+    pageWidthPt: 595.28,
+    pageHeightPt: 841.89,
+    columns: 3,
+    rows: 8,
+    marginLeftPt: 21.42,
+    marginTopPt: 36.85,
+    gutterXPt: 7.11,
+    gutterYPt: 0,
+  );
+
+  /// 2 x 4 = 8 larger labels on A4, ideal for box/shelf labels.
+  static const a4_8 = LabelSheetPreset(
+    id: 'a4-8',
+    name: 'A4 — 8 labels (2x4)',
+    pageWidthPt: 595.28,
+    pageHeightPt: 841.89,
+    columns: 2,
+    rows: 4,
+    marginLeftPt: 28.35,
+    marginTopPt: 42.52,
+    gutterXPt: 14.17,
+    gutterYPt: 14.17,
+  );
+
+  /// 3 x 10 = 30 labels on US Letter. Matches Avery 5160.
+  static const letter_30 = LabelSheetPreset(
+    id: 'letter-30',
+    name: 'US Letter — 30 labels (3x10, Avery 5160)',
+    pageWidthPt: 612,
+    pageHeightPt: 792,
+    columns: 3,
+    rows: 10,
+    marginLeftPt: 13.5,
+    marginTopPt: 36,
+    gutterXPt: 9,
+    gutterYPt: 0,
+  );
+
+  static const builtIn = <LabelSheetPreset>[a4_24, a4_8, letter_30];
+}
+
+/// The effective size of a single label cell within the sheet.
+extension LabelSheetPresetGeometry on LabelSheetPreset {
+  double get labelWidthPt {
+    final usable = pageWidthPt - 2 * marginLeftPt - gutterXPt * (columns - 1);
+    return usable / columns;
+  }
+
+  double get labelHeightPt {
+    final usable = pageHeightPt - 2 * marginTopPt - gutterYPt * (rows - 1);
+    return usable / rows;
+  }
+
+  int get labelsPerPage => columns * rows;
+}

--- a/lib/domain/entities/label_sheet_preset.freezed.dart
+++ b/lib/domain/entities/label_sheet_preset.freezed.dart
@@ -1,0 +1,292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'label_sheet_preset.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$LabelSheetPreset {
+
+ String get id; String get name; double get pageWidthPt; double get pageHeightPt; int get columns; int get rows; double get marginLeftPt; double get marginTopPt; double get gutterXPt; double get gutterYPt;
+/// Create a copy of LabelSheetPreset
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LabelSheetPresetCopyWith<LabelSheetPreset> get copyWith => _$LabelSheetPresetCopyWithImpl<LabelSheetPreset>(this as LabelSheetPreset, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LabelSheetPreset&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.pageWidthPt, pageWidthPt) || other.pageWidthPt == pageWidthPt)&&(identical(other.pageHeightPt, pageHeightPt) || other.pageHeightPt == pageHeightPt)&&(identical(other.columns, columns) || other.columns == columns)&&(identical(other.rows, rows) || other.rows == rows)&&(identical(other.marginLeftPt, marginLeftPt) || other.marginLeftPt == marginLeftPt)&&(identical(other.marginTopPt, marginTopPt) || other.marginTopPt == marginTopPt)&&(identical(other.gutterXPt, gutterXPt) || other.gutterXPt == gutterXPt)&&(identical(other.gutterYPt, gutterYPt) || other.gutterYPt == gutterYPt));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id,name,pageWidthPt,pageHeightPt,columns,rows,marginLeftPt,marginTopPt,gutterXPt,gutterYPt);
+
+@override
+String toString() {
+  return 'LabelSheetPreset(id: $id, name: $name, pageWidthPt: $pageWidthPt, pageHeightPt: $pageHeightPt, columns: $columns, rows: $rows, marginLeftPt: $marginLeftPt, marginTopPt: $marginTopPt, gutterXPt: $gutterXPt, gutterYPt: $gutterYPt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LabelSheetPresetCopyWith<$Res>  {
+  factory $LabelSheetPresetCopyWith(LabelSheetPreset value, $Res Function(LabelSheetPreset) _then) = _$LabelSheetPresetCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, double pageWidthPt, double pageHeightPt, int columns, int rows, double marginLeftPt, double marginTopPt, double gutterXPt, double gutterYPt
+});
+
+
+
+
+}
+/// @nodoc
+class _$LabelSheetPresetCopyWithImpl<$Res>
+    implements $LabelSheetPresetCopyWith<$Res> {
+  _$LabelSheetPresetCopyWithImpl(this._self, this._then);
+
+  final LabelSheetPreset _self;
+  final $Res Function(LabelSheetPreset) _then;
+
+/// Create a copy of LabelSheetPreset
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? pageWidthPt = null,Object? pageHeightPt = null,Object? columns = null,Object? rows = null,Object? marginLeftPt = null,Object? marginTopPt = null,Object? gutterXPt = null,Object? gutterYPt = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,pageWidthPt: null == pageWidthPt ? _self.pageWidthPt : pageWidthPt // ignore: cast_nullable_to_non_nullable
+as double,pageHeightPt: null == pageHeightPt ? _self.pageHeightPt : pageHeightPt // ignore: cast_nullable_to_non_nullable
+as double,columns: null == columns ? _self.columns : columns // ignore: cast_nullable_to_non_nullable
+as int,rows: null == rows ? _self.rows : rows // ignore: cast_nullable_to_non_nullable
+as int,marginLeftPt: null == marginLeftPt ? _self.marginLeftPt : marginLeftPt // ignore: cast_nullable_to_non_nullable
+as double,marginTopPt: null == marginTopPt ? _self.marginTopPt : marginTopPt // ignore: cast_nullable_to_non_nullable
+as double,gutterXPt: null == gutterXPt ? _self.gutterXPt : gutterXPt // ignore: cast_nullable_to_non_nullable
+as double,gutterYPt: null == gutterYPt ? _self.gutterYPt : gutterYPt // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [LabelSheetPreset].
+extension LabelSheetPresetPatterns on LabelSheetPreset {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _LabelSheetPreset value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _LabelSheetPreset() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _LabelSheetPreset value)  $default,){
+final _that = this;
+switch (_that) {
+case _LabelSheetPreset():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _LabelSheetPreset value)?  $default,){
+final _that = this;
+switch (_that) {
+case _LabelSheetPreset() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  double pageWidthPt,  double pageHeightPt,  int columns,  int rows,  double marginLeftPt,  double marginTopPt,  double gutterXPt,  double gutterYPt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _LabelSheetPreset() when $default != null:
+return $default(_that.id,_that.name,_that.pageWidthPt,_that.pageHeightPt,_that.columns,_that.rows,_that.marginLeftPt,_that.marginTopPt,_that.gutterXPt,_that.gutterYPt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  double pageWidthPt,  double pageHeightPt,  int columns,  int rows,  double marginLeftPt,  double marginTopPt,  double gutterXPt,  double gutterYPt)  $default,) {final _that = this;
+switch (_that) {
+case _LabelSheetPreset():
+return $default(_that.id,_that.name,_that.pageWidthPt,_that.pageHeightPt,_that.columns,_that.rows,_that.marginLeftPt,_that.marginTopPt,_that.gutterXPt,_that.gutterYPt);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  double pageWidthPt,  double pageHeightPt,  int columns,  int rows,  double marginLeftPt,  double marginTopPt,  double gutterXPt,  double gutterYPt)?  $default,) {final _that = this;
+switch (_that) {
+case _LabelSheetPreset() when $default != null:
+return $default(_that.id,_that.name,_that.pageWidthPt,_that.pageHeightPt,_that.columns,_that.rows,_that.marginLeftPt,_that.marginTopPt,_that.gutterXPt,_that.gutterYPt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _LabelSheetPreset implements LabelSheetPreset {
+  const _LabelSheetPreset({required this.id, required this.name, required this.pageWidthPt, required this.pageHeightPt, required this.columns, required this.rows, required this.marginLeftPt, required this.marginTopPt, required this.gutterXPt, required this.gutterYPt});
+  
+
+@override final  String id;
+@override final  String name;
+@override final  double pageWidthPt;
+@override final  double pageHeightPt;
+@override final  int columns;
+@override final  int rows;
+@override final  double marginLeftPt;
+@override final  double marginTopPt;
+@override final  double gutterXPt;
+@override final  double gutterYPt;
+
+/// Create a copy of LabelSheetPreset
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LabelSheetPresetCopyWith<_LabelSheetPreset> get copyWith => __$LabelSheetPresetCopyWithImpl<_LabelSheetPreset>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LabelSheetPreset&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.pageWidthPt, pageWidthPt) || other.pageWidthPt == pageWidthPt)&&(identical(other.pageHeightPt, pageHeightPt) || other.pageHeightPt == pageHeightPt)&&(identical(other.columns, columns) || other.columns == columns)&&(identical(other.rows, rows) || other.rows == rows)&&(identical(other.marginLeftPt, marginLeftPt) || other.marginLeftPt == marginLeftPt)&&(identical(other.marginTopPt, marginTopPt) || other.marginTopPt == marginTopPt)&&(identical(other.gutterXPt, gutterXPt) || other.gutterXPt == gutterXPt)&&(identical(other.gutterYPt, gutterYPt) || other.gutterYPt == gutterYPt));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,id,name,pageWidthPt,pageHeightPt,columns,rows,marginLeftPt,marginTopPt,gutterXPt,gutterYPt);
+
+@override
+String toString() {
+  return 'LabelSheetPreset(id: $id, name: $name, pageWidthPt: $pageWidthPt, pageHeightPt: $pageHeightPt, columns: $columns, rows: $rows, marginLeftPt: $marginLeftPt, marginTopPt: $marginTopPt, gutterXPt: $gutterXPt, gutterYPt: $gutterYPt)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LabelSheetPresetCopyWith<$Res> implements $LabelSheetPresetCopyWith<$Res> {
+  factory _$LabelSheetPresetCopyWith(_LabelSheetPreset value, $Res Function(_LabelSheetPreset) _then) = __$LabelSheetPresetCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, double pageWidthPt, double pageHeightPt, int columns, int rows, double marginLeftPt, double marginTopPt, double gutterXPt, double gutterYPt
+});
+
+
+
+
+}
+/// @nodoc
+class __$LabelSheetPresetCopyWithImpl<$Res>
+    implements _$LabelSheetPresetCopyWith<$Res> {
+  __$LabelSheetPresetCopyWithImpl(this._self, this._then);
+
+  final _LabelSheetPreset _self;
+  final $Res Function(_LabelSheetPreset) _then;
+
+/// Create a copy of LabelSheetPreset
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? pageWidthPt = null,Object? pageHeightPt = null,Object? columns = null,Object? rows = null,Object? marginLeftPt = null,Object? marginTopPt = null,Object? gutterXPt = null,Object? gutterYPt = null,}) {
+  return _then(_LabelSheetPreset(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,pageWidthPt: null == pageWidthPt ? _self.pageWidthPt : pageWidthPt // ignore: cast_nullable_to_non_nullable
+as double,pageHeightPt: null == pageHeightPt ? _self.pageHeightPt : pageHeightPt // ignore: cast_nullable_to_non_nullable
+as double,columns: null == columns ? _self.columns : columns // ignore: cast_nullable_to_non_nullable
+as int,rows: null == rows ? _self.rows : rows // ignore: cast_nullable_to_non_nullable
+as int,marginLeftPt: null == marginLeftPt ? _self.marginLeftPt : marginLeftPt // ignore: cast_nullable_to_non_nullable
+as double,marginTopPt: null == marginTopPt ? _self.marginTopPt : marginTopPt // ignore: cast_nullable_to_non_nullable
+as double,gutterXPt: null == gutterXPt ? _self.gutterXPt : gutterXPt // ignore: cast_nullable_to_non_nullable
+as double,gutterYPt: null == gutterYPt ? _self.gutterYPt : gutterYPt // ignore: cast_nullable_to_non_nullable
+as double,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/domain/entities/label_target.dart
+++ b/lib/domain/entities/label_target.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'label_target.freezed.dart';
+
+/// A single label to be printed. The [qrPayload] is the stable identifier
+/// encoded in the QR code (e.g. `item:abc-123` or `location:xyz-456`) and
+/// is distinct from the human-readable [title] / [subtitle].
+@freezed
+sealed class LabelTarget with _$LabelTarget {
+  const factory LabelTarget({
+    required String qrPayload,
+    required String title,
+    String? subtitle,
+  }) = _LabelTarget;
+
+  /// Canonical QR payload for a media item: `item:<uuid>`.
+  static String itemPayload(String id) => 'item:$id';
+
+  /// Canonical QR payload for a location: `location:<uuid>`.
+  static String locationPayload(String id) => 'location:$id';
+}

--- a/lib/domain/entities/label_target.freezed.dart
+++ b/lib/domain/entities/label_target.freezed.dart
@@ -1,0 +1,271 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'label_target.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$LabelTarget {
+
+ String get qrPayload; String get title; String? get subtitle;
+/// Create a copy of LabelTarget
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$LabelTargetCopyWith<LabelTarget> get copyWith => _$LabelTargetCopyWithImpl<LabelTarget>(this as LabelTarget, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is LabelTarget&&(identical(other.qrPayload, qrPayload) || other.qrPayload == qrPayload)&&(identical(other.title, title) || other.title == title)&&(identical(other.subtitle, subtitle) || other.subtitle == subtitle));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,qrPayload,title,subtitle);
+
+@override
+String toString() {
+  return 'LabelTarget(qrPayload: $qrPayload, title: $title, subtitle: $subtitle)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $LabelTargetCopyWith<$Res>  {
+  factory $LabelTargetCopyWith(LabelTarget value, $Res Function(LabelTarget) _then) = _$LabelTargetCopyWithImpl;
+@useResult
+$Res call({
+ String qrPayload, String title, String? subtitle
+});
+
+
+
+
+}
+/// @nodoc
+class _$LabelTargetCopyWithImpl<$Res>
+    implements $LabelTargetCopyWith<$Res> {
+  _$LabelTargetCopyWithImpl(this._self, this._then);
+
+  final LabelTarget _self;
+  final $Res Function(LabelTarget) _then;
+
+/// Create a copy of LabelTarget
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? qrPayload = null,Object? title = null,Object? subtitle = freezed,}) {
+  return _then(_self.copyWith(
+qrPayload: null == qrPayload ? _self.qrPayload : qrPayload // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,subtitle: freezed == subtitle ? _self.subtitle : subtitle // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [LabelTarget].
+extension LabelTargetPatterns on LabelTarget {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _LabelTarget value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _LabelTarget() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _LabelTarget value)  $default,){
+final _that = this;
+switch (_that) {
+case _LabelTarget():
+return $default(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _LabelTarget value)?  $default,){
+final _that = this;
+switch (_that) {
+case _LabelTarget() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String qrPayload,  String title,  String? subtitle)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _LabelTarget() when $default != null:
+return $default(_that.qrPayload,_that.title,_that.subtitle);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String qrPayload,  String title,  String? subtitle)  $default,) {final _that = this;
+switch (_that) {
+case _LabelTarget():
+return $default(_that.qrPayload,_that.title,_that.subtitle);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String qrPayload,  String title,  String? subtitle)?  $default,) {final _that = this;
+switch (_that) {
+case _LabelTarget() when $default != null:
+return $default(_that.qrPayload,_that.title,_that.subtitle);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _LabelTarget implements LabelTarget {
+  const _LabelTarget({required this.qrPayload, required this.title, this.subtitle});
+  
+
+@override final  String qrPayload;
+@override final  String title;
+@override final  String? subtitle;
+
+/// Create a copy of LabelTarget
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$LabelTargetCopyWith<_LabelTarget> get copyWith => __$LabelTargetCopyWithImpl<_LabelTarget>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _LabelTarget&&(identical(other.qrPayload, qrPayload) || other.qrPayload == qrPayload)&&(identical(other.title, title) || other.title == title)&&(identical(other.subtitle, subtitle) || other.subtitle == subtitle));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,qrPayload,title,subtitle);
+
+@override
+String toString() {
+  return 'LabelTarget(qrPayload: $qrPayload, title: $title, subtitle: $subtitle)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$LabelTargetCopyWith<$Res> implements $LabelTargetCopyWith<$Res> {
+  factory _$LabelTargetCopyWith(_LabelTarget value, $Res Function(_LabelTarget) _then) = __$LabelTargetCopyWithImpl;
+@override @useResult
+$Res call({
+ String qrPayload, String title, String? subtitle
+});
+
+
+
+
+}
+/// @nodoc
+class __$LabelTargetCopyWithImpl<$Res>
+    implements _$LabelTargetCopyWith<$Res> {
+  __$LabelTargetCopyWithImpl(this._self, this._then);
+
+  final _LabelTarget _self;
+  final $Res Function(_LabelTarget) _then;
+
+/// Create a copy of LabelTarget
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? qrPayload = null,Object? title = null,Object? subtitle = freezed,}) {
+  return _then(_LabelTarget(
+qrPayload: null == qrPayload ? _self.qrPayload : qrPayload // ignore: cast_nullable_to_non_nullable
+as String,title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,subtitle: freezed == subtitle ? _self.subtitle : subtitle // ignore: cast_nullable_to_non_nullable
+as String?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/domain/services/label_pdf_generator.dart
+++ b/lib/domain/services/label_pdf_generator.dart
@@ -1,0 +1,154 @@
+import 'dart:typed_data';
+
+import 'package:mymediascanner/domain/entities/label_sheet_preset.dart';
+import 'package:mymediascanner/domain/entities/label_target.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+/// Renders a list of [LabelTarget]s onto one or more pages using the
+/// grid defined by a [LabelSheetPreset]. Each label carries a QR of the
+/// target's [LabelTarget.qrPayload] and its human-readable title.
+///
+/// Pure: no I/O, no Flutter dependencies. Returns the rendered PDF as a
+/// [Uint8List]; callers are responsible for previewing, saving, or
+/// sharing the bytes.
+class LabelPdfGenerator {
+  const LabelPdfGenerator();
+
+  /// Returns a PDF with [targets] laid out under [preset]. An empty
+  /// [targets] still produces a valid single blank page.
+  Future<Uint8List> generate({
+    required List<LabelTarget> targets,
+    required LabelSheetPreset preset,
+  }) async {
+    final doc = pw.Document();
+    final perPage = preset.labelsPerPage;
+    final pageSize = PdfPageFormat(preset.pageWidthPt, preset.pageHeightPt);
+
+    // Pre-compute the grid cell geometry once.
+    final cellW = preset.labelWidthPt;
+    final cellH = preset.labelHeightPt;
+
+    // Chunk targets into pages.
+    final totalPages = targets.isEmpty
+        ? 1
+        : (targets.length + perPage - 1) ~/ perPage;
+
+    for (var page = 0; page < totalPages; page++) {
+      final start = page * perPage;
+      final end = (start + perPage).clamp(0, targets.length);
+      final pageTargets = targets.sublist(start, end);
+
+      doc.addPage(pw.Page(
+        pageFormat: pageSize,
+        build: (context) => pw.Stack(
+          children: [
+            for (var i = 0; i < pageTargets.length; i++)
+              _positionCell(
+                preset: preset,
+                index: i,
+                cellW: cellW,
+                cellH: cellH,
+                child: _LabelCell(target: pageTargets[i]),
+              ),
+          ],
+        ),
+      ));
+    }
+
+    return doc.save();
+  }
+
+  pw.Widget _positionCell({
+    required LabelSheetPreset preset,
+    required int index,
+    required double cellW,
+    required double cellH,
+    required pw.Widget child,
+  }) {
+    final col = index % preset.columns;
+    final row = index ~/ preset.columns;
+    final x = preset.marginLeftPt + col * (cellW + preset.gutterXPt);
+    final y = preset.marginTopPt + row * (cellH + preset.gutterYPt);
+
+    return pw.Positioned(
+      left: x,
+      top: y,
+      child: pw.SizedBox(
+        width: cellW,
+        height: cellH,
+        child: child,
+      ),
+    );
+  }
+}
+
+class _LabelCell extends pw.StatelessWidget {
+  _LabelCell({required this.target});
+
+  final LabelTarget target;
+
+  @override
+  pw.Widget build(pw.Context context) {
+    return pw.Container(
+      padding: const pw.EdgeInsets.all(6),
+      decoration: pw.BoxDecoration(
+        border: pw.Border.all(width: 0.25, color: PdfColors.grey400),
+      ),
+      child: pw.Row(
+        crossAxisAlignment: pw.CrossAxisAlignment.center,
+        children: [
+          pw.SizedBox(
+            width: 56,
+            height: 56,
+            child: pw.BarcodeWidget(
+              barcode: pw.Barcode.qrCode(),
+              data: target.qrPayload,
+              drawText: false,
+            ),
+          ),
+          pw.SizedBox(width: 8),
+          pw.Expanded(
+            child: pw.Column(
+              crossAxisAlignment: pw.CrossAxisAlignment.start,
+              mainAxisAlignment: pw.MainAxisAlignment.center,
+              children: [
+                pw.Text(
+                  target.title,
+                  style: pw.TextStyle(
+                    fontSize: 10,
+                    fontWeight: pw.FontWeight.bold,
+                  ),
+                  maxLines: 2,
+                  overflow: pw.TextOverflow.clip,
+                ),
+                if (target.subtitle != null) ...[
+                  pw.SizedBox(height: 2),
+                  pw.Text(
+                    target.subtitle!,
+                    style: const pw.TextStyle(
+                      fontSize: 8,
+                      color: PdfColors.grey700,
+                    ),
+                    maxLines: 2,
+                    overflow: pw.TextOverflow.clip,
+                  ),
+                ],
+                pw.SizedBox(height: 3),
+                pw.Text(
+                  target.qrPayload,
+                  style: const pw.TextStyle(
+                    fontSize: 6,
+                    color: PdfColors.grey500,
+                  ),
+                  maxLines: 1,
+                  overflow: pw.TextOverflow.clip,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/labels/label_print_screen.dart
+++ b/lib/presentation/screens/labels/label_print_screen.dart
@@ -1,0 +1,260 @@
+// Label printing — batch-select media items or locations, pick a sheet
+// preset, preview and export the generated PDF.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/domain/entities/label_sheet_preset.dart';
+import 'package:mymediascanner/domain/entities/label_target.dart';
+import 'package:mymediascanner/domain/entities/location.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/services/label_pdf_generator.dart';
+import 'package:mymediascanner/presentation/providers/location_provider.dart';
+import 'package:mymediascanner/presentation/providers/recommendations_provider.dart';
+import 'package:mymediascanner/presentation/widgets/screen_header.dart';
+import 'package:printing/printing.dart';
+
+enum _LabelSource { items, locations }
+
+class LabelPrintScreen extends ConsumerStatefulWidget {
+  const LabelPrintScreen({super.key});
+
+  @override
+  ConsumerState<LabelPrintScreen> createState() => _LabelPrintScreenState();
+}
+
+class _LabelPrintScreenState extends ConsumerState<LabelPrintScreen> {
+  _LabelSource _source = _LabelSource.locations;
+  LabelSheetPreset _preset = LabelSheetPresets.a4_24;
+  final Set<String> _selectedIds = {};
+
+  @override
+  Widget build(BuildContext context) {
+    final isDesktop = PlatformCapability.isDesktop;
+    return Scaffold(
+      appBar:
+          isDesktop ? null : AppBar(title: const Text('Print labels')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (isDesktop)
+              const ScreenHeader(
+                title: 'Print labels',
+                subtitle:
+                    'Generate a printable sheet of QR labels for your '
+                    'locations or items.',
+              ),
+            _Toolbar(
+              source: _source,
+              preset: _preset,
+              onSourceChanged: (s) => setState(() {
+                _source = s;
+                _selectedIds.clear();
+              }),
+              onPresetChanged: (p) => setState(() => _preset = p),
+              selectedCount: _selectedIds.length,
+              onPreview: _selectedIds.isEmpty ? null : _preview,
+            ),
+            const SizedBox(height: 12),
+            Expanded(child: _source == _LabelSource.locations
+                ? _LocationSelector(
+                    selected: _selectedIds,
+                    onToggle: _toggle,
+                  )
+                : _ItemSelector(
+                    selected: _selectedIds,
+                    onToggle: _toggle,
+                  )),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _toggle(String id, bool on) {
+    setState(() {
+      if (on) {
+        _selectedIds.add(id);
+      } else {
+        _selectedIds.remove(id);
+      }
+    });
+  }
+
+  Future<void> _preview() async {
+    final targets = <LabelTarget>[];
+    if (_source == _LabelSource.locations) {
+      final all = ref.read(allLocationsProvider).value ?? const <Location>[];
+      for (final l in all) {
+        if (_selectedIds.contains(l.id)) {
+          targets.add(LabelTarget(
+            qrPayload: LabelTarget.locationPayload(l.id),
+            title: l.name,
+            subtitle: 'Location',
+          ));
+        }
+      }
+    } else {
+      final all = ref.read(ownedItemsProvider).value ?? const <MediaItem>[];
+      for (final item in all) {
+        if (_selectedIds.contains(item.id)) {
+          targets.add(LabelTarget(
+            qrPayload: LabelTarget.itemPayload(item.id),
+            title: item.title,
+            subtitle: item.publisher ?? item.format,
+          ));
+        }
+      }
+    }
+
+    const generator = LabelPdfGenerator();
+    final bytes = await generator.generate(
+      targets: targets,
+      preset: _preset,
+    );
+    if (!mounted) return;
+    await Printing.layoutPdf(
+      onLayout: (_) async => bytes,
+      name: 'mymediascanner-labels',
+    );
+  }
+}
+
+class _Toolbar extends StatelessWidget {
+  const _Toolbar({
+    required this.source,
+    required this.preset,
+    required this.onSourceChanged,
+    required this.onPresetChanged,
+    required this.selectedCount,
+    required this.onPreview,
+  });
+
+  final _LabelSource source;
+  final LabelSheetPreset preset;
+  final ValueChanged<_LabelSource> onSourceChanged;
+  final ValueChanged<LabelSheetPreset> onPresetChanged;
+  final int selectedCount;
+  final VoidCallback? onPreview;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12,
+      runSpacing: 12,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        SegmentedButton<_LabelSource>(
+          segments: const [
+            ButtonSegment(
+              value: _LabelSource.locations,
+              icon: Icon(Icons.place_outlined),
+              label: Text('Locations'),
+            ),
+            ButtonSegment(
+              value: _LabelSource.items,
+              icon: Icon(Icons.library_music_outlined),
+              label: Text('Items'),
+            ),
+          ],
+          selected: {source},
+          showSelectedIcon: false,
+          onSelectionChanged: (s) => onSourceChanged(s.first),
+        ),
+        DropdownButton<LabelSheetPreset>(
+          value: preset,
+          items: [
+            for (final p in LabelSheetPresets.builtIn)
+              DropdownMenuItem(value: p, child: Text(p.name)),
+          ],
+          onChanged: (p) {
+            if (p != null) onPresetChanged(p);
+          },
+        ),
+        Text('$selectedCount selected'),
+        FilledButton.icon(
+          icon: const Icon(Icons.picture_as_pdf_outlined),
+          label: const Text('Preview / print'),
+          onPressed: onPreview,
+        ),
+      ],
+    );
+  }
+}
+
+class _LocationSelector extends ConsumerWidget {
+  const _LocationSelector({required this.selected, required this.onToggle});
+
+  final Set<String> selected;
+  final void Function(String id, bool on) onToggle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(allLocationsProvider);
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Error: $e')),
+      data: (locations) {
+        if (locations.isEmpty) {
+          return const Center(child: Text('No locations defined yet.'));
+        }
+        return ListView.separated(
+          itemCount: locations.length,
+          separatorBuilder: (_, _) => const Divider(height: 1),
+          itemBuilder: (context, i) {
+            final l = locations[i];
+            final isSelected = selected.contains(l.id);
+            return CheckboxListTile(
+              value: isSelected,
+              title: Text(l.name),
+              subtitle: Text(LabelTarget.locationPayload(l.id)),
+              onChanged: (v) => onToggle(l.id, v ?? false),
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _ItemSelector extends ConsumerWidget {
+  const _ItemSelector({required this.selected, required this.onToggle});
+
+  final Set<String> selected;
+  final void Function(String id, bool on) onToggle;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(ownedItemsProvider);
+    return async.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(child: Text('Error: $e')),
+      data: (items) {
+        if (items.isEmpty) {
+          return const Center(
+              child: Text('No owned items in the collection.'));
+        }
+        return ListView.separated(
+          itemCount: items.length,
+          separatorBuilder: (_, _) => const Divider(height: 1),
+          itemBuilder: (context, i) {
+            final item = items[i];
+            final isSelected = selected.contains(item.id);
+            return CheckboxListTile(
+              value: isSelected,
+              title: Text(item.title, maxLines: 1,
+                  overflow: TextOverflow.ellipsis),
+              subtitle: Text(LabelTarget.itemPayload(item.id)),
+              onChanged: (v) => onToggle(item.id, v ?? false),
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -88,6 +88,24 @@ class SettingsScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 16),
 
+          // Printing section — QR labels for shelves, boxes, items
+          _SectionCard(
+            title: 'Printing',
+            colors: colors,
+            theme: theme,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.print_outlined),
+                title: const Text('Print labels'),
+                subtitle: const Text(
+                    'QR labels for locations or items, preview and export as PDF'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => context.go('/settings/labels'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+
           // FLAC Library section (desktop only)
           if (isDesktop) ...[
             _SectionCard(

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <camera_desktop/camera_desktop_plugin.h>
 #include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
+#include <printing/printing_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
@@ -23,6 +24,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
+  g_autoptr(FlPluginRegistrar) printing_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "PrintingPlugin");
+  printing_plugin_register_with_registrar(printing_registrar);
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   camera_desktop
   file_selector_linux
   flutter_secure_storage_linux
+  printing
   screen_retriever_linux
   url_launcher_linux
   window_manager

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import flutter_secure_storage_darwin
 import just_audio
 import mobile_scanner
 import package_info_plus
+import printing
 import screen_retriever_macos
 import shared_preferences_foundation
 import sqflite_darwin
@@ -30,6 +31,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.25"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      sha256: "7b6729c37e3b7f34233e2318d866e8c48ddb46c1f7ad01ff7bb2a8de1da2b9f4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.9"
+  bidi:
+    dependency: transitive
+    description:
+      name: bidi
+      sha256: "77f475165e94b261745cf1032c751e2032b8ed92ccb2bf5716036db79320637d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.13"
   boolean_selector:
     dependency: transitive
     description:
@@ -1127,6 +1143,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: "direct main"
     description:
@@ -1175,6 +1199,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  pdf:
+    dependency: "direct main"
+    description:
+      name: pdf
+      sha256: e47a275b267873d5944ad5f5ff0dcc7ac2e36c02b3046a0ffac9b72fd362c44b
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.12.0"
+  pdf_widget_wrapper:
+    dependency: transitive
+    description:
+      name: pdf_widget_wrapper
+      sha256: c930860d987213a3d58c7ec3b7ecf8085c3897f773e8dc23da9cae60a5d6d0f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -1223,6 +1263,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.5.9"
+  printing:
+    dependency: "direct main"
+    description:
+      name: printing
+      sha256: "689170c9ddb1bda85826466ba80378aa8993486d3c959a71cd7d2d80cb606692"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.14.3"
   process:
     dependency: transitive
     description:
@@ -1255,6 +1303,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      sha256: "5a1d2586170e172b8a8c8470bbbffd5eb0cd38a66c0d77155ea138d3af3a4445"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   recase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,8 @@ dependencies:
   dart_rip_log: ^0.0.1
   dart_cue: ^0.0.1
   csv: ^6.0.0
+  pdf: ^3.11.0
+  printing: ^5.14.0
 
 dev_dependencies:
   flutter_test:

--- a/test/unit/domain/services/label_pdf_generator_test.dart
+++ b/test/unit/domain/services/label_pdf_generator_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/domain/entities/label_sheet_preset.dart';
+import 'package:mymediascanner/domain/entities/label_target.dart';
+import 'package:mymediascanner/domain/services/label_pdf_generator.dart';
+
+void main() {
+  const generator = LabelPdfGenerator();
+
+  test('a4_24 preset reports 24 labels per page', () {
+    expect(LabelSheetPresets.a4_24.labelsPerPage, 24);
+  });
+
+  test('a4_24 cell width splits the usable area equally across columns', () {
+    const preset = LabelSheetPresets.a4_24;
+    final total = preset.labelWidthPt * preset.columns +
+        preset.gutterXPt * (preset.columns - 1) +
+        preset.marginLeftPt * 2;
+    // Should recover the page width within rounding.
+    expect(total, closeTo(preset.pageWidthPt, 0.01));
+  });
+
+  test('letter_30 cell height splits usable area across rows', () {
+    const preset = LabelSheetPresets.letter_30;
+    final total = preset.labelHeightPt * preset.rows +
+        preset.gutterYPt * (preset.rows - 1) +
+        preset.marginTopPt * 2;
+    expect(total, closeTo(preset.pageHeightPt, 0.01));
+  });
+
+  test('labelPayload helpers produce canonical prefixes', () {
+    expect(LabelTarget.itemPayload('abc'), 'item:abc');
+    expect(LabelTarget.locationPayload('xyz'), 'location:xyz');
+  });
+
+  test('empty target list still produces a valid single-page PDF',
+      () async {
+    final bytes = await generator.generate(
+      targets: const [],
+      preset: LabelSheetPresets.a4_8,
+    );
+    expect(bytes.length, greaterThan(100));
+    // PDFs start with "%PDF-".
+    expect(String.fromCharCodes(bytes.sublist(0, 5)), '%PDF-');
+  });
+
+  test('single page PDF is generated when targets fit on one page',
+      () async {
+    final targets = [
+      for (var i = 0; i < 5; i++)
+        LabelTarget(
+          qrPayload: 'item:$i',
+          title: 'Item $i',
+          subtitle: 'Shelf A',
+        ),
+    ];
+    final bytes = await generator.generate(
+      targets: targets,
+      preset: LabelSheetPresets.a4_8,
+    );
+    expect(bytes.length, greaterThan(500));
+  });
+
+  test('multi-page PDF is generated when targets exceed labelsPerPage',
+      () async {
+    const preset = LabelSheetPresets.a4_8; // 8 labels/page
+    final targets = [
+      for (var i = 0; i < 20; i++)
+        LabelTarget(qrPayload: 'item:$i', title: 'Item $i'),
+    ];
+    final bytes = await generator.generate(
+      targets: targets,
+      preset: preset,
+    );
+    // Heuristic: 3-page PDF is materially larger than a 1-page PDF.
+    final onePage = await generator.generate(
+      targets: targets.sublist(0, 1),
+      preset: preset,
+    );
+    expect(bytes.length, greaterThan(onePage.length));
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <camera_desktop/camera_desktop_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
+#include <printing/printing_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
@@ -20,6 +21,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
+  PrintingPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("PrintingPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   camera_desktop
   file_selector_windows
   flutter_secure_storage_windows
+  printing
   screen_retriever_windows
   url_launcher_windows
   window_manager


### PR DESCRIPTION
## Summary

Implements milestone 3 issue #42 — printable QR label sheets.

- **\`LabelSheetPreset\`** captures physical sheet layout in PostScript points. Three built-in presets:
  - \`a4-24\` (3×8) — small inventory labels
  - \`a4-8\` (2×4) — larger shelf/box labels
  - \`letter-30\` (3×10) — Avery 5160 compatible
  Geometry helpers derive \`labelWidthPt\` / \`labelHeightPt\` from margins + gutters so any future preset drops in without code changes.
- **\`LabelTarget\`** — canonical QR payloads via static helpers: \`item:<uuid>\` and \`location:<uuid>\`. Future scanner integration decodes them identically.
- **\`LabelPdfGenerator\`** — pure, Flutter-free: takes \`List<LabelTarget>\` + preset, returns \`Uint8List\`. Multi-page aware, centred grid, 56pt QR per cell, bold title, optional subtitle, payload echo footer.
- **\`/settings/labels\`** screen with source segment (Locations / Items), preset dropdown, multi-select list, and a Preview/Print button that hands off to \`Printing.layoutPdf\` for system print or save-as-PDF.

Adds \`pdf: ^3.11.0\` and \`printing: ^5.14.0\`.

## Test plan

- [x] 7 scorer tests covering preset math, payload helpers, empty-input PDF validity, single-page and multi-page output
- [x] \`flutter analyze\`: no issues
- [x] Full \`flutter test\`: 987 green (+7)
- [ ] Manual: create a few locations, open Settings → Print labels → Locations, select them, pick a preset, confirm preview renders (requires running app)

**Out of scope** (potential follow-ups): custom preset editor UI, QR size tuning per preset, additional Avery templates, per-item cover-art thumbnail on larger labels.

Closes #42