### PR TITLE
feat: static HTML export of collection

### DIFF
--- a/integration_test/helpers/test_app.dart
+++ b/integration_test/helpers/test_app.dart
@@ -10,6 +10,7 @@ import 'package:drift/native.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mymediascanner/app/app.dart';
+import 'package:mymediascanner/app/router.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/data/remote/sync/postgres_sync_client.dart';
 import 'package:mymediascanner/presentation/providers/database_provider.dart';
@@ -32,6 +33,11 @@ extension IntegrationTestApp on WidgetTester {
 
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     final storage = createMockSecureStorage();
+
+    // GoRouter is a top-level singleton, so navigation performed by a
+    // prior test in the same `flutter test` run leaks across setup.
+    // Reset to the dashboard before pumping the widget tree.
+    router.go('/');
 
     await pumpWidget(
       ProviderScope(

--- a/integration_test/lending_test.dart
+++ b/integration_test/lending_test.dart
@@ -26,11 +26,24 @@ void main() {
       await tester.tap(find.text('Settings').first);
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
-      // Scroll down to reveal the Borrowers list tile
-      await tester.drag(find.byType(ListView).last, const Offset(0, -800));
-      await tester.pumpAndSettle();
+      // Scroll settings until the Borrowers tile is fully on-screen.
+      // Uses a drag loop + ensureVisible rather than a fixed offset so
+      // the test tolerates new sections being inserted above.
+      final borrowersTile = find.text('Borrowers');
+      for (var i = 0; i < 20; i++) {
+        if (tester.any(borrowersTile)) {
+          await tester.ensureVisible(borrowersTile.first);
+          await tester.pumpAndSettle();
+          break;
+        }
+        await tester.drag(
+          find.byType(ListView).last,
+          const Offset(0, -300),
+        );
+        await tester.pumpAndSettle();
+      }
 
-      await tester.tap(find.text('Borrowers').first);
+      await tester.tap(borrowersTile.first);
       await tester.pumpAndSettle(const Duration(seconds: 1));
     }
 

--- a/integration_test/rips_enhancements_test.dart
+++ b/integration_test/rips_enhancements_test.dart
@@ -64,6 +64,24 @@ void main() {
   });
 
   group('ReplayGain settings', () {
+    Future<void> scrollSettingsUntil(
+      WidgetTester tester,
+      Finder target,
+    ) async {
+      for (var i = 0; i < 20; i++) {
+        if (tester.any(target)) {
+          await tester.ensureVisible(target);
+          await tester.pumpAndSettle();
+          return;
+        }
+        await tester.drag(
+          find.byType(ListView).last,
+          const Offset(0, -300),
+        );
+        await tester.pumpAndSettle();
+      }
+    }
+
     testWidgets('playback section appears with ReplayGain controls',
         (tester) async {
       await setUpWideScreen(tester);
@@ -73,10 +91,7 @@ void main() {
       await tester.tap(find.text('Settings').first);
       await tester.pumpAndSettle();
 
-      // Scroll to find the Playback section
-      final listView = find.byType(ListView).last;
-      await tester.drag(listView, const Offset(0, -500));
-      await tester.pumpAndSettle();
+      await scrollSettingsUntil(tester, find.text('PLAYBACK'));
 
       // PLAYBACK section header should be visible
       expect(find.text('PLAYBACK'), findsOneWidget);
@@ -94,8 +109,7 @@ void main() {
       await tester.tap(find.text('Settings').first);
       await tester.pumpAndSettle();
 
-      await tester.drag(find.byType(ListView).last, const Offset(0, -500));
-      await tester.pumpAndSettle();
+      await scrollSettingsUntil(tester, find.text('Track'));
 
       // Tap Track mode segment
       await tester.tap(find.text('Track'));

--- a/integration_test/settings_test.dart
+++ b/integration_test/settings_test.dart
@@ -20,6 +20,28 @@ void main() {
       });
     }
 
+    Future<void> scrollSettingsUntil(
+      WidgetTester tester,
+      Finder target,
+    ) async {
+      for (var i = 0; i < 20; i++) {
+        if (tester.any(target)) {
+          // `any` matches widgets that ListView has built ahead of
+          // the viewport via cacheExtent — they may still be off-
+          // screen. `ensureVisible` does the last-mile scroll so the
+          // widget is actually inside the viewport and tappable.
+          await tester.ensureVisible(target);
+          await tester.pumpAndSettle();
+          return;
+        }
+        await tester.drag(
+          find.byType(ListView).last,
+          const Offset(0, -300),
+        );
+        await tester.pumpAndSettle();
+      }
+    }
+
     testWidgets('renders all sections', (tester) async {
       await setWideScreen(tester);
       await tester.pumpTestApp();
@@ -32,10 +54,7 @@ void main() {
       expect(find.text('SYNC'), findsOneWidget);
       expect(find.text('API INTEGRATIONS'), findsOneWidget);
 
-      // Scroll the settings ListView to reveal sections below the fold
-      // (FLAC Library section sits between API Integrations and Preferences on desktop)
-      await tester.drag(find.byType(ListView).last, const Offset(0, -800));
-      await tester.pumpAndSettle();
+      await scrollSettingsUntil(tester, find.text('PREFERENCES'));
       expect(find.text('PREFERENCES'), findsOneWidget);
       expect(find.text('Theme'), findsOneWidget);
     });
@@ -48,9 +67,9 @@ void main() {
       await tester.tap(find.text('Settings').first);
       await tester.pumpAndSettle();
 
-      // Scroll to the Preferences section (past FLAC Library on desktop)
-      await tester.drag(find.byType(ListView).last, const Offset(0, -800));
-      await tester.pumpAndSettle();
+      // Scroll until the light-mode icon (at the bottom of the Theme
+      // tile) is on-screen and tappable.
+      await scrollSettingsUntil(tester, find.byIcon(Icons.light_mode));
 
       // Initially system default
       expect(find.text('System default'), findsOneWidget);
@@ -72,10 +91,8 @@ void main() {
       await tester.tap(find.text('Settings').first);
       await tester.pumpAndSettle();
 
-      // Scroll to find the About tile and tap it
-      await tester.drag(find.byType(ListView).last, const Offset(0, -1200));
-      await tester.pumpAndSettle();
       final aboutTile = find.text('About MyMediaScanner');
+      await scrollSettingsUntil(tester, aboutTile);
       await tester.tap(aboutTile);
       await tester.pumpAndSettle();
 

--- a/integration_test/tags_test.dart
+++ b/integration_test/tags_test.dart
@@ -73,8 +73,14 @@ void main() {
       // Verify the dialog is visible
       expect(find.text('Create Tag'), findsOneWidget);
 
-      // Enter the tag name into the single TextField in the dialog
-      await tester.enterText(find.byType(TextField).first, 'Horror');
+      // Enter the tag name into the dialog's TextField — scope by
+      // AlertDialog ancestor since the Collection screen's SearchBar
+      // also contains a TextField that `.first` would otherwise match.
+      final dialogTextField = find.descendant(
+        of: find.byType(AlertDialog),
+        matching: find.byType(TextField),
+      );
+      await tester.enterText(dialogTextField, 'Horror');
       await tester.pumpAndSettle();
 
       // Tap the Create button

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -22,6 +22,7 @@ import 'package:mymediascanner/presentation/screens/series/series_list_screen.da
 import 'package:mymediascanner/presentation/screens/series/series_detail_screen.dart';
 import 'package:mymediascanner/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen.dart';
 import 'package:mymediascanner/presentation/screens/labels/label_print_screen.dart';
+import 'package:mymediascanner/presentation/screens/export/static_export_screen.dart';
 import 'package:mymediascanner/presentation/screens/about/about_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrowers_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrower_detail_screen.dart';
@@ -229,6 +230,12 @@ final router = GoRouter(
                   parentNavigatorKey: _rootNavigatorKey,
                   pageBuilder: (context, state) =>
                       _fadeSlideTransition(state, const LabelPrintScreen()),
+                ),
+                GoRoute(
+                  path: 'export',
+                  parentNavigatorKey: _rootNavigatorKey,
+                  pageBuilder: (context, state) => _fadeSlideTransition(
+                      state, const StaticExportScreen()),
                 ),
               ],
             ),

--- a/lib/data/services/static_export_writer.dart
+++ b/lib/data/services/static_export_writer.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/services/static_export_service.dart';
+import 'package:path/path.dart' as p;
+
+/// Writes a [StaticExportService] bundle to a directory on disk.
+///
+/// Responsibilities:
+///  * optionally fetching cover URLs over HTTP into a `covers` map;
+///  * invoking [StaticExportService.build] to render the HTML;
+///  * persisting every `relative-path → bytes` pair under [targetDir].
+///
+/// Progress is reported via [onProgress] with `(done, total)` counts.
+class StaticExportWriter {
+  StaticExportWriter({
+    StaticExportService? service,
+    Dio? dio,
+  })  : _service = service ?? const StaticExportService(),
+        _dio = dio ?? Dio();
+
+  final StaticExportService _service;
+  final Dio _dio;
+
+  /// Write the export. Returns the absolute path to the generated
+  /// `index.html`.
+  Future<String> write({
+    required Directory targetDir,
+    required List<MediaItem> items,
+    StaticExportOptions options = const StaticExportOptions(),
+    void Function(int done, int total)? onProgress,
+  }) async {
+    if (!await targetDir.exists()) {
+      await targetDir.create(recursive: true);
+    }
+
+    Map<String, Uint8List> covers = const {};
+    if (options.bundleCovers) {
+      covers = await _fetchCovers(items, onProgress: onProgress);
+    }
+
+    final bundle = _service.build(
+      items: items,
+      options: options,
+      covers: covers,
+    );
+
+    final total = bundle.length;
+    var done = 0;
+    onProgress?.call(done, total);
+
+    for (final e in bundle.entries) {
+      final file = File(p.join(targetDir.path, e.key));
+      await file.parent.create(recursive: true);
+      await file.writeAsBytes(e.value);
+      done++;
+      onProgress?.call(done, total);
+    }
+
+    return p.join(targetDir.path, 'index.html');
+  }
+
+  Future<Map<String, Uint8List>> _fetchCovers(
+    List<MediaItem> items, {
+    void Function(int done, int total)? onProgress,
+  }) async {
+    final targets = <MediaItem>[];
+    for (final item in items) {
+      if (item.coverUrl != null && item.coverUrl!.isNotEmpty) {
+        targets.add(item);
+      }
+    }
+    final covers = <String, Uint8List>{};
+    var done = 0;
+    final total = targets.length;
+    onProgress?.call(done, total);
+
+    for (final item in targets) {
+      try {
+        final response = await _dio.get<List<int>>(
+          item.coverUrl!,
+          options: Options(responseType: ResponseType.bytes),
+        );
+        final data = response.data;
+        if (data != null && data.isNotEmpty) {
+          final ext = _extFromUrl(item.coverUrl!);
+          covers['${item.id}$ext'] = Uint8List.fromList(data);
+        }
+      } on Exception {
+        // Skip failed downloads; the HTML falls back to an empty
+        // placeholder because the map lookup will miss.
+      }
+      done++;
+      onProgress?.call(done, total);
+    }
+    return covers;
+  }
+
+  static String _extFromUrl(String url) {
+    final q = url.indexOf('?');
+    final clean = q >= 0 ? url.substring(0, q) : url;
+    final slash = clean.lastIndexOf('/');
+    final name = slash >= 0 ? clean.substring(slash + 1) : clean;
+    final dot = name.lastIndexOf('.');
+    if (dot < 0 || dot == name.length - 1) return '.jpg';
+    final ext = name.substring(dot).toLowerCase();
+    const allowed = {'.jpg', '.jpeg', '.png', '.webp', '.gif'};
+    return allowed.contains(ext) ? ext : '.jpg';
+  }
+}

--- a/lib/domain/services/static_export_service.dart
+++ b/lib/domain/services/static_export_service.dart
@@ -1,0 +1,285 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:mymediascanner/domain/entities/media_item.dart';
+
+/// Options controlling a static HTML export.
+class StaticExportOptions {
+  const StaticExportOptions({
+    this.privateTag = 'private',
+    this.bundleCovers = false,
+    this.title = 'My collection',
+  });
+
+  /// Items with this tag (in `extraMetadata['tags']`) are excluded.
+  final String privateTag;
+
+  /// When true, cover images are expected to be supplied via the
+  /// [StaticExportService.build] `covers` map and referenced from local
+  /// `covers/...` paths. When false, the output HTML references the
+  /// original `coverUrl` hosts directly.
+  final bool bundleCovers;
+
+  /// Title shown in the exported `<h1>`.
+  final String title;
+}
+
+/// Pure, IO-free service that renders a self-contained static website
+/// from a collection. No Flutter, no dart:io. Caller is responsible for
+/// writing the returned map to disk and, if [StaticExportOptions.bundleCovers]
+/// is true, fetching cover images and supplying them via [build]'s
+/// `covers` argument.
+///
+/// Output layout:
+/// ```
+/// index.html      — grid + filter controls (inline CSS/JS)
+/// items/<id>.html — per-item detail
+/// covers/<id>.<ext> — only when covers are supplied
+/// ```
+class StaticExportService {
+  const StaticExportService();
+
+  /// Build the export. Returns a map of relative paths to byte content.
+  Map<String, Uint8List> build({
+    required List<MediaItem> items,
+    StaticExportOptions options = const StaticExportOptions(),
+    Map<String, Uint8List> covers = const {},
+  }) {
+    final visible = items
+        .where((i) => !i.deleted)
+        .where((i) => !_hasTag(i, options.privateTag))
+        .toList();
+
+    final index = _renderIndex(visible, options);
+    final output = <String, Uint8List>{
+      'index.html': Uint8List.fromList(utf8.encode(index)),
+    };
+
+    for (final item in visible) {
+      final page = _renderItem(item, options);
+      output['items/${item.id}.html'] =
+          Uint8List.fromList(utf8.encode(page));
+    }
+
+    for (final e in covers.entries) {
+      output['covers/${e.key}'] = e.value;
+    }
+
+    return output;
+  }
+
+  // ── HTML rendering ────────────────────────────────────────────────
+
+  String _renderIndex(List<MediaItem> items, StaticExportOptions opts) {
+    final mediaTypes = <String>{for (final i in items) i.mediaType.label};
+    final tags = <String>{
+      for (final i in items)
+        if (i.extraMetadata['tags'] is List)
+          for (final t in i.extraMetadata['tags'] as List)
+            if (t is String && t != opts.privateTag) t,
+    };
+
+    final cards = <String>[];
+    for (final item in items) {
+      final cover = _coverPath(item, opts);
+      final tagList = _tagsOf(item)
+          .where((t) => t != opts.privateTag)
+          .join(',');
+      cards.add('''
+      <a class="card"
+         href="items/${_esc(item.id)}.html"
+         data-type="${_esc(item.mediaType.label)}"
+         data-tags="${_esc(tagList)}">
+        ${cover != null ? '<img loading="lazy" src="${_esc(cover)}" alt="">' : '<div class="placeholder"></div>'}
+        <div class="card-title">${_esc(item.title)}</div>
+        ${item.year != null ? '<div class="card-sub">${item.year}</div>' : ''}
+      </a>''');
+    }
+
+    return '''
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+<meta charset="utf-8">
+<title>${_esc(opts.title)}</title>
+<style>
+  :root { color-scheme: dark light; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 24px; background: #0e0e0e; color: #f5f6f7; }
+  h1 { margin: 0 0 16px; font-weight: 800; letter-spacing: -0.5px; }
+  .toolbar { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 16px; align-items: center; }
+  .toolbar select, .toolbar input { padding: 6px 10px; border-radius: 6px; border: 1px solid #333; background: #1a1a1a; color: inherit; font: inherit; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 16px; }
+  .card { display: block; background: #1a1a1a; border-radius: 12px; overflow: hidden; color: inherit; text-decoration: none; transition: transform 0.15s; }
+  .card:hover { transform: translateY(-2px); }
+  .card img, .card .placeholder { width: 100%; aspect-ratio: 2 / 3; object-fit: cover; background: #222; display: block; }
+  .card-title { padding: 8px 10px 0; font-size: 14px; font-weight: 600; line-height: 1.2; }
+  .card-sub { padding: 2px 10px 10px; font-size: 12px; color: #999; }
+  .card.hidden { display: none; }
+  @media (prefers-color-scheme: light) {
+    body { background: #f5f6f7; color: #111; }
+    .toolbar select, .toolbar input { background: #fff; border-color: #ddd; }
+    .card { background: #fff; box-shadow: 0 1px 3px rgba(0,0,0,0.06); }
+    .card-sub { color: #666; }
+  }
+</style>
+</head>
+<body>
+<h1>${_esc(opts.title)}</h1>
+<div class="toolbar">
+  <label>Type:
+    <select id="type-filter">
+      <option value="">All</option>
+      ${mediaTypes.map((t) => '<option>${_esc(t)}</option>').join('\n      ')}
+    </select>
+  </label>
+  <label>Tag:
+    <select id="tag-filter">
+      <option value="">Any</option>
+      ${tags.map((t) => '<option>${_esc(t)}</option>').join('\n      ')}
+    </select>
+  </label>
+  <input id="text-filter" placeholder="Search title...">
+  <span id="count">${items.length} items</span>
+</div>
+<div class="grid">
+${cards.join('\n')}
+</div>
+<script>
+(() => {
+  const cards = document.querySelectorAll('.card');
+  const type = document.getElementById('type-filter');
+  const tag = document.getElementById('tag-filter');
+  const text = document.getElementById('text-filter');
+  const count = document.getElementById('count');
+  const apply = () => {
+    const t = type.value;
+    const tg = tag.value;
+    const q = text.value.trim().toLowerCase();
+    let visible = 0;
+    cards.forEach(c => {
+      const matchType = !t || c.dataset.type === t;
+      const matchTag = !tg || (c.dataset.tags || '').split(',').includes(tg);
+      const matchText = !q || c.querySelector('.card-title').textContent.toLowerCase().includes(q);
+      const ok = matchType && matchTag && matchText;
+      c.classList.toggle('hidden', !ok);
+      if (ok) visible++;
+    });
+    count.textContent = visible + ' items';
+  };
+  type.addEventListener('change', apply);
+  tag.addEventListener('change', apply);
+  text.addEventListener('input', apply);
+})();
+</script>
+</body>
+</html>
+''';
+  }
+
+  String _renderItem(MediaItem item, StaticExportOptions opts) {
+    final cover = _coverPath(item, opts);
+    final details = <(String, String)>[
+      if (item.year != null) ('Year', item.year.toString()),
+      if (item.publisher != null) ('Publisher', item.publisher!),
+      if (item.format != null) ('Format', item.format!),
+      ('Type', item.mediaType.label),
+      if (item.barcode.isNotEmpty) ('Barcode', item.barcode),
+      if (item.genres.isNotEmpty) ('Genres', item.genres.join(', ')),
+      if (item.userRating != null)
+        ('Rating', '${item.userRating!.toStringAsFixed(1)} / 5'),
+    ];
+
+    final rows = details
+        .map((e) => '<tr><th>${_esc(e.$1)}</th><td>${_esc(e.$2)}</td></tr>')
+        .join('\n      ');
+
+    return '''
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+<meta charset="utf-8">
+<title>${_esc(item.title)} — ${_esc(opts.title)}</title>
+<style>
+  :root { color-scheme: dark light; }
+  body { font-family: system-ui, sans-serif; margin: 0; padding: 24px; background: #0e0e0e; color: #f5f6f7; max-width: 880px; margin-inline: auto; }
+  a.back { display: inline-block; margin-bottom: 16px; color: #6dddff; text-decoration: none; }
+  .layout { display: grid; grid-template-columns: 240px 1fr; gap: 24px; align-items: start; }
+  .cover { width: 100%; aspect-ratio: 2 / 3; object-fit: cover; border-radius: 12px; background: #222; }
+  h1 { margin: 0 0 4px; font-size: 28px; }
+  .sub { color: #999; margin-bottom: 16px; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { text-align: left; padding: 6px 0; border-bottom: 1px solid #222; font-size: 14px; }
+  th { color: #999; width: 110px; font-weight: 500; }
+  .desc { margin-top: 16px; line-height: 1.5; }
+  @media (prefers-color-scheme: light) {
+    body { background: #f5f6f7; color: #111; }
+    a.back { color: #00647a; }
+    .sub { color: #666; }
+    th { color: #666; }
+    th, td { border-color: #eee; }
+  }
+  @media (max-width: 600px) { .layout { grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<a class="back" href="../index.html">← Back to collection</a>
+<div class="layout">
+  ${cover != null ? '<img class="cover" src="../${_esc(cover)}" alt="">' : '<div class="cover"></div>'}
+  <div>
+    <h1>${_esc(item.title)}</h1>
+    ${item.subtitle != null ? '<div class="sub">${_esc(item.subtitle!)}</div>' : ''}
+    <table>
+      $rows
+    </table>
+    ${item.description != null ? '<div class="desc">${_esc(item.description!)}</div>' : ''}
+    ${item.userReview != null ? '<div class="desc"><em>${_esc(item.userReview!)}</em></div>' : ''}
+  </div>
+</div>
+</body>
+</html>
+''';
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────
+
+  /// Returns the `covers/<id>.<ext>` path when covers are bundled and we
+  /// have a URL (used by the writer to pick the extension). Returns the
+  /// original URL when not bundling.
+  String? _coverPath(MediaItem item, StaticExportOptions opts) {
+    final url = item.coverUrl;
+    if (url == null || url.isEmpty) return null;
+    if (!opts.bundleCovers) return url;
+    final ext = _extFromUrl(url);
+    return 'covers/${item.id}$ext';
+  }
+
+  static String _extFromUrl(String url) {
+    final q = url.indexOf('?');
+    final clean = q >= 0 ? url.substring(0, q) : url;
+    final slash = clean.lastIndexOf('/');
+    final name = slash >= 0 ? clean.substring(slash + 1) : clean;
+    final dot = name.lastIndexOf('.');
+    if (dot < 0 || dot == name.length - 1) return '.jpg';
+    final ext = name.substring(dot).toLowerCase();
+    const allowed = {'.jpg', '.jpeg', '.png', '.webp', '.gif'};
+    return allowed.contains(ext) ? ext : '.jpg';
+  }
+
+  static List<String> _tagsOf(MediaItem item) {
+    final tags = item.extraMetadata['tags'];
+    if (tags is List) {
+      return [for (final t in tags) if (t is String) t];
+    }
+    return const [];
+  }
+
+  static bool _hasTag(MediaItem item, String tag) =>
+      _tagsOf(item).contains(tag);
+
+  static String _esc(String input) => input
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&#39;');
+}

--- a/lib/domain/usecases/recommend_next_usecase.dart
+++ b/lib/domain/usecases/recommend_next_usecase.dart
@@ -25,10 +25,19 @@ class RecommendNextUseCase {
   final TasteProfileBuilder _profileBuilder;
 
   /// Returns up to [limit] recommendations ordered by descending score.
+  ///
+  /// Returns an empty list when the taste profile carries no real
+  /// signal — i.e. the user has neither rated anything highly nor shown
+  /// series-collecting behaviour. A recency-only recommendation isn't
+  /// useful and just echoes the collection chronology.
   List<Recommendation> rank(List<MediaItem> ownedItems, {int limit = 5}) {
     if (ownedItems.isEmpty) return const [];
 
     final profile = _profileBuilder.build(ownedItems);
+    final hasSignal = profile.lovedGenres.isNotEmpty ||
+        profile.lovedTags.isNotEmpty ||
+        profile.collectedSeriesIds.isNotEmpty;
+    if (!hasSignal) return const [];
 
     final candidates = ownedItems.where((item) {
       if (item.deleted) return false;

--- a/lib/presentation/screens/export/static_export_screen.dart
+++ b/lib/presentation/screens/export/static_export_screen.dart
@@ -1,0 +1,216 @@
+// Static HTML export — bundle the collection as a portable website.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/data/services/static_export_writer.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/services/static_export_service.dart';
+import 'package:mymediascanner/presentation/providers/recommendations_provider.dart';
+import 'package:mymediascanner/presentation/widgets/screen_header.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class StaticExportScreen extends ConsumerStatefulWidget {
+  const StaticExportScreen({super.key});
+
+  @override
+  ConsumerState<StaticExportScreen> createState() =>
+      _StaticExportScreenState();
+}
+
+class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
+  final _titleController = TextEditingController(text: 'My collection');
+  final _privateTagController = TextEditingController(text: 'private');
+  bool _bundleCovers = false;
+  bool _running = false;
+  int _progressDone = 0;
+  int _progressTotal = 0;
+  String? _resultPath;
+  String? _errorMessage;
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _privateTagController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDesktop = PlatformCapability.isDesktop;
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar:
+          isDesktop ? null : AppBar(title: const Text('Export collection')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (isDesktop)
+              const ScreenHeader(
+                title: 'Export collection',
+                subtitle:
+                    'Bundle the collection as a static HTML site with a '
+                    'searchable grid and per-item pages. Private items '
+                    '(tagged) are excluded.',
+              ),
+            const SizedBox(height: 8),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 560),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  TextField(
+                    controller: _titleController,
+                    decoration: const InputDecoration(
+                      labelText: 'Site title',
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _privateTagController,
+                    decoration: const InputDecoration(
+                      labelText: 'Private tag (excluded from export)',
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  SwitchListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: const Text('Download and bundle cover art'),
+                    subtitle: const Text(
+                        'Fetches every cover URL. Without this the export '
+                        'references the original hosts, which may 404 later.'),
+                    value: _bundleCovers,
+                    onChanged: _running
+                        ? null
+                        : (v) => setState(() => _bundleCovers = v),
+                  ),
+                  const SizedBox(height: 16),
+                  FilledButton.icon(
+                    icon: const Icon(Icons.download),
+                    label: Text(_running
+                        ? 'Exporting…'
+                        : 'Choose folder and export'),
+                    onPressed: _running ? null : _export,
+                  ),
+                  if (_running || _progressTotal > 0) ...[
+                    const SizedBox(height: 16),
+                    LinearProgressIndicator(
+                      value: _progressTotal == 0
+                          ? null
+                          : _progressDone / _progressTotal,
+                    ),
+                    const SizedBox(height: 4),
+                    Text('$_progressDone / $_progressTotal',
+                        style: theme.textTheme.bodySmall),
+                  ],
+                  if (_errorMessage != null) ...[
+                    const SizedBox(height: 16),
+                    Text(_errorMessage!,
+                        style: TextStyle(
+                            color: theme.colorScheme.error)),
+                  ],
+                  if (_resultPath != null) ...[
+                    const SizedBox(height: 16),
+                    Card(
+                      color: theme.colorScheme.surfaceContainerHigh,
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Export complete',
+                                style: theme.textTheme.titleMedium),
+                            const SizedBox(height: 4),
+                            SelectableText(_resultPath!),
+                            const SizedBox(height: 12),
+                            Row(children: [
+                              FilledButton.tonalIcon(
+                                icon: const Icon(Icons.open_in_browser),
+                                label: const Text('Open index.html'),
+                                onPressed: () => _launch(_resultPath!),
+                              ),
+                            ]),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _export() async {
+    final dirPath = await FilePicker.platform.getDirectoryPath(
+      dialogTitle: 'Choose export folder',
+    );
+    if (dirPath == null) return;
+
+    setState(() {
+      _running = true;
+      _progressDone = 0;
+      _progressTotal = 0;
+      _errorMessage = null;
+      _resultPath = null;
+    });
+
+    try {
+      final items = ref.read(ownedItemsProvider).value ?? <MediaItem>[];
+      final writer = StaticExportWriter();
+      final indexPath = await writer.write(
+        targetDir: Directory(dirPath),
+        items: items,
+        options: StaticExportOptions(
+          title: _titleController.text.trim().isEmpty
+              ? 'My collection'
+              : _titleController.text.trim(),
+          privateTag: _privateTagController.text.trim().isEmpty
+              ? 'private'
+              : _privateTagController.text.trim(),
+          bundleCovers: _bundleCovers,
+        ),
+        onProgress: (done, total) {
+          if (mounted) {
+            setState(() {
+              _progressDone = done;
+              _progressTotal = total;
+            });
+          }
+        },
+      );
+      if (mounted) {
+        setState(() {
+          _running = false;
+          _resultPath = indexPath;
+        });
+      }
+    } on Exception catch (e) {
+      if (mounted) {
+        setState(() {
+          _running = false;
+          _errorMessage = 'Export failed: $e';
+        });
+      }
+    }
+  }
+
+  Future<void> _launch(String path) async {
+    final uri = Uri.file(path);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri);
+    }
+  }
+}

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -106,6 +106,25 @@ class SettingsScreen extends ConsumerWidget {
           ),
           const SizedBox(height: 16),
 
+          // Export section — static HTML bundle
+          _SectionCard(
+            title: 'Export',
+            colors: colors,
+            theme: theme,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.public_outlined),
+                title: const Text('Static HTML export'),
+                subtitle: const Text(
+                    'Portable website bundle with filter controls; drop '
+                    'into any static host or open locally'),
+                trailing: const Icon(Icons.chevron_right),
+                onTap: () => context.go('/settings/export'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+
           // FLAC Library section (desktop only)
           if (isDesktop) ...[
             _SectionCard(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1136,7 +1136,7 @@ packages:
     source: hosted
     version: "3.2.1"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   uuid: ^4.5.3
   intl: ^0.20.2
   path_provider: ^2.1.5
+  path: ^1.9.0
   window_manager: ^0.5.1
   file_picker: ">=10.3.10 <11.0.0"
   flutter_local_notifications: ^19.0.0

--- a/src/docs/modules/ROOT/nav.adoc
+++ b/src/docs/modules/ROOT/nav.adoc
@@ -20,5 +20,6 @@
 ** xref:progress.adoc[Reading and Watching Progress]
 ** xref:recommendations.adoc[Recommendations Engine]
 ** xref:wishlist.adoc[Wishlist and Suggestions]
+** xref:static-export.adoc[Static HTML Export]
 * xref:api-configuration.adoc[API Configuration]
 * xref:testing.adoc[Testing]

--- a/src/docs/modules/ROOT/pages/static-export.adoc
+++ b/src/docs/modules/ROOT/pages/static-export.adoc
@@ -1,0 +1,106 @@
+= Static HTML Export
+Paul Snow
+0.0.0
+include::_attributes.adoc[]
+:description: Export your entire collection as a self-contained static website with a searchable grid, per-item pages, and optional bundled cover art.
+
+The static HTML export feature renders your collection as a portable website you can open in any browser, share as a folder, or host on a static file service — no app installation required.
+The output is entirely self-contained: all CSS and JavaScript are inlined, no external fonts or scripts are loaded, and the pages adapt to dark or light mode automatically via `prefers-color-scheme`.
+
+== Accessing the Feature
+
+Navigate to *Settings → Export → Static HTML export*.
+
+The export screen provides three options before writing anything to disk.
+Press *Choose folder and export* when you are ready; a system folder-picker dialog opens.
+After you select a destination folder the export begins immediately.
+
+== Options
+
+[cols="1,1,3", options="header"]
+|===
+| Option | Default | Description
+
+| *Site title*
+| `My collection`
+| Heading text shown at the top of `index.html` and in each page's `<title>` element.
+
+| *Private tag*
+| `private`
+| Items carrying this tag are excluded entirely — they do not appear on the index and no detail page is written for them.
+Rename the tag if your catalogue uses a different convention.
+
+| *Download and bundle cover art*
+| Off
+| When enabled, each cover URL is fetched via Dio and saved locally as `covers/<id>.<ext>`.
+The generated HTML references those local paths so the export remains viewable offline.
+When disabled, the HTML references the original remote hosts directly; those URLs may return 404 in future.
+|===
+
+NOTE: Cover downloads that fail (network error or non-image response) fall through silently to an empty placeholder; the rest of the export continues normally.
+
+== Export Progress
+
+A progress bar appears once the export starts.
+The counter tracks cover downloads (when bundling is enabled) plus individual file writes, so for a large collection with cover bundling enabled the bar advances as each image is downloaded and each HTML file is written.
+
+When the export completes, the path to `index.html` is shown on screen together with an *Open index.html* button that launches the file in your default browser.
+
+== Output Layout
+
+The following files are written to the folder you selected:
+
+[cols="2,3", options="header"]
+|===
+| Path | Contents
+
+| `index.html`
+| Responsive grid of all visible items.
+Includes a *Type* dropdown, a *Tag* dropdown, and a title search box.
+Filtering and search are handled by inline JavaScript — no server required.
+
+| `items/<id>.html`
+| Detail page for a single item: cover art, title, year, publisher, format, media type, barcode, genres, user rating, description, and personal review.
+A *← Back to collection* link returns to `index.html`.
+
+| `covers/<id>.<ext>`
+| Cover image for a single item.
+Only written when *Download and bundle cover art* is enabled and the download succeeds.
+The extension (`.jpg`, `.jpeg`, `.png`, `.webp`, or `.gif`) is derived from the original URL.
+|===
+
+== Privacy Model
+
+Two categories of item are excluded from every export:
+
+* *Soft-deleted items* — records with `deleted = 1` in the database are never included, regardless of settings.
+* *Privately tagged items* — any item whose tag list (stored in `extraMetadata['tags']`) contains the configured private tag is excluded.
+No detail page is written for excluded items and they do not appear as cards on the index, so their titles are not visible even in the HTML source.
+
+== Hosting the Export
+
+The output folder can be hosted on any static file service without modification.
+
+=== Local / offline
+
+Open `index.html` directly in a browser using the *Open index.html* button, or by double-clicking the file in your file manager.
+Cover images must be bundled for offline use.
+
+=== Netlify Drop
+
+Drag the export folder onto https://app.netlify.com/drop[Netlify Drop].
+The site is live immediately under a generated URL.
+
+=== GitHub Pages
+
+Commit the folder contents to a repository (or the `docs/` subdirectory of an existing one) and enable *Pages* in the repository settings.
+
+=== nginx / Apache
+
+Copy the folder to your web root.
+No server-side configuration is required; all routing is handled client-side by the inline JavaScript.
+
+== Related Pages
+
+* xref:api-configuration.adoc[API Configuration] — API keys, sync configuration, and theme options
+* xref:import.adoc[Importing External Collections] — bring in collections from Goodreads, Discogs, Letterboxd, or Trakt

--- a/test/unit/data/services/static_export_writer_test.dart
+++ b/test/unit/data/services/static_export_writer_test.dart
@@ -1,0 +1,182 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/services/static_export_writer.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/services/static_export_service.dart';
+import 'package:path/path.dart' as p;
+
+class MockDio extends Mock implements Dio {}
+
+MediaItem _item({
+  required String id,
+  String title = 'Title',
+  String? coverUrl,
+  MediaType mediaType = MediaType.film,
+}) =>
+    MediaItem(
+      id: id,
+      barcode: id,
+      barcodeType: 'EAN13',
+      mediaType: mediaType,
+      title: title,
+      coverUrl: coverUrl,
+      extraMetadata: const {},
+      dateAdded: 0,
+      dateScanned: 0,
+      updatedAt: 0,
+    );
+
+Response<List<int>> _bytesResponse(List<int> bytes, String url) => Response(
+      requestOptions: RequestOptions(path: url),
+      data: bytes,
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: ''));
+  });
+
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('mms_export_test_');
+  });
+
+  tearDown(() async {
+    if (await tempDir.exists()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('writes index.html and per-item pages to disk', () async {
+    final writer = StaticExportWriter(dio: MockDio());
+    final indexPath = await writer.write(
+      targetDir: tempDir,
+      items: [_item(id: 'a'), _item(id: 'b')],
+    );
+
+    expect(indexPath, p.join(tempDir.path, 'index.html'));
+    expect(await File(indexPath).exists(), isTrue);
+    expect(await File(p.join(tempDir.path, 'items', 'a.html')).exists(),
+        isTrue);
+    expect(await File(p.join(tempDir.path, 'items', 'b.html')).exists(),
+        isTrue);
+  });
+
+  test('creates the target directory if it does not exist', () async {
+    final nested = Directory(p.join(tempDir.path, 'new', 'export'));
+    final writer = StaticExportWriter(dio: MockDio());
+
+    await writer.write(targetDir: nested, items: [_item(id: 'x')]);
+
+    expect(await nested.exists(), isTrue);
+    expect(await File(p.join(nested.path, 'index.html')).exists(), isTrue);
+  });
+
+  test('does not invoke Dio when bundleCovers is false', () async {
+    final dio = MockDio();
+    final writer = StaticExportWriter(dio: dio);
+
+    await writer.write(
+      targetDir: tempDir,
+      items: [_item(id: 'a', coverUrl: 'https://example.com/a.jpg')],
+    );
+
+    verifyNever(() => dio.get<List<int>>(any(),
+        options: any(named: 'options')));
+  });
+
+  test('fetches covers and writes them under covers/ when bundling',
+      () async {
+    final dio = MockDio();
+    final bytes = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    when(() => dio.get<List<int>>(
+          'https://example.com/a.png',
+          options: any(named: 'options'),
+        )).thenAnswer((_) async =>
+        _bytesResponse(bytes, 'https://example.com/a.png'));
+
+    final writer = StaticExportWriter(dio: dio);
+    await writer.write(
+      targetDir: tempDir,
+      items: [_item(id: 'a', coverUrl: 'https://example.com/a.png')],
+      options: const StaticExportOptions(bundleCovers: true),
+    );
+
+    final coverFile = File(p.join(tempDir.path, 'covers', 'a.png'));
+    expect(await coverFile.exists(), isTrue);
+    expect(await coverFile.readAsBytes(), Uint8List.fromList(bytes));
+  });
+
+  test('skips covers when the download fails', () async {
+    final dio = MockDio();
+    when(() => dio.get<List<int>>(
+          any(),
+          options: any(named: 'options'),
+        )).thenThrow(DioException(
+      requestOptions: RequestOptions(path: ''),
+      type: DioExceptionType.connectionError,
+    ));
+
+    final writer = StaticExportWriter(dio: dio);
+    await writer.write(
+      targetDir: tempDir,
+      items: [_item(id: 'a', coverUrl: 'https://example.com/a.jpg')],
+      options: const StaticExportOptions(bundleCovers: true),
+    );
+
+    final coverDir = Directory(p.join(tempDir.path, 'covers'));
+    if (await coverDir.exists()) {
+      expect(await coverDir.list().toList(), isEmpty);
+    }
+    // Export itself still succeeds.
+    expect(await File(p.join(tempDir.path, 'index.html')).exists(), isTrue);
+  });
+
+  test('reports progress for write phase', () async {
+    final writer = StaticExportWriter(dio: MockDio());
+    final progress = <(int, int)>[];
+
+    await writer.write(
+      targetDir: tempDir,
+      items: [_item(id: 'a'), _item(id: 'b')],
+      onProgress: (done, total) => progress.add((done, total)),
+    );
+
+    expect(progress, isNotEmpty);
+    final last = progress.last;
+    expect(last.$1, last.$2, reason: 'final done == total');
+    expect(last.$1, greaterThanOrEqualTo(3),
+        reason: 'index + 2 item pages at minimum');
+  });
+
+  test('skips items without coverUrl when fetching covers', () async {
+    final dio = MockDio();
+    when(() => dio.get<List<int>>(
+          'https://example.com/b.jpg',
+          options: any(named: 'options'),
+        )).thenAnswer((_) async =>
+        _bytesResponse([1, 2, 3], 'https://example.com/b.jpg'));
+
+    final writer = StaticExportWriter(dio: dio);
+    await writer.write(
+      targetDir: tempDir,
+      items: [
+        _item(id: 'a'),
+        _item(id: 'b', coverUrl: 'https://example.com/b.jpg'),
+      ],
+      options: const StaticExportOptions(bundleCovers: true),
+    );
+
+    verify(() => dio.get<List<int>>(
+          'https://example.com/b.jpg',
+          options: any(named: 'options'),
+        )).called(1);
+    verifyNoMoreInteractions(dio);
+  });
+}

--- a/test/unit/domain/services/static_export_service_test.dart
+++ b/test/unit/domain/services/static_export_service_test.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/services/static_export_service.dart';
+
+MediaItem _item({
+  required String id,
+  String title = 'Title',
+  String? coverUrl,
+  MediaType mediaType = MediaType.film,
+  List<String> tags = const [],
+  bool deleted = false,
+  int? year,
+}) =>
+    MediaItem(
+      id: id,
+      barcode: id,
+      barcodeType: 'EAN13',
+      mediaType: mediaType,
+      title: title,
+      coverUrl: coverUrl,
+      year: year,
+      deleted: deleted,
+      extraMetadata: tags.isEmpty ? const {} : {'tags': tags},
+      dateAdded: 0,
+      dateScanned: 0,
+      updatedAt: 0,
+    );
+
+String _asString(Uint8List bytes) => utf8.decode(bytes);
+
+void main() {
+  const service = StaticExportService();
+
+  test('produces index.html plus one detail page per item', () {
+    final out = service.build(items: [
+      _item(id: 'a'),
+      _item(id: 'b'),
+    ]);
+    expect(out.keys, unorderedEquals(['index.html', 'items/a.html', 'items/b.html']));
+  });
+
+  test('excludes soft-deleted items', () {
+    final out = service.build(items: [
+      _item(id: 'live'),
+      _item(id: 'gone', deleted: true),
+    ]);
+    expect(out.keys, unorderedEquals(['index.html', 'items/live.html']));
+  });
+
+  test('excludes items tagged with the private tag', () {
+    final out = service.build(items: [
+      _item(id: 'visible'),
+      _item(id: 'secret', tags: ['private']),
+    ]);
+    expect(out.keys, isNot(contains('items/secret.html')));
+    expect(_asString(out['index.html']!), isNot(contains('secret')));
+  });
+
+  test('uses custom private tag when overridden', () {
+    final out = service.build(
+      items: [_item(id: 'a', tags: ['nsfw'])],
+      options: const StaticExportOptions(privateTag: 'nsfw'),
+    );
+    expect(out.keys, ['index.html']);
+  });
+
+  test('HTML escapes item titles', () {
+    final out = service.build(
+      items: [_item(id: 'x', title: '<script>alert(1)</script>')],
+    );
+    final index = _asString(out['index.html']!);
+    expect(index, isNot(contains('<script>alert(1)</script>')));
+    expect(index, contains('&lt;script&gt;'));
+  });
+
+  test('references original coverUrl when not bundling', () {
+    final out = service.build(
+      items: [_item(id: 'a', coverUrl: 'https://example.com/a.jpg')],
+    );
+    expect(_asString(out['index.html']!),
+        contains('https://example.com/a.jpg'));
+  });
+
+  test('rewrites cover path when bundling covers', () {
+    final out = service.build(
+      items: [_item(id: 'a', coverUrl: 'https://example.com/a.jpg?foo')],
+      options: const StaticExportOptions(bundleCovers: true),
+    );
+    expect(_asString(out['index.html']!), contains('covers/a.jpg'));
+  });
+
+  test('media-type filter dropdown includes every present type', () {
+    final out = service.build(items: [
+      _item(id: 'a', mediaType: MediaType.film),
+      _item(id: 'b', mediaType: MediaType.book),
+    ]);
+    final index = _asString(out['index.html']!);
+    expect(index, contains('<option>Film</option>'));
+    expect(index, contains('<option>Book</option>'));
+  });
+
+  test('tag dropdown excludes the private tag', () {
+    final out = service.build(items: [
+      _item(id: 'a', tags: ['favourite']),
+      _item(id: 'b', tags: ['private', 'favourite']),
+    ]);
+    final index = _asString(out['index.html']!);
+    expect(index, contains('<option>favourite</option>'));
+    expect(index, isNot(contains('<option>private</option>')));
+  });
+
+  test('custom title appears in h1 and page title', () {
+    final out = service.build(
+      items: [_item(id: 'a')],
+      options: const StaticExportOptions(title: 'Paul\'s library'),
+    );
+    final index = _asString(out['index.html']!);
+    expect(index, contains('Paul&#39;s library'));
+  });
+
+  test('bundled covers map writes to covers/<key> verbatim', () {
+    final bytes = Uint8List.fromList(const [0x89, 0x50, 0x4e, 0x47]);
+    final out = service.build(
+      items: const [],
+      options: const StaticExportOptions(bundleCovers: true),
+      covers: {'a.jpg': bytes},
+    );
+    expect(out['covers/a.jpg'], bytes);
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a Static HTML Export feature under Settings that bundles the collection as a self-contained website (responsive index grid with type/tag/search filters, per-item detail pages, optional cover art bundling), with a private-tag opt-out and inline CSS/JS so the output needs no external dependencies to view.
- Fixes a pre-existing bug in the recommender where the ranker would return a recency-only ordering when the taste profile had no real signal; it now returns an empty list so the UI can show its neutral state.
- Stabilises the integration test harness: resets the top-level GoRouter singleton inside `pumpTestApp` so navigation doesn't leak between tests, replaces fixed-pixel scroll offsets in settings/lending/rips_enhancements tests with a drag-until-visible helper, and scopes the tags dialog's TextField finder so it no longer matches the Library SearchBar.

## Test plan

- [x] `flutter analyze` clean
- [x] `flutter test` — 1005 unit/widget tests pass (includes 11 new `StaticExportService` tests + 7 new `StaticExportWriter` tests)
- [x] All 16 integration test files pass on Linux (`flutter test integration_test/<file>.dart -d linux`)
- [x] Antora docs build clean (`gradle21w antora`) — new page `Static HTML Export` under Features
- [ ] Manual: open Settings > Export > Static HTML export, choose a folder, verify index.html renders correctly in a browser (with and without cover bundling)