### PR TITLE
feat: GnuDB metadata lookup for rip albums

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -29,6 +29,15 @@ abstract final class ApiConstants {
   // UPCitemdb
   static const upcItemDbBaseUrl = 'https://api.upcitemdb.com/prod/trial';
 
+  // GnuDB — CDDB-compatible disc metadata lookup. The service is HTTP only.
+  static const gnudbBaseUrl = 'http://gnudb.gnudb.org';
+  static const gnudbCgiPath = '/~cddb/cddb.cgi';
+  static const gnudbDefaultUser = 'mymediascanner';
+  static const gnudbClientName = 'MyMediaScanner';
+  static const gnudbClientVersion = '1.0';
+  static const gnudbUserAgent =
+      'MyMediaScanner/1.0 (https://github.com/bovinemagnet/MyMediaScanner)';
+
   // Cache
   static const cacheDurationDays = 7;
 }

--- a/lib/core/gnudb/cddb_disc_id_calculator.dart
+++ b/lib/core/gnudb/cddb_disc_id_calculator.dart
@@ -1,0 +1,80 @@
+/// Pure implementation of the CDDB Disc ID hashing algorithm used by GnuDB
+/// (and, historically, FreeDB). Given per-track LBA frame offsets and the
+/// leadout frame offset, produces an 8-character lowercase hexadecimal
+/// identifier.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+/// Calculator for CDDB Disc IDs.
+class CddbDiscIdCalculator {
+  const CddbDiscIdCalculator._();
+
+  /// Frames per second on a CD (constant: 75 frames = 1 second).
+  static const int framesPerSecond = 75;
+
+  /// Returns the sum of the decimal digits of [n].
+  ///
+  /// Example: `cddbSum(123)` returns `6`. Negative inputs are treated as
+  /// their absolute value; zero returns zero.
+  static int cddbSum(int n) {
+    var x = n.abs();
+    var sum = 0;
+    if (x == 0) return 0;
+    while (x > 0) {
+      sum += x % 10;
+      x ~/= 10;
+    }
+    return sum;
+  }
+
+  /// Computes the CDDB Disc ID.
+  ///
+  /// [frameOffsets] contains the starting LBA frame offset of each track,
+  /// including the conventional 150-frame (2-second) pregap baked in — i.e.
+  /// track 1 normally starts at frame 150. Offsets must be strictly
+  /// ascending.
+  ///
+  /// [leadoutFrame] is the LBA frame offset of the leadout (one past the
+  /// final sample). Must be strictly greater than the last track offset.
+  ///
+  /// Returns the Disc ID as eight lowercase hexadecimal characters.
+  static String calculate({
+    required List<int> frameOffsets,
+    required int leadoutFrame,
+  }) {
+    if (frameOffsets.isEmpty) {
+      throw ArgumentError.value(
+          frameOffsets, 'frameOffsets', 'must not be empty');
+    }
+    for (var i = 1; i < frameOffsets.length; i++) {
+      if (frameOffsets[i] <= frameOffsets[i - 1]) {
+        throw ArgumentError.value(
+            frameOffsets, 'frameOffsets', 'must be strictly ascending');
+      }
+    }
+    if (leadoutFrame <= frameOffsets.last) {
+      throw ArgumentError.value(leadoutFrame, 'leadoutFrame',
+          'must be strictly greater than the last track offset');
+    }
+
+    final numTracks = frameOffsets.length;
+    final firstOffsetSeconds = frameOffsets.first ~/ framesPerSecond;
+    final leadoutSeconds = leadoutFrame ~/ framesPerSecond;
+
+    var n = 0;
+    for (final frameOffset in frameOffsets) {
+      final seconds = frameOffset ~/ framesPerSecond;
+      n += cddbSum(seconds);
+    }
+
+    final t = leadoutSeconds - firstOffsetSeconds;
+    final topByte = n % 255;
+    final discId = ((topByte & 0xFF) << 24) |
+        ((t & 0xFFFF) << 8) |
+        (numTracks & 0xFF);
+
+    return discId.toRadixString(16).padLeft(8, '0').toLowerCase();
+  }
+}

--- a/lib/core/gnudb/cue_frame_offsets_parser.dart
+++ b/lib/core/gnudb/cue_frame_offsets_parser.dart
@@ -1,0 +1,135 @@
+/// Parses INDEX 01 offsets from a CUE sheet for CDDB Disc ID computation.
+///
+/// The `dart_cue` package exposes track-level metadata (titles, durations)
+/// but does not surface raw `INDEX 01 MM:SS:FF` offsets in a stable way.
+/// Those raw offsets are what the CDDB algorithm needs, so this small
+/// dedicated parser reads them directly from the CUE text.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'dart:io';
+
+/// A per-track INDEX 01 offset extracted from a CUE sheet.
+class CueTrackOffset {
+  const CueTrackOffset({
+    required this.trackNumber,
+    required this.filePath,
+    required this.inFileFrameOffset,
+  });
+
+  /// 1-based track number as declared in the CUE sheet.
+  final int trackNumber;
+
+  /// Path to the audio file this track lives in, relative to the CUE.
+  final String filePath;
+
+  /// Frames from the start of [filePath] to the INDEX 01 position.
+  /// 75 frames = 1 second.
+  final int inFileFrameOffset;
+
+  @override
+  String toString() =>
+      'CueTrackOffset(track: $trackNumber, file: $filePath, frames: $inFileFrameOffset)';
+}
+
+/// Parser for extracting INDEX 01 offsets from CUE sheets.
+class CueFrameOffsetsParser {
+  const CueFrameOffsetsParser._();
+
+  static final RegExp _fileLine =
+      RegExp(r'^\s*FILE\s+(?:"([^"]+)"|(\S+))(?:\s+\w+)?\s*$');
+  static final RegExp _trackLine =
+      RegExp(r'^\s*TRACK\s+(\d+)\s+(\S+)\s*$');
+  static final RegExp _indexLine =
+      RegExp(r'^\s*INDEX\s+(\d+)\s+(\d+):(\d+):(\d+)\s*$');
+
+  /// Converts an MM:SS:FF triple (as found in CUE INDEX lines) to absolute
+  /// frames. Each second contains 75 frames.
+  static int msfToFrames(int minutes, int seconds, int frames) {
+    return ((minutes * 60) + seconds) * 75 + frames;
+  }
+
+  /// Parses [cueText] and returns the INDEX 01 offset for every audio
+  /// track, in declared order.
+  ///
+  /// Throws a [FormatException] if a TRACK ... AUDIO block lacks an
+  /// INDEX 01. Non-AUDIO tracks (data tracks) are skipped.
+  static List<CueTrackOffset> parse(String cueText) {
+    final result = <CueTrackOffset>[];
+    final lines = cueText.split(RegExp(r'\r?\n'));
+
+    String? currentFile;
+    int? pendingTrackNumber;
+    bool pendingIsAudio = false;
+    int? pendingIndex01;
+
+    void flushPending() {
+      final trackNumber = pendingTrackNumber;
+      final index01 = pendingIndex01;
+      final file = currentFile;
+      if (trackNumber != null) {
+        if (pendingIsAudio) {
+          if (index01 == null) {
+            throw FormatException(
+                'Track $trackNumber has no INDEX 01 entry');
+          }
+          if (file == null) {
+            throw FormatException(
+                'Track $trackNumber declared before any FILE');
+          }
+          result.add(CueTrackOffset(
+            trackNumber: trackNumber,
+            filePath: file,
+            inFileFrameOffset: index01,
+          ));
+        }
+      }
+      pendingTrackNumber = null;
+      pendingIsAudio = false;
+      pendingIndex01 = null;
+    }
+
+    for (final rawLine in lines) {
+      final line = rawLine;
+
+      final fileMatch = _fileLine.firstMatch(line);
+      if (fileMatch != null) {
+        flushPending();
+        currentFile = fileMatch.group(1) ?? fileMatch.group(2);
+        continue;
+      }
+
+      final trackMatch = _trackLine.firstMatch(line);
+      if (trackMatch != null) {
+        flushPending();
+        pendingTrackNumber = int.parse(trackMatch.group(1)!);
+        pendingIsAudio = trackMatch.group(2)!.toUpperCase() == 'AUDIO';
+        continue;
+      }
+
+      final indexMatch = _indexLine.firstMatch(line);
+      if (indexMatch != null && pendingTrackNumber != null) {
+        final indexNum = int.parse(indexMatch.group(1)!);
+        if (indexNum == 1) {
+          pendingIndex01 = msfToFrames(
+            int.parse(indexMatch.group(2)!),
+            int.parse(indexMatch.group(3)!),
+            int.parse(indexMatch.group(4)!),
+          );
+        }
+        continue;
+      }
+    }
+
+    flushPending();
+    return result;
+  }
+
+  /// Reads the CUE file at [cuePath] from disk and parses it.
+  static Future<List<CueTrackOffset>> parseFile(String cuePath) async {
+    final text = await File(cuePath).readAsString();
+    return parse(text);
+  }
+}

--- a/lib/data/local/dao/rip_library_dao.dart
+++ b/lib/data/local/dao/rip_library_dao.dart
@@ -141,6 +141,16 @@ class RipLibraryDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
+  /// Update the GnuDB Disc ID on an album.
+  Future<void> updateGnudbDiscId(String ripAlbumId, String? discId) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return (update(ripAlbumsTable)..where((t) => t.id.equals(ripAlbumId)))
+        .write(RipAlbumsTableCompanion(
+      gnudbDiscId: Value(discId),
+      updatedAt: Value(now),
+    ));
+  }
+
   /// Update the title of a single track.
   Future<void> updateTrackTitle(String trackId, String? title) {
     final now = DateTime.now().millisecondsSinceEpoch;

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -84,7 +84,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 15;
+  int get schemaVersion => 16;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(

--- a/lib/data/local/database/app_database.g.dart
+++ b/lib/data/local/database/app_database.g.dart
@@ -5528,6 +5528,17 @@ class $RipAlbumsTableTable extends RipAlbumsTable
     type: DriftSqlType.string,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _gnudbDiscIdMeta = const VerificationMeta(
+    'gnudbDiscId',
+  );
+  @override
+  late final GeneratedColumn<String> gnudbDiscId = GeneratedColumn<String>(
+    'gnudb_disc_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _deletedMeta = const VerificationMeta(
     'deleted',
   );
@@ -5554,6 +5565,7 @@ class $RipAlbumsTableTable extends RipAlbumsTable
     lastScannedAt,
     updatedAt,
     cueFilePath,
+    gnudbDiscId,
     deleted,
   ];
   @override
@@ -5664,6 +5676,15 @@ class $RipAlbumsTableTable extends RipAlbumsTable
         ),
       );
     }
+    if (data.containsKey('gnudb_disc_id')) {
+      context.handle(
+        _gnudbDiscIdMeta,
+        gnudbDiscId.isAcceptableOrUnknown(
+          data['gnudb_disc_id']!,
+          _gnudbDiscIdMeta,
+        ),
+      );
+    }
     if (data.containsKey('deleted')) {
       context.handle(
         _deletedMeta,
@@ -5727,6 +5748,10 @@ class $RipAlbumsTableTable extends RipAlbumsTable
         DriftSqlType.string,
         data['${effectivePrefix}cue_file_path'],
       ),
+      gnudbDiscId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}gnudb_disc_id'],
+      ),
       deleted: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
         data['${effectivePrefix}deleted'],
@@ -5754,6 +5779,7 @@ class RipAlbumsTableData extends DataClass
   final int lastScannedAt;
   final int updatedAt;
   final String? cueFilePath;
+  final String? gnudbDiscId;
   final int deleted;
   const RipAlbumsTableData({
     required this.id,
@@ -5768,6 +5794,7 @@ class RipAlbumsTableData extends DataClass
     required this.lastScannedAt,
     required this.updatedAt,
     this.cueFilePath,
+    this.gnudbDiscId,
     required this.deleted,
   });
   @override
@@ -5794,6 +5821,9 @@ class RipAlbumsTableData extends DataClass
     map['updated_at'] = Variable<int>(updatedAt);
     if (!nullToAbsent || cueFilePath != null) {
       map['cue_file_path'] = Variable<String>(cueFilePath);
+    }
+    if (!nullToAbsent || gnudbDiscId != null) {
+      map['gnudb_disc_id'] = Variable<String>(gnudbDiscId);
     }
     map['deleted'] = Variable<int>(deleted);
     return map;
@@ -5823,6 +5853,9 @@ class RipAlbumsTableData extends DataClass
       cueFilePath: cueFilePath == null && nullToAbsent
           ? const Value.absent()
           : Value(cueFilePath),
+      gnudbDiscId: gnudbDiscId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(gnudbDiscId),
       deleted: Value(deleted),
     );
   }
@@ -5845,6 +5878,7 @@ class RipAlbumsTableData extends DataClass
       lastScannedAt: serializer.fromJson<int>(json['lastScannedAt']),
       updatedAt: serializer.fromJson<int>(json['updatedAt']),
       cueFilePath: serializer.fromJson<String?>(json['cueFilePath']),
+      gnudbDiscId: serializer.fromJson<String?>(json['gnudbDiscId']),
       deleted: serializer.fromJson<int>(json['deleted']),
     );
   }
@@ -5864,6 +5898,7 @@ class RipAlbumsTableData extends DataClass
       'lastScannedAt': serializer.toJson<int>(lastScannedAt),
       'updatedAt': serializer.toJson<int>(updatedAt),
       'cueFilePath': serializer.toJson<String?>(cueFilePath),
+      'gnudbDiscId': serializer.toJson<String?>(gnudbDiscId),
       'deleted': serializer.toJson<int>(deleted),
     };
   }
@@ -5881,6 +5916,7 @@ class RipAlbumsTableData extends DataClass
     int? lastScannedAt,
     int? updatedAt,
     Value<String?> cueFilePath = const Value.absent(),
+    Value<String?> gnudbDiscId = const Value.absent(),
     int? deleted,
   }) => RipAlbumsTableData(
     id: id ?? this.id,
@@ -5895,6 +5931,7 @@ class RipAlbumsTableData extends DataClass
     lastScannedAt: lastScannedAt ?? this.lastScannedAt,
     updatedAt: updatedAt ?? this.updatedAt,
     cueFilePath: cueFilePath.present ? cueFilePath.value : this.cueFilePath,
+    gnudbDiscId: gnudbDiscId.present ? gnudbDiscId.value : this.gnudbDiscId,
     deleted: deleted ?? this.deleted,
   );
   RipAlbumsTableData copyWithCompanion(RipAlbumsTableCompanion data) {
@@ -5925,6 +5962,9 @@ class RipAlbumsTableData extends DataClass
       cueFilePath: data.cueFilePath.present
           ? data.cueFilePath.value
           : this.cueFilePath,
+      gnudbDiscId: data.gnudbDiscId.present
+          ? data.gnudbDiscId.value
+          : this.gnudbDiscId,
       deleted: data.deleted.present ? data.deleted.value : this.deleted,
     );
   }
@@ -5944,6 +5984,7 @@ class RipAlbumsTableData extends DataClass
           ..write('lastScannedAt: $lastScannedAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('cueFilePath: $cueFilePath, ')
+          ..write('gnudbDiscId: $gnudbDiscId, ')
           ..write('deleted: $deleted')
           ..write(')'))
         .toString();
@@ -5963,6 +6004,7 @@ class RipAlbumsTableData extends DataClass
     lastScannedAt,
     updatedAt,
     cueFilePath,
+    gnudbDiscId,
     deleted,
   );
   @override
@@ -5981,6 +6023,7 @@ class RipAlbumsTableData extends DataClass
           other.lastScannedAt == this.lastScannedAt &&
           other.updatedAt == this.updatedAt &&
           other.cueFilePath == this.cueFilePath &&
+          other.gnudbDiscId == this.gnudbDiscId &&
           other.deleted == this.deleted);
 }
 
@@ -5997,6 +6040,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
   final Value<int> lastScannedAt;
   final Value<int> updatedAt;
   final Value<String?> cueFilePath;
+  final Value<String?> gnudbDiscId;
   final Value<int> deleted;
   final Value<int> rowid;
   const RipAlbumsTableCompanion({
@@ -6012,6 +6056,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
     this.lastScannedAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
     this.cueFilePath = const Value.absent(),
+    this.gnudbDiscId = const Value.absent(),
     this.deleted = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -6028,6 +6073,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
     required int lastScannedAt,
     required int updatedAt,
     this.cueFilePath = const Value.absent(),
+    this.gnudbDiscId = const Value.absent(),
     this.deleted = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
@@ -6049,6 +6095,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
     Expression<int>? lastScannedAt,
     Expression<int>? updatedAt,
     Expression<String>? cueFilePath,
+    Expression<String>? gnudbDiscId,
     Expression<int>? deleted,
     Expression<int>? rowid,
   }) {
@@ -6065,6 +6112,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
       if (lastScannedAt != null) 'last_scanned_at': lastScannedAt,
       if (updatedAt != null) 'updated_at': updatedAt,
       if (cueFilePath != null) 'cue_file_path': cueFilePath,
+      if (gnudbDiscId != null) 'gnudb_disc_id': gnudbDiscId,
       if (deleted != null) 'deleted': deleted,
       if (rowid != null) 'rowid': rowid,
     });
@@ -6083,6 +6131,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
     Value<int>? lastScannedAt,
     Value<int>? updatedAt,
     Value<String?>? cueFilePath,
+    Value<String?>? gnudbDiscId,
     Value<int>? deleted,
     Value<int>? rowid,
   }) {
@@ -6099,6 +6148,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
       lastScannedAt: lastScannedAt ?? this.lastScannedAt,
       updatedAt: updatedAt ?? this.updatedAt,
       cueFilePath: cueFilePath ?? this.cueFilePath,
+      gnudbDiscId: gnudbDiscId ?? this.gnudbDiscId,
       deleted: deleted ?? this.deleted,
       rowid: rowid ?? this.rowid,
     );
@@ -6143,6 +6193,9 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
     if (cueFilePath.present) {
       map['cue_file_path'] = Variable<String>(cueFilePath.value);
     }
+    if (gnudbDiscId.present) {
+      map['gnudb_disc_id'] = Variable<String>(gnudbDiscId.value);
+    }
     if (deleted.present) {
       map['deleted'] = Variable<int>(deleted.value);
     }
@@ -6167,6 +6220,7 @@ class RipAlbumsTableCompanion extends UpdateCompanion<RipAlbumsTableData> {
           ..write('lastScannedAt: $lastScannedAt, ')
           ..write('updatedAt: $updatedAt, ')
           ..write('cueFilePath: $cueFilePath, ')
+          ..write('gnudbDiscId: $gnudbDiscId, ')
           ..write('deleted: $deleted, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -14172,6 +14226,7 @@ typedef $$RipAlbumsTableTableCreateCompanionBuilder =
       required int lastScannedAt,
       required int updatedAt,
       Value<String?> cueFilePath,
+      Value<String?> gnudbDiscId,
       Value<int> deleted,
       Value<int> rowid,
     });
@@ -14189,6 +14244,7 @@ typedef $$RipAlbumsTableTableUpdateCompanionBuilder =
       Value<int> lastScannedAt,
       Value<int> updatedAt,
       Value<String?> cueFilePath,
+      Value<String?> gnudbDiscId,
       Value<int> deleted,
       Value<int> rowid,
     });
@@ -14314,6 +14370,11 @@ class $$RipAlbumsTableTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<String> get gnudbDiscId => $composableBuilder(
+    column: $table.gnudbDiscId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<int> get deleted => $composableBuilder(
     column: $table.deleted,
     builder: (column) => ColumnFilters(column),
@@ -14432,6 +14493,11 @@ class $$RipAlbumsTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get gnudbDiscId => $composableBuilder(
+    column: $table.gnudbDiscId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<int> get deleted => $composableBuilder(
     column: $table.deleted,
     builder: (column) => ColumnOrderings(column),
@@ -14512,6 +14578,11 @@ class $$RipAlbumsTableTableAnnotationComposer
 
   GeneratedColumn<String> get cueFilePath => $composableBuilder(
     column: $table.cueFilePath,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get gnudbDiscId => $composableBuilder(
+    column: $table.gnudbDiscId,
     builder: (column) => column,
   );
 
@@ -14609,6 +14680,7 @@ class $$RipAlbumsTableTableTableManager
                 Value<int> lastScannedAt = const Value.absent(),
                 Value<int> updatedAt = const Value.absent(),
                 Value<String?> cueFilePath = const Value.absent(),
+                Value<String?> gnudbDiscId = const Value.absent(),
                 Value<int> deleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => RipAlbumsTableCompanion(
@@ -14624,6 +14696,7 @@ class $$RipAlbumsTableTableTableManager
                 lastScannedAt: lastScannedAt,
                 updatedAt: updatedAt,
                 cueFilePath: cueFilePath,
+                gnudbDiscId: gnudbDiscId,
                 deleted: deleted,
                 rowid: rowid,
               ),
@@ -14641,6 +14714,7 @@ class $$RipAlbumsTableTableTableManager
                 required int lastScannedAt,
                 required int updatedAt,
                 Value<String?> cueFilePath = const Value.absent(),
+                Value<String?> gnudbDiscId = const Value.absent(),
                 Value<int> deleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => RipAlbumsTableCompanion.insert(
@@ -14656,6 +14730,7 @@ class $$RipAlbumsTableTableTableManager
                 lastScannedAt: lastScannedAt,
                 updatedAt: updatedAt,
                 cueFilePath: cueFilePath,
+                gnudbDiscId: gnudbDiscId,
                 deleted: deleted,
                 rowid: rowid,
               ),

--- a/lib/data/local/database/tables/rip_albums_table.dart
+++ b/lib/data/local/database/tables/rip_albums_table.dart
@@ -18,6 +18,7 @@ class RipAlbumsTable extends Table {
   IntColumn get lastScannedAt => integer()();
   IntColumn get updatedAt => integer()();
   TextColumn get cueFilePath => text().nullable()();
+  TextColumn get gnudbDiscId => text().nullable()();
   IntColumn get deleted => integer().withDefault(const Constant(0))();
 
   @override

--- a/lib/data/mappers/gnudb_mapper.dart
+++ b/lib/data/mappers/gnudb_mapper.dart
@@ -1,0 +1,65 @@
+/// Maps GnuDB DTOs into MyMediaScanner domain objects.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/metadata_candidate.dart';
+import 'package:mymediascanner/domain/entities/metadata_result.dart';
+
+/// Builds [MetadataResult]s and [MetadataCandidate]s from [GnudbDiscDto]s.
+abstract final class GnudbMapper {
+  /// Converts a fully-resolved GnuDB disc into a [MetadataResult].
+  ///
+  /// [category] is the GnuDB genre bucket the entry was found under (e.g.
+  /// `rock`, `classical`). It is retained in `extraMetadata` so it can be
+  /// round-tripped back to the API for re-reads.
+  static MetadataResult toMetadataResult(
+    GnudbDiscDto dto, {
+    required String category,
+  }) {
+    final trackListing = <Map<String, dynamic>>[
+      for (var i = 0; i < dto.trackTitles.length; i++)
+        {
+          'position': i + 1,
+          'title': dto.trackTitles[i],
+        },
+    ];
+
+    return MetadataResult(
+      barcode: 'gnudb:${dto.discId}',
+      barcodeType: 'cddb',
+      mediaType: MediaType.music,
+      title: dto.albumTitle,
+      subtitle: dto.artist,
+      year: dto.year,
+      genres: (dto.genre == null || dto.genre!.isEmpty) ? const [] : [dto.genre!],
+      extraMetadata: {
+        'gnudb_disc_id': dto.discId,
+        'gnudb_category': category,
+        'gnudb_track_titles': dto.trackTitles,
+        if (dto.extendedAlbum != null && dto.extendedAlbum!.isNotEmpty)
+          'gnudb_album_notes': dto.extendedAlbum,
+        'track_listing': trackListing,
+      },
+      sourceApis: const ['gnudb'],
+    );
+  }
+
+  /// Lighter-weight candidate used by disambiguation UIs.
+  static MetadataCandidate toCandidate(
+    GnudbDiscDto dto, {
+    required String category,
+  }) {
+    return MetadataCandidate(
+      sourceApi: 'gnudb',
+      sourceId: '$category:${dto.discId}',
+      title: dto.albumTitle,
+      subtitle: dto.artist,
+      year: dto.year,
+      mediaType: MediaType.music,
+    );
+  }
+}

--- a/lib/data/remote/api/dio_factory.dart
+++ b/lib/data/remote/api/dio_factory.dart
@@ -59,6 +59,32 @@ class DioFactory {
     );
   }
 
+  /// Creates a Dio instance configured for plain-text responses.
+  ///
+  /// Used for CDDB-style APIs like GnuDB whose wire format is plain text
+  /// rather than JSON.
+  static Dio createForPlainText({
+    required String baseUrl,
+    required String userAgent,
+  }) {
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: baseUrl,
+        connectTimeout: const Duration(seconds: 15),
+        receiveTimeout: const Duration(seconds: 15),
+        responseType: ResponseType.plain,
+        headers: {'User-Agent': userAgent},
+      ),
+    );
+    if (kDebugMode) {
+      dio.interceptors.add(LogInterceptor(
+        requestBody: false,
+        responseBody: false,
+      ));
+    }
+    return dio;
+  }
+
   /// Creates a Dio instance with a Bearer token header.
   static Dio createWithBearerToken({
     required String baseUrl,

--- a/lib/data/remote/api/gnudb/gnudb_api.dart
+++ b/lib/data/remote/api/gnudb/gnudb_api.dart
@@ -1,0 +1,98 @@
+/// HTTP client for the GnuDB CDDB server (gnudb.org).
+///
+/// Uses manual Dio calls because the wire format is plain text rather than
+/// JSON. Enforces CDDB protocol conventions on every request:
+///
+/// * `hello=<user> <host> <client-name> <client-version>` identifies the
+///   client to the server.
+/// * `proto=6` requests UTF-8 responses; lower protocol levels return
+///   legacy 8-bit encodings.
+///
+/// A 1.1-second rate limiter guards the public endpoint to keep within the
+/// community service's courtesy limits.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:dio/dio.dart';
+import 'package:mymediascanner/core/constants/api_constants.dart';
+import 'package:mymediascanner/core/utils/rate_limiter.dart';
+import 'package:mymediascanner/data/remote/api/dio_factory.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_response_parser.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+
+/// Thin wrapper over the GnuDB CDDB CGI endpoint.
+class GnudbApi {
+  GnudbApi({
+    Dio? dio,
+    RateLimiter? rateLimiter,
+    String user = ApiConstants.gnudbDefaultUser,
+    String host = 'localhost',
+  })  : _dio = dio ??
+            DioFactory.createForPlainText(
+              baseUrl: ApiConstants.gnudbBaseUrl,
+              userAgent: ApiConstants.gnudbUserAgent,
+            ),
+        _rateLimiter = rateLimiter ??
+            RateLimiter(minInterval: const Duration(milliseconds: 1100)),
+        _user = user,
+        _host = host;
+
+  final Dio _dio;
+  final RateLimiter _rateLimiter;
+  final String _user;
+  final String _host;
+
+  String get _hello =>
+      '$_user $_host ${ApiConstants.gnudbClientName} ${ApiConstants.gnudbClientVersion}';
+
+  /// Executes `cddb query` for the given Disc ID and TOC.
+  ///
+  /// [frameOffsets] must be LBA frame offsets (including the 150-frame
+  /// pregap) in declared track order. [totalSeconds] is the total disc
+  /// length in seconds.
+  Future<GnudbQueryResult> query({
+    required String discId,
+    required List<int> frameOffsets,
+    required int totalSeconds,
+  }) async {
+    await _rateLimiter.throttle();
+    final cmd = <String>[
+      'cddb query',
+      discId,
+      frameOffsets.length.toString(),
+      ...frameOffsets.map((f) => f.toString()),
+      totalSeconds.toString(),
+    ].join(' ');
+    final response = await _dio.get<String>(
+      ApiConstants.gnudbCgiPath,
+      queryParameters: {
+        'cmd': cmd,
+        'hello': _hello,
+        'proto': '6',
+      },
+    );
+    return GnudbResponseParser.parseQuery(response.data ?? '');
+  }
+
+  /// Executes `cddb read` for the given category and Disc ID.
+  ///
+  /// Returns `null` when the server replies with a non-success status.
+  Future<GnudbDiscDto?> read({
+    required String category,
+    required String discId,
+  }) async {
+    await _rateLimiter.throttle();
+    final cmd = 'cddb read $category $discId';
+    final response = await _dio.get<String>(
+      ApiConstants.gnudbCgiPath,
+      queryParameters: {
+        'cmd': cmd,
+        'hello': _hello,
+        'proto': '6',
+      },
+    );
+    return GnudbResponseParser.parseDisc(response.data ?? '');
+  }
+}

--- a/lib/data/remote/api/gnudb/gnudb_response_parser.dart
+++ b/lib/data/remote/api/gnudb/gnudb_response_parser.dart
@@ -1,0 +1,193 @@
+/// Parses CDDB text responses returned by a GnuDB server.
+///
+/// The CDDB wire format is plain text: a status line (three-digit code
+/// plus free-form message) optionally followed by a body terminated by a
+/// line containing only `.`. Query responses emit a single line (200) or a
+/// list of matches (210/211); read responses emit `KEY=VALUE` pairs.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_query_match.dart';
+
+/// Sealed result type for `parseQuery`.
+sealed class GnudbQueryResult {
+  const GnudbQueryResult();
+}
+
+/// Response code 200 — a single exact match.
+class GnudbQuerySingle extends GnudbQueryResult {
+  const GnudbQuerySingle(this.match);
+  final GnudbQueryMatch match;
+}
+
+/// Response code 210 or 211 — multiple matches to disambiguate between.
+class GnudbQueryMulti extends GnudbQueryResult {
+  const GnudbQueryMulti(this.matches);
+  final List<GnudbQueryMatch> matches;
+}
+
+/// Response code 202 — no match for the supplied Disc ID.
+class GnudbQueryNoMatch extends GnudbQueryResult {
+  const GnudbQueryNoMatch();
+}
+
+/// Any other response code (401, 403, 5xx…) or malformed body.
+class GnudbQueryError extends GnudbQueryResult {
+  const GnudbQueryError({required this.code, required this.message});
+  final int code;
+  final String message;
+}
+
+/// Parser for CDDB/GnuDB text responses.
+class GnudbResponseParser {
+  const GnudbResponseParser._();
+
+  static final RegExp _statusLine = RegExp(r'^(\d{3})\s*(.*)$');
+  static final RegExp _matchLine =
+      RegExp(r'^(\S+)\s+([0-9a-fA-F]{8})\s+(.*)$');
+
+  /// Parses the body of a `cddb query` response.
+  static GnudbQueryResult parseQuery(String body) {
+    if (body.trim().isEmpty) {
+      return const GnudbQueryError(
+          code: 0, message: 'Empty response body');
+    }
+
+    final lines = body.split(RegExp(r'\r?\n'));
+    final statusMatch = _statusLine.firstMatch(lines.first);
+    if (statusMatch == null) {
+      return GnudbQueryError(code: 0, message: 'Malformed status: ${lines.first}');
+    }
+    final code = int.parse(statusMatch.group(1)!);
+    final message = statusMatch.group(2) ?? '';
+
+    switch (code) {
+      case 200:
+        // The match is encoded on the status line itself: `200 cat disc title`.
+        final rest = message;
+        final m = _matchLine.firstMatch(rest);
+        if (m == null) {
+          return GnudbQueryError(
+              code: 200,
+              message: 'Could not parse 200 payload: $rest');
+        }
+        return GnudbQuerySingle(GnudbQueryMatch(
+          category: m.group(1)!,
+          discId: m.group(2)!.toLowerCase(),
+          title: m.group(3)!.trim(),
+        ));
+
+      case 210:
+      case 211:
+        final matches = <GnudbQueryMatch>[];
+        for (var i = 1; i < lines.length; i++) {
+          final line = lines[i];
+          if (line.trim() == '.') break;
+          if (line.trim().isEmpty) continue;
+          final m = _matchLine.firstMatch(line);
+          if (m != null) {
+            matches.add(GnudbQueryMatch(
+              category: m.group(1)!,
+              discId: m.group(2)!.toLowerCase(),
+              title: m.group(3)!.trim(),
+            ));
+          }
+        }
+        return GnudbQueryMulti(matches);
+
+      case 202:
+        return const GnudbQueryNoMatch();
+
+      default:
+        return GnudbQueryError(code: code, message: message);
+    }
+  }
+
+  /// Parses the body of a `cddb read` response. Returns `null` when the
+  /// status code is not a success (2xx).
+  static GnudbDiscDto? parseDisc(String body) {
+    final lines = body.split(RegExp(r'\r?\n'));
+    if (lines.isEmpty) return null;
+
+    final statusMatch = _statusLine.firstMatch(lines.first);
+    if (statusMatch == null) return null;
+    final code = int.parse(statusMatch.group(1)!);
+    if (code ~/ 100 != 2) return null;
+
+    // Pull discId from the status line where present: `210 cat discid ...`.
+    String? discIdFromStatus;
+    final statusParts = (statusMatch.group(2) ?? '').split(RegExp(r'\s+'));
+    if (statusParts.length >= 2 &&
+        RegExp(r'^[0-9a-fA-F]{8}$').hasMatch(statusParts[1])) {
+      discIdFromStatus = statusParts[1].toLowerCase();
+    }
+
+    final kv = <String, List<String>>{};
+    for (var i = 1; i < lines.length; i++) {
+      final line = lines[i];
+      if (line.trim() == '.') break;
+      if (line.startsWith('#') || line.trim().isEmpty) continue;
+
+      final eq = line.indexOf('=');
+      if (eq <= 0) continue;
+      final key = line.substring(0, eq);
+      final value = line.substring(eq + 1);
+      (kv[key] ??= []).add(value);
+    }
+
+    String? joined(String key) {
+      final parts = kv[key];
+      if (parts == null || parts.isEmpty) return null;
+      return parts.join('');
+    }
+
+    final discId = joined('DISCID')?.toLowerCase() ?? discIdFromStatus;
+    if (discId == null) return null;
+
+    final dtitle = joined('DTITLE') ?? '';
+    String artist;
+    String albumTitle;
+    final slash = dtitle.indexOf(' / ');
+    if (slash >= 0) {
+      artist = dtitle.substring(0, slash).trim();
+      albumTitle = dtitle.substring(slash + 3).trim();
+    } else {
+      artist = dtitle.trim();
+      albumTitle = dtitle.trim();
+    }
+
+    final yearStr = joined('DYEAR')?.trim();
+    int? year;
+    if (yearStr != null && yearStr.isNotEmpty) {
+      year = int.tryParse(yearStr);
+    }
+
+    final genre = joined('DGENRE')?.trim();
+
+    final trackTitles = <String>[];
+    for (var i = 0;; i++) {
+      final title = joined('TTITLE$i');
+      if (title == null) break;
+      trackTitles.add(title);
+    }
+
+    final extTracks = <String>[];
+    for (var i = 0; i < trackTitles.length; i++) {
+      extTracks.add(joined('EXTT$i') ?? '');
+    }
+
+    return GnudbDiscDto(
+      discId: discId,
+      artist: artist,
+      albumTitle: albumTitle,
+      year: year,
+      genre: (genre == null || genre.isEmpty) ? null : genre,
+      trackTitles: trackTitles,
+      extendedAlbum: joined('EXTD'),
+      extendedTracks: extTracks,
+    );
+  }
+}

--- a/lib/data/remote/api/gnudb/models/gnudb_disc_dto.dart
+++ b/lib/data/remote/api/gnudb/models/gnudb_disc_dto.dart
@@ -1,0 +1,47 @@
+/// The metadata body returned by a CDDB `cddb read` request.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+/// Parsed disc-level metadata from a GnuDB read response.
+class GnudbDiscDto {
+  const GnudbDiscDto({
+    required this.discId,
+    required this.artist,
+    required this.albumTitle,
+    required this.trackTitles,
+    this.year,
+    this.genre,
+    this.extendedAlbum,
+    this.extendedTracks = const [],
+  });
+
+  /// Disc identifier this metadata is for (8-char hex).
+  final String discId;
+
+  /// Artist portion of `DTITLE` (before the `/`). Falls back to the whole
+  /// DTITLE when no slash is present.
+  final String artist;
+
+  /// Album portion of `DTITLE` (after the `/`). Falls back to the whole
+  /// DTITLE when no slash is present.
+  final String albumTitle;
+
+  /// Parsed `DYEAR` value. `null` when absent or unparseable.
+  final int? year;
+
+  /// Parsed `DGENRE` value. `null` when absent or empty.
+  final String? genre;
+
+  /// Per-track titles from `TTITLE0..TTITLEn`, in index order. Continuation
+  /// lines (a repeated key) are joined per the CDDB protocol.
+  final List<String> trackTitles;
+
+  /// Parsed `EXTD` album-level notes.
+  final String? extendedAlbum;
+
+  /// Parsed `EXTT0..EXTTn` per-track notes, in index order. Empty strings
+  /// are preserved to keep alignment with [trackTitles].
+  final List<String> extendedTracks;
+}

--- a/lib/data/remote/api/gnudb/models/gnudb_query_match.dart
+++ b/lib/data/remote/api/gnudb/models/gnudb_query_match.dart
@@ -1,0 +1,37 @@
+/// A single match from a CDDB `cddb query` response.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+/// One candidate returned by a GnuDB query.
+class GnudbQueryMatch {
+  const GnudbQueryMatch({
+    required this.category,
+    required this.discId,
+    required this.title,
+  });
+
+  /// Category (genre bucket) the match lives in — e.g. `rock`, `classical`.
+  final String category;
+
+  /// 8-character hex CDDB Disc ID (may differ from the queried ID for 211
+  /// inexact matches).
+  final String discId;
+
+  /// The concatenated "Artist / Album" title field.
+  final String title;
+
+  @override
+  String toString() => 'GnudbQueryMatch($category $discId $title)';
+
+  @override
+  bool operator ==(Object other) =>
+      other is GnudbQueryMatch &&
+      other.category == category &&
+      other.discId == discId &&
+      other.title == title;
+
+  @override
+  int get hashCode => Object.hash(category, discId, title);
+}

--- a/lib/data/repositories/rip_library_repository_impl.dart
+++ b/lib/data/repositories/rip_library_repository_impl.dart
@@ -42,6 +42,7 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
       totalSizeBytes: Value(album.totalSizeBytes),
       mediaItemId: Value(album.mediaItemId),
       cueFilePath: Value(album.cueFilePath),
+      gnudbDiscId: Value(album.gnudbDiscId),
       lastScannedAt: Value(album.lastScannedAt),
       updatedAt: Value(album.updatedAt),
     ));
@@ -60,9 +61,15 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
       totalSizeBytes: Value(album.totalSizeBytes),
       mediaItemId: Value(album.mediaItemId),
       cueFilePath: Value(album.cueFilePath),
+      gnudbDiscId: Value(album.gnudbDiscId),
       lastScannedAt: Value(album.lastScannedAt),
       updatedAt: Value(album.updatedAt),
     ));
+  }
+
+  @override
+  Future<void> updateGnudbDiscId(String ripAlbumId, String? discId) async {
+    await _dao.updateGnudbDiscId(ripAlbumId, discId);
   }
 
   @override
@@ -142,6 +149,7 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
         totalSizeBytes: row.totalSizeBytes,
         mediaItemId: row.mediaItemId,
         cueFilePath: row.cueFilePath,
+        gnudbDiscId: row.gnudbDiscId,
         lastScannedAt: row.lastScannedAt,
         updatedAt: row.updatedAt,
         deleted: row.deleted == 1,

--- a/lib/domain/entities/rip_album.dart
+++ b/lib/domain/entities/rip_album.dart
@@ -15,6 +15,7 @@ sealed class RipAlbum with _$RipAlbum {
     required int totalSizeBytes,
     String? mediaItemId,
     String? cueFilePath,
+    String? gnudbDiscId,
     required int lastScannedAt,
     required int updatedAt,
     @Default(false) bool deleted,

--- a/lib/domain/entities/rip_album.freezed.dart
+++ b/lib/domain/entities/rip_album.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$RipAlbum {
 
- String get id; String get libraryPath; String? get artist; String? get albumTitle; String? get barcode; int get trackCount; int get discCount; int get totalSizeBytes; String? get mediaItemId; String? get cueFilePath; int get lastScannedAt; int get updatedAt; bool get deleted;
+ String get id; String get libraryPath; String? get artist; String? get albumTitle; String? get barcode; int get trackCount; int get discCount; int get totalSizeBytes; String? get mediaItemId; String? get cueFilePath; String? get gnudbDiscId; int get lastScannedAt; int get updatedAt; bool get deleted;
 /// Create a copy of RipAlbum
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $RipAlbumCopyWith<RipAlbum> get copyWith => _$RipAlbumCopyWithImpl<RipAlbum>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RipAlbum&&(identical(other.id, id) || other.id == id)&&(identical(other.libraryPath, libraryPath) || other.libraryPath == libraryPath)&&(identical(other.artist, artist) || other.artist == artist)&&(identical(other.albumTitle, albumTitle) || other.albumTitle == albumTitle)&&(identical(other.barcode, barcode) || other.barcode == barcode)&&(identical(other.trackCount, trackCount) || other.trackCount == trackCount)&&(identical(other.discCount, discCount) || other.discCount == discCount)&&(identical(other.totalSizeBytes, totalSizeBytes) || other.totalSizeBytes == totalSizeBytes)&&(identical(other.mediaItemId, mediaItemId) || other.mediaItemId == mediaItemId)&&(identical(other.cueFilePath, cueFilePath) || other.cueFilePath == cueFilePath)&&(identical(other.lastScannedAt, lastScannedAt) || other.lastScannedAt == lastScannedAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deleted, deleted) || other.deleted == deleted));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RipAlbum&&(identical(other.id, id) || other.id == id)&&(identical(other.libraryPath, libraryPath) || other.libraryPath == libraryPath)&&(identical(other.artist, artist) || other.artist == artist)&&(identical(other.albumTitle, albumTitle) || other.albumTitle == albumTitle)&&(identical(other.barcode, barcode) || other.barcode == barcode)&&(identical(other.trackCount, trackCount) || other.trackCount == trackCount)&&(identical(other.discCount, discCount) || other.discCount == discCount)&&(identical(other.totalSizeBytes, totalSizeBytes) || other.totalSizeBytes == totalSizeBytes)&&(identical(other.mediaItemId, mediaItemId) || other.mediaItemId == mediaItemId)&&(identical(other.cueFilePath, cueFilePath) || other.cueFilePath == cueFilePath)&&(identical(other.gnudbDiscId, gnudbDiscId) || other.gnudbDiscId == gnudbDiscId)&&(identical(other.lastScannedAt, lastScannedAt) || other.lastScannedAt == lastScannedAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deleted, deleted) || other.deleted == deleted));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,id,libraryPath,artist,albumTitle,barcode,trackCount,discCount,totalSizeBytes,mediaItemId,cueFilePath,lastScannedAt,updatedAt,deleted);
+int get hashCode => Object.hash(runtimeType,id,libraryPath,artist,albumTitle,barcode,trackCount,discCount,totalSizeBytes,mediaItemId,cueFilePath,gnudbDiscId,lastScannedAt,updatedAt,deleted);
 
 @override
 String toString() {
-  return 'RipAlbum(id: $id, libraryPath: $libraryPath, artist: $artist, albumTitle: $albumTitle, barcode: $barcode, trackCount: $trackCount, discCount: $discCount, totalSizeBytes: $totalSizeBytes, mediaItemId: $mediaItemId, cueFilePath: $cueFilePath, lastScannedAt: $lastScannedAt, updatedAt: $updatedAt, deleted: $deleted)';
+  return 'RipAlbum(id: $id, libraryPath: $libraryPath, artist: $artist, albumTitle: $albumTitle, barcode: $barcode, trackCount: $trackCount, discCount: $discCount, totalSizeBytes: $totalSizeBytes, mediaItemId: $mediaItemId, cueFilePath: $cueFilePath, gnudbDiscId: $gnudbDiscId, lastScannedAt: $lastScannedAt, updatedAt: $updatedAt, deleted: $deleted)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $RipAlbumCopyWith<$Res>  {
   factory $RipAlbumCopyWith(RipAlbum value, $Res Function(RipAlbum) _then) = _$RipAlbumCopyWithImpl;
 @useResult
 $Res call({
- String id, String libraryPath, String? artist, String? albumTitle, String? barcode, int trackCount, int discCount, int totalSizeBytes, String? mediaItemId, String? cueFilePath, int lastScannedAt, int updatedAt, bool deleted
+ String id, String libraryPath, String? artist, String? albumTitle, String? barcode, int trackCount, int discCount, int totalSizeBytes, String? mediaItemId, String? cueFilePath, String? gnudbDiscId, int lastScannedAt, int updatedAt, bool deleted
 });
 
 
@@ -62,7 +62,7 @@ class _$RipAlbumCopyWithImpl<$Res>
 
 /// Create a copy of RipAlbum
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? libraryPath = null,Object? artist = freezed,Object? albumTitle = freezed,Object? barcode = freezed,Object? trackCount = null,Object? discCount = null,Object? totalSizeBytes = null,Object? mediaItemId = freezed,Object? cueFilePath = freezed,Object? lastScannedAt = null,Object? updatedAt = null,Object? deleted = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? libraryPath = null,Object? artist = freezed,Object? albumTitle = freezed,Object? barcode = freezed,Object? trackCount = null,Object? discCount = null,Object? totalSizeBytes = null,Object? mediaItemId = freezed,Object? cueFilePath = freezed,Object? gnudbDiscId = freezed,Object? lastScannedAt = null,Object? updatedAt = null,Object? deleted = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,libraryPath: null == libraryPath ? _self.libraryPath : libraryPath // ignore: cast_nullable_to_non_nullable
@@ -74,6 +74,7 @@ as int,discCount: null == discCount ? _self.discCount : discCount // ignore: cas
 as int,totalSizeBytes: null == totalSizeBytes ? _self.totalSizeBytes : totalSizeBytes // ignore: cast_nullable_to_non_nullable
 as int,mediaItemId: freezed == mediaItemId ? _self.mediaItemId : mediaItemId // ignore: cast_nullable_to_non_nullable
 as String?,cueFilePath: freezed == cueFilePath ? _self.cueFilePath : cueFilePath // ignore: cast_nullable_to_non_nullable
+as String?,gnudbDiscId: freezed == gnudbDiscId ? _self.gnudbDiscId : gnudbDiscId // ignore: cast_nullable_to_non_nullable
 as String?,lastScannedAt: null == lastScannedAt ? _self.lastScannedAt : lastScannedAt // ignore: cast_nullable_to_non_nullable
 as int,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as int,deleted: null == deleted ? _self.deleted : deleted // ignore: cast_nullable_to_non_nullable
@@ -159,10 +160,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String libraryPath,  String? artist,  String? albumTitle,  String? barcode,  int trackCount,  int discCount,  int totalSizeBytes,  String? mediaItemId,  String? cueFilePath,  int lastScannedAt,  int updatedAt,  bool deleted)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String libraryPath,  String? artist,  String? albumTitle,  String? barcode,  int trackCount,  int discCount,  int totalSizeBytes,  String? mediaItemId,  String? cueFilePath,  String? gnudbDiscId,  int lastScannedAt,  int updatedAt,  bool deleted)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _RipAlbum() when $default != null:
-return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.barcode,_that.trackCount,_that.discCount,_that.totalSizeBytes,_that.mediaItemId,_that.cueFilePath,_that.lastScannedAt,_that.updatedAt,_that.deleted);case _:
+return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.barcode,_that.trackCount,_that.discCount,_that.totalSizeBytes,_that.mediaItemId,_that.cueFilePath,_that.gnudbDiscId,_that.lastScannedAt,_that.updatedAt,_that.deleted);case _:
   return orElse();
 
 }
@@ -180,10 +181,10 @@ return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.b
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String libraryPath,  String? artist,  String? albumTitle,  String? barcode,  int trackCount,  int discCount,  int totalSizeBytes,  String? mediaItemId,  String? cueFilePath,  int lastScannedAt,  int updatedAt,  bool deleted)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String libraryPath,  String? artist,  String? albumTitle,  String? barcode,  int trackCount,  int discCount,  int totalSizeBytes,  String? mediaItemId,  String? cueFilePath,  String? gnudbDiscId,  int lastScannedAt,  int updatedAt,  bool deleted)  $default,) {final _that = this;
 switch (_that) {
 case _RipAlbum():
-return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.barcode,_that.trackCount,_that.discCount,_that.totalSizeBytes,_that.mediaItemId,_that.cueFilePath,_that.lastScannedAt,_that.updatedAt,_that.deleted);}
+return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.barcode,_that.trackCount,_that.discCount,_that.totalSizeBytes,_that.mediaItemId,_that.cueFilePath,_that.gnudbDiscId,_that.lastScannedAt,_that.updatedAt,_that.deleted);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -197,10 +198,10 @@ return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.b
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String libraryPath,  String? artist,  String? albumTitle,  String? barcode,  int trackCount,  int discCount,  int totalSizeBytes,  String? mediaItemId,  String? cueFilePath,  int lastScannedAt,  int updatedAt,  bool deleted)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String libraryPath,  String? artist,  String? albumTitle,  String? barcode,  int trackCount,  int discCount,  int totalSizeBytes,  String? mediaItemId,  String? cueFilePath,  String? gnudbDiscId,  int lastScannedAt,  int updatedAt,  bool deleted)?  $default,) {final _that = this;
 switch (_that) {
 case _RipAlbum() when $default != null:
-return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.barcode,_that.trackCount,_that.discCount,_that.totalSizeBytes,_that.mediaItemId,_that.cueFilePath,_that.lastScannedAt,_that.updatedAt,_that.deleted);case _:
+return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.barcode,_that.trackCount,_that.discCount,_that.totalSizeBytes,_that.mediaItemId,_that.cueFilePath,_that.gnudbDiscId,_that.lastScannedAt,_that.updatedAt,_that.deleted);case _:
   return null;
 
 }
@@ -212,7 +213,7 @@ return $default(_that.id,_that.libraryPath,_that.artist,_that.albumTitle,_that.b
 
 
 class _RipAlbum implements RipAlbum {
-  const _RipAlbum({required this.id, required this.libraryPath, this.artist, this.albumTitle, this.barcode, required this.trackCount, this.discCount = 1, required this.totalSizeBytes, this.mediaItemId, this.cueFilePath, required this.lastScannedAt, required this.updatedAt, this.deleted = false});
+  const _RipAlbum({required this.id, required this.libraryPath, this.artist, this.albumTitle, this.barcode, required this.trackCount, this.discCount = 1, required this.totalSizeBytes, this.mediaItemId, this.cueFilePath, this.gnudbDiscId, required this.lastScannedAt, required this.updatedAt, this.deleted = false});
   
 
 @override final  String id;
@@ -225,6 +226,7 @@ class _RipAlbum implements RipAlbum {
 @override final  int totalSizeBytes;
 @override final  String? mediaItemId;
 @override final  String? cueFilePath;
+@override final  String? gnudbDiscId;
 @override final  int lastScannedAt;
 @override final  int updatedAt;
 @override@JsonKey() final  bool deleted;
@@ -239,16 +241,16 @@ _$RipAlbumCopyWith<_RipAlbum> get copyWith => __$RipAlbumCopyWithImpl<_RipAlbum>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RipAlbum&&(identical(other.id, id) || other.id == id)&&(identical(other.libraryPath, libraryPath) || other.libraryPath == libraryPath)&&(identical(other.artist, artist) || other.artist == artist)&&(identical(other.albumTitle, albumTitle) || other.albumTitle == albumTitle)&&(identical(other.barcode, barcode) || other.barcode == barcode)&&(identical(other.trackCount, trackCount) || other.trackCount == trackCount)&&(identical(other.discCount, discCount) || other.discCount == discCount)&&(identical(other.totalSizeBytes, totalSizeBytes) || other.totalSizeBytes == totalSizeBytes)&&(identical(other.mediaItemId, mediaItemId) || other.mediaItemId == mediaItemId)&&(identical(other.cueFilePath, cueFilePath) || other.cueFilePath == cueFilePath)&&(identical(other.lastScannedAt, lastScannedAt) || other.lastScannedAt == lastScannedAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deleted, deleted) || other.deleted == deleted));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RipAlbum&&(identical(other.id, id) || other.id == id)&&(identical(other.libraryPath, libraryPath) || other.libraryPath == libraryPath)&&(identical(other.artist, artist) || other.artist == artist)&&(identical(other.albumTitle, albumTitle) || other.albumTitle == albumTitle)&&(identical(other.barcode, barcode) || other.barcode == barcode)&&(identical(other.trackCount, trackCount) || other.trackCount == trackCount)&&(identical(other.discCount, discCount) || other.discCount == discCount)&&(identical(other.totalSizeBytes, totalSizeBytes) || other.totalSizeBytes == totalSizeBytes)&&(identical(other.mediaItemId, mediaItemId) || other.mediaItemId == mediaItemId)&&(identical(other.cueFilePath, cueFilePath) || other.cueFilePath == cueFilePath)&&(identical(other.gnudbDiscId, gnudbDiscId) || other.gnudbDiscId == gnudbDiscId)&&(identical(other.lastScannedAt, lastScannedAt) || other.lastScannedAt == lastScannedAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.deleted, deleted) || other.deleted == deleted));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,id,libraryPath,artist,albumTitle,barcode,trackCount,discCount,totalSizeBytes,mediaItemId,cueFilePath,lastScannedAt,updatedAt,deleted);
+int get hashCode => Object.hash(runtimeType,id,libraryPath,artist,albumTitle,barcode,trackCount,discCount,totalSizeBytes,mediaItemId,cueFilePath,gnudbDiscId,lastScannedAt,updatedAt,deleted);
 
 @override
 String toString() {
-  return 'RipAlbum(id: $id, libraryPath: $libraryPath, artist: $artist, albumTitle: $albumTitle, barcode: $barcode, trackCount: $trackCount, discCount: $discCount, totalSizeBytes: $totalSizeBytes, mediaItemId: $mediaItemId, cueFilePath: $cueFilePath, lastScannedAt: $lastScannedAt, updatedAt: $updatedAt, deleted: $deleted)';
+  return 'RipAlbum(id: $id, libraryPath: $libraryPath, artist: $artist, albumTitle: $albumTitle, barcode: $barcode, trackCount: $trackCount, discCount: $discCount, totalSizeBytes: $totalSizeBytes, mediaItemId: $mediaItemId, cueFilePath: $cueFilePath, gnudbDiscId: $gnudbDiscId, lastScannedAt: $lastScannedAt, updatedAt: $updatedAt, deleted: $deleted)';
 }
 
 
@@ -259,7 +261,7 @@ abstract mixin class _$RipAlbumCopyWith<$Res> implements $RipAlbumCopyWith<$Res>
   factory _$RipAlbumCopyWith(_RipAlbum value, $Res Function(_RipAlbum) _then) = __$RipAlbumCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String libraryPath, String? artist, String? albumTitle, String? barcode, int trackCount, int discCount, int totalSizeBytes, String? mediaItemId, String? cueFilePath, int lastScannedAt, int updatedAt, bool deleted
+ String id, String libraryPath, String? artist, String? albumTitle, String? barcode, int trackCount, int discCount, int totalSizeBytes, String? mediaItemId, String? cueFilePath, String? gnudbDiscId, int lastScannedAt, int updatedAt, bool deleted
 });
 
 
@@ -276,7 +278,7 @@ class __$RipAlbumCopyWithImpl<$Res>
 
 /// Create a copy of RipAlbum
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? libraryPath = null,Object? artist = freezed,Object? albumTitle = freezed,Object? barcode = freezed,Object? trackCount = null,Object? discCount = null,Object? totalSizeBytes = null,Object? mediaItemId = freezed,Object? cueFilePath = freezed,Object? lastScannedAt = null,Object? updatedAt = null,Object? deleted = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? libraryPath = null,Object? artist = freezed,Object? albumTitle = freezed,Object? barcode = freezed,Object? trackCount = null,Object? discCount = null,Object? totalSizeBytes = null,Object? mediaItemId = freezed,Object? cueFilePath = freezed,Object? gnudbDiscId = freezed,Object? lastScannedAt = null,Object? updatedAt = null,Object? deleted = null,}) {
   return _then(_RipAlbum(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,libraryPath: null == libraryPath ? _self.libraryPath : libraryPath // ignore: cast_nullable_to_non_nullable
@@ -288,6 +290,7 @@ as int,discCount: null == discCount ? _self.discCount : discCount // ignore: cas
 as int,totalSizeBytes: null == totalSizeBytes ? _self.totalSizeBytes : totalSizeBytes // ignore: cast_nullable_to_non_nullable
 as int,mediaItemId: freezed == mediaItemId ? _self.mediaItemId : mediaItemId // ignore: cast_nullable_to_non_nullable
 as String?,cueFilePath: freezed == cueFilePath ? _self.cueFilePath : cueFilePath // ignore: cast_nullable_to_non_nullable
+as String?,gnudbDiscId: freezed == gnudbDiscId ? _self.gnudbDiscId : gnudbDiscId // ignore: cast_nullable_to_non_nullable
 as String?,lastScannedAt: null == lastScannedAt ? _self.lastScannedAt : lastScannedAt // ignore: cast_nullable_to_non_nullable
 as int,updatedAt: null == updatedAt ? _self.updatedAt : updatedAt // ignore: cast_nullable_to_non_nullable
 as int,deleted: null == deleted ? _self.deleted : deleted // ignore: cast_nullable_to_non_nullable

--- a/lib/domain/repositories/i_rip_library_repository.dart
+++ b/lib/domain/repositories/i_rip_library_repository.dart
@@ -16,6 +16,7 @@ abstract interface class IRipLibraryRepository {
   Future<void> unlinkFromMediaItem(String ripAlbumId);
   Future<List<RipAlbum>> getAllNonDeleted();
   Future<void> updateTrackTitle(String trackId, String? title);
+  Future<void> updateGnudbDiscId(String ripAlbumId, String? discId);
   Future<void> updateTrackQuality(
     String trackId, {
     String? arStatus,

--- a/lib/domain/usecases/apply_gnudb_result_usecase.dart
+++ b/lib/domain/usecases/apply_gnudb_result_usecase.dart
@@ -1,0 +1,114 @@
+/// Applies a resolved GnuDB result to the local library.
+///
+/// On success the caller has picked (or auto-selected) a [GnudbCandidate].
+/// This use case fans the metadata out to three destinations:
+///
+/// 1. `rip_albums` (artist + album title) and `rip_tracks.title` rows via
+///    [EditRipMetadataUseCase], which also writes ALBUMARTIST/ALBUM/TITLE
+///    Vorbis Comment tags to FLAC files (MP3 tags are not supported by
+///    the underlying `metaflac` tool — MP3 tracks are skipped silently).
+/// 2. A new linked `MediaItem` in the main collection via
+///    [SaveMediaItemUseCase], created only when the rip album is not
+///    already linked to one.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:mymediascanner/data/mappers/gnudb_mapper.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
+import 'package:mymediascanner/domain/repositories/i_rip_library_repository.dart';
+import 'package:mymediascanner/domain/usecases/edit_rip_metadata_usecase.dart';
+import 'package:mymediascanner/domain/usecases/lookup_gnudb_for_rip_usecase.dart';
+import 'package:mymediascanner/domain/usecases/save_media_item_usecase.dart';
+
+/// Summary of what was written.
+class GnudbApplyOutcome {
+  const GnudbApplyOutcome({
+    required this.albumUpdated,
+    required this.tracksUpdated,
+    required this.mediaItemCreated,
+    required this.mediaItemId,
+  });
+  final bool albumUpdated;
+  final int tracksUpdated;
+  final bool mediaItemCreated;
+  final String? mediaItemId;
+}
+
+/// Orchestrator for writing GnuDB metadata back to a rip album.
+class ApplyGnudbResultUseCase {
+  const ApplyGnudbResultUseCase({
+    required EditRipMetadataUseCase editRipMetadata,
+    required SaveMediaItemUseCase saveMediaItem,
+    required IRipLibraryRepository repository,
+  })  : _editRipMetadata = editRipMetadata,
+        _saveMediaItem = saveMediaItem,
+        _repository = repository;
+
+  final EditRipMetadataUseCase _editRipMetadata;
+  final SaveMediaItemUseCase _saveMediaItem;
+  final IRipLibraryRepository _repository;
+
+  /// Applies [candidate] to [album] and its [tracks]. Set
+  /// [createMediaItemIfUnlinked] to `false` to skip the collection-creation
+  /// step (e.g. when the caller wants to defer linking).
+  Future<GnudbApplyOutcome> execute({
+    required RipAlbum album,
+    required List<RipTrack> tracks,
+    required GnudbCandidate candidate,
+    bool createMediaItemIfUnlinked = true,
+  }) async {
+    final dto = candidate.dto;
+
+    // 1. Album-level fields + FLAC tags.
+    await _editRipMetadata.editAlbumMetadata(
+      album: album,
+      tracks: tracks,
+      artist: dto.artist,
+      albumTitle: dto.albumTitle,
+    );
+
+    // 2. Per-track titles. dto.trackTitles is index-aligned (0-based) to the
+    // sorted track list returned by GnuDB (matching CD track 1..N).
+    final orderedTracks = [...tracks]
+      ..sort((a, b) => a.trackNumber.compareTo(b.trackNumber));
+    int tracksUpdated = 0;
+    for (final track in orderedTracks) {
+      final idx = track.trackNumber - 1;
+      if (idx < 0 || idx >= dto.trackTitles.length) continue;
+      final newTitle = dto.trackTitles[idx];
+      if (newTitle.isEmpty) continue;
+      if (track.title == newTitle) continue;
+      await _editRipMetadata.editTrackTitle(
+        track: track,
+        title: newTitle,
+      );
+      tracksUpdated++;
+    }
+
+    // 3. Optionally create a linked MediaItem.
+    String? mediaItemId;
+    bool mediaItemCreated = false;
+    if (createMediaItemIfUnlinked && album.mediaItemId == null) {
+      final metadata = GnudbMapper.toMetadataResult(
+        dto,
+        category: candidate.category,
+      );
+      final item = await _saveMediaItem.execute(metadata);
+      await _repository.linkToMediaItem(album.id, item.id);
+      mediaItemId = item.id;
+      mediaItemCreated = true;
+    } else {
+      mediaItemId = album.mediaItemId;
+    }
+
+    return GnudbApplyOutcome(
+      albumUpdated: true,
+      tracksUpdated: tracksUpdated,
+      mediaItemCreated: mediaItemCreated,
+      mediaItemId: mediaItemId,
+    );
+  }
+}

--- a/lib/domain/usecases/lookup_gnudb_for_rip_usecase.dart
+++ b/lib/domain/usecases/lookup_gnudb_for_rip_usecase.dart
@@ -1,0 +1,325 @@
+/// Orchestrates the GnuDB lookup flow for a single rip album.
+///
+/// The use case:
+///
+/// 1. Parses the album's CUE sheet to obtain per-track INDEX 01 offsets.
+/// 2. Combines those with track durations to compute the LBA frame offsets
+///    and leadout, from which the CDDB Disc ID is derived.
+/// 3. Persists the Disc ID on the rip album.
+/// 4. Checks the shared barcode cache (keyed `gnudb:<discid>`) for a recent
+///    response before hitting the network.
+/// 5. Queries GnuDB. On single match, reads full metadata and returns it.
+///    On multi match, reads each candidate (capped) and returns them.
+///    On no-match or error, returns the corresponding sealed result.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+import 'package:mymediascanner/core/constants/api_constants.dart';
+import 'package:mymediascanner/core/gnudb/cddb_disc_id_calculator.dart';
+import 'package:mymediascanner/core/gnudb/cue_frame_offsets_parser.dart';
+import 'package:mymediascanner/data/local/dao/barcode_cache_dao.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_api.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_response_parser.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
+import 'package:mymediascanner/domain/repositories/i_rip_library_repository.dart';
+
+/// Pairs a `MetadataResult`-ready payload with its GnuDB disc id.
+class GnudbCandidate {
+  const GnudbCandidate({
+    required this.discId,
+    required this.category,
+    required this.dto,
+  });
+  final String discId;
+  final String category;
+  final GnudbDiscDto dto;
+}
+
+/// Sealed result of [LookupGnudbForRipUseCase.execute].
+sealed class GnudbLookupResult {
+  const GnudbLookupResult();
+}
+
+class GnudbLookupSingle extends GnudbLookupResult {
+  const GnudbLookupSingle(this.candidate);
+  final GnudbCandidate candidate;
+}
+
+class GnudbLookupMulti extends GnudbLookupResult {
+  const GnudbLookupMulti(this.candidates);
+  final List<GnudbCandidate> candidates;
+}
+
+class GnudbLookupNoMatch extends GnudbLookupResult {
+  const GnudbLookupNoMatch();
+}
+
+class GnudbLookupError extends GnudbLookupResult {
+  const GnudbLookupError(this.message);
+  final String message;
+}
+
+/// Maximum number of candidates we'll read from GnuDB on a multi-match.
+const int _maxMultiCandidates = 5;
+
+/// Pregap, in frames, conventionally added to track offsets to yield LBA.
+const int _pregapFrames = 150;
+
+/// Orchestrator for GnuDB metadata lookups keyed off a rip album's CUE.
+class LookupGnudbForRipUseCase {
+  LookupGnudbForRipUseCase({
+    required GnudbApi api,
+    required BarcodeCacheDao cacheDao,
+    required IRipLibraryRepository repository,
+    required String rootPath,
+    CueFrameOffsetsLoader? loader,
+  })  : _api = api,
+        _cacheDao = cacheDao,
+        _repository = repository,
+        _rootPath = rootPath,
+        _loader = loader ?? _defaultLoader;
+
+  final GnudbApi _api;
+  final BarcodeCacheDao _cacheDao;
+  final IRipLibraryRepository _repository;
+  final String _rootPath;
+  final CueFrameOffsetsLoader _loader;
+
+  static Future<List<CueTrackOffset>> _defaultLoader(String path) {
+    return CueFrameOffsetsParser.parseFile(path);
+  }
+
+  /// Runs a GnuDB lookup for [album] using its CUE and [tracks] durations.
+  Future<GnudbLookupResult> execute({
+    required RipAlbum album,
+    required List<RipTrack> tracks,
+  }) async {
+    if (album.cueFilePath == null) {
+      return const GnudbLookupError('Album has no CUE sheet');
+    }
+    if (album.discCount != 1) {
+      return const GnudbLookupError(
+          'Multi-disc albums are not supported by GnuDB in this version');
+    }
+    if (tracks.isEmpty) {
+      return const GnudbLookupError('Album has no tracks');
+    }
+
+    // Tracks must be ordered by track number for correct offset assembly.
+    final ordered = [...tracks]..sort(
+        (a, b) => a.trackNumber.compareTo(b.trackNumber));
+
+    final List<CueTrackOffset> cueOffsets;
+    try {
+      final resolvedCuePath = _resolveCuePath(album.cueFilePath!);
+      cueOffsets = await _loader(resolvedCuePath);
+    } catch (e) {
+      return GnudbLookupError('Failed to parse CUE sheet: $e');
+    }
+
+    if (cueOffsets.isEmpty) {
+      return const GnudbLookupError('CUE sheet contains no audio tracks');
+    }
+    if (cueOffsets.length != ordered.length) {
+      return GnudbLookupError(
+          'CUE has ${cueOffsets.length} tracks but album has ${ordered.length}');
+    }
+    for (final t in ordered) {
+      if (t.durationMs == null || t.durationMs! <= 0) {
+        return GnudbLookupError(
+            'Track ${t.trackNumber} is missing a valid duration');
+      }
+    }
+
+    final layout = _buildLayout(cueOffsets, ordered);
+    final discId = CddbDiscIdCalculator.calculate(
+      frameOffsets: layout.lbaOffsets,
+      leadoutFrame: layout.leadoutFrame,
+    );
+
+    await _repository.updateGnudbDiscId(album.id, discId);
+
+    // Cache fast path.
+    final cached = await _readCached(discId);
+    if (cached != null) return cached;
+
+    final query = await _api.query(
+      discId: discId,
+      frameOffsets: layout.lbaOffsets,
+      totalSeconds: layout.totalSeconds,
+    );
+
+    switch (query) {
+      case GnudbQueryNoMatch():
+        return const GnudbLookupNoMatch();
+      case GnudbQueryError(:final code, :final message):
+        return GnudbLookupError(
+            'GnuDB server returned $code: $message');
+      case GnudbQuerySingle(:final match):
+        final dto = await _api.read(
+            category: match.category, discId: match.discId);
+        if (dto == null) {
+          return const GnudbLookupError('GnuDB read returned no data');
+        }
+        final candidate = GnudbCandidate(
+          discId: match.discId,
+          category: match.category,
+          dto: dto,
+        );
+        await _writeCached(discId, [candidate]);
+        return GnudbLookupSingle(candidate);
+      case GnudbQueryMulti(:final matches):
+        if (matches.isEmpty) return const GnudbLookupNoMatch();
+        final candidates = <GnudbCandidate>[];
+        for (final m in matches.take(_maxMultiCandidates)) {
+          final dto = await _api.read(
+              category: m.category, discId: m.discId);
+          if (dto != null) {
+            candidates.add(GnudbCandidate(
+              discId: m.discId,
+              category: m.category,
+              dto: dto,
+            ));
+          }
+        }
+        if (candidates.isEmpty) {
+          return const GnudbLookupNoMatch();
+        }
+        await _writeCached(discId, candidates);
+        return GnudbLookupMulti(candidates);
+    }
+  }
+
+  String _resolveCuePath(String cueRelativePath) {
+    // Match the rip scanner's semantics: paths are stored relative to the
+    // library root, with forward slashes for stable on-disk records.
+    if (cueRelativePath.startsWith('/') ||
+        RegExp(r'^[a-zA-Z]:').hasMatch(cueRelativePath)) {
+      return cueRelativePath;
+    }
+    final sep = _rootPath.endsWith('/') || _rootPath.endsWith(r'\') ? '' : '/';
+    return '$_rootPath$sep$cueRelativePath';
+  }
+
+  _DiscLayout _buildLayout(
+      List<CueTrackOffset> cueOffsets, List<RipTrack> ordered) {
+    // LBA offsets grow through every FILE boundary: when the FILE changes,
+    // the cumulative frame count jumps by the total frames of the tracks in
+    // the file we are leaving.
+    final lbaOffsets = <int>[];
+    int cumulativeFileFrames = 0;
+    String? currentFile;
+    int firstTrackInFileIndex = 0;
+
+    for (int i = 0; i < cueOffsets.length; i++) {
+      final o = cueOffsets[i];
+      if (o.filePath != currentFile) {
+        if (currentFile != null) {
+          for (int j = firstTrackInFileIndex; j < i; j++) {
+            cumulativeFileFrames +=
+                (((ordered[j].durationMs ?? 0) * 75) ~/ 1000);
+          }
+        }
+        currentFile = o.filePath;
+        firstTrackInFileIndex = i;
+      }
+      lbaOffsets.add(_pregapFrames + cumulativeFileFrames + o.inFileFrameOffset);
+    }
+
+    final totalTrackFrames = ordered
+        .map((t) => ((t.durationMs ?? 0) * 75) ~/ 1000)
+        .fold<int>(0, (a, b) => a + b);
+    final leadoutFrame = _pregapFrames + totalTrackFrames;
+    final totalSeconds = leadoutFrame ~/ 75;
+
+    return _DiscLayout(
+      lbaOffsets: lbaOffsets,
+      leadoutFrame: leadoutFrame,
+      totalSeconds: totalSeconds,
+    );
+  }
+
+  Future<GnudbLookupResult?> _readCached(String discId) async {
+    final hit = await _cacheDao.getByBarcode(_cacheKey(discId));
+    if (hit == null) return null;
+    final age =
+        DateTime.now().millisecondsSinceEpoch - hit.cachedAt;
+    const maxAgeMs = ApiConstants.cacheDurationDays * 86_400_000;
+    if (age > maxAgeMs) return null;
+    try {
+      final payload = jsonDecode(hit.responseJson) as Map<String, dynamic>;
+      final candidates = (payload['candidates'] as List)
+          .map((c) => GnudbCandidate(
+                discId: c['disc_id'] as String,
+                category: c['category'] as String,
+                dto: GnudbDiscDto(
+                  discId: c['disc_id'] as String,
+                  artist: c['artist'] as String,
+                  albumTitle: c['album_title'] as String,
+                  year: c['year'] as int?,
+                  genre: c['genre'] as String?,
+                  trackTitles: (c['track_titles'] as List).cast<String>(),
+                  extendedAlbum: c['extended_album'] as String?,
+                ),
+              ))
+          .toList();
+      if (candidates.isEmpty) return const GnudbLookupNoMatch();
+      if (candidates.length == 1) return GnudbLookupSingle(candidates.first);
+      return GnudbLookupMulti(candidates);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _writeCached(
+      String discId, List<GnudbCandidate> candidates) async {
+    final payload = jsonEncode({
+      'candidates': [
+        for (final c in candidates)
+          {
+            'disc_id': c.discId,
+            'category': c.category,
+            'artist': c.dto.artist,
+            'album_title': c.dto.albumTitle,
+            'year': c.dto.year,
+            'genre': c.dto.genre,
+            'track_titles': c.dto.trackTitles,
+            'extended_album': c.dto.extendedAlbum,
+          }
+      ],
+    });
+    await _cacheDao.upsert(BarcodeCacheTableCompanion(
+      barcode: Value(_cacheKey(discId)),
+      mediaTypeHint: const Value('music'),
+      responseJson: Value(payload),
+      sourceApi: const Value('gnudb'),
+      cachedAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
+  String _cacheKey(String discId) => 'gnudb:$discId';
+}
+
+/// Allows tests to inject an in-memory CUE offsets source.
+typedef CueFrameOffsetsLoader = Future<List<CueTrackOffset>> Function(
+    String resolvedPath);
+
+class _DiscLayout {
+  const _DiscLayout({
+    required this.lbaOffsets,
+    required this.leadoutFrame,
+    required this.totalSeconds,
+  });
+  final List<int> lbaOffsets;
+  final int leadoutFrame;
+  final int totalSeconds;
+}
+

--- a/lib/presentation/providers/gnudb_provider.dart
+++ b/lib/presentation/providers/gnudb_provider.dart
@@ -1,0 +1,225 @@
+/// Riverpod providers for the GnuDB lookup UX.
+///
+/// The [GnudbLookupNotifier] drives the "Look up on GnuDB" button in the
+/// rip album detail dialog. It runs [LookupGnudbForRipUseCase], holds any
+/// ambiguous candidates for user selection, then applies the chosen one
+/// via [ApplyGnudbResultUseCase].
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_api.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/usecases/apply_gnudb_result_usecase.dart';
+import 'package:mymediascanner/domain/usecases/edit_rip_metadata_usecase.dart';
+import 'package:mymediascanner/domain/usecases/lookup_gnudb_for_rip_usecase.dart';
+import 'package:mymediascanner/domain/usecases/resolve_series_usecase.dart';
+import 'package:mymediascanner/domain/usecases/save_media_item_usecase.dart';
+import 'package:mymediascanner/presentation/providers/database_provider.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+import 'package:mymediascanner/presentation/providers/series_provider.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+
+/// Provider for the shared [GnudbApi] client.
+///
+/// The username used for the CDDB "hello" string is read from
+/// [gnudbUsernameProvider] so the user can identify themselves to GnuDB;
+/// the client falls back to the default when the setting is absent.
+final gnudbApiProvider = Provider<GnudbApi>((ref) {
+  final user = ref.watch(gnudbUsernameProvider);
+  return GnudbApi(user: user);
+});
+
+/// Factory for [LookupGnudbForRipUseCase]. The `rootPath` changes with the
+/// user's configured rip library, so the use-case is built per call.
+LookupGnudbForRipUseCase _buildLookupUseCase(Ref ref, String rootPath) {
+  return LookupGnudbForRipUseCase(
+    api: ref.read(gnudbApiProvider),
+    cacheDao: ref.read(barcodeCacheDaoProvider),
+    repository: ref.read(ripLibraryRepositoryProvider),
+    rootPath: rootPath,
+  );
+}
+
+/// Factory for [ApplyGnudbResultUseCase].
+ApplyGnudbResultUseCase _buildApplyUseCase(Ref ref) {
+  return ApplyGnudbResultUseCase(
+    editRipMetadata: EditRipMetadataUseCase(
+      repository: ref.read(ripLibraryRepositoryProvider),
+      writer: ref.read(metaflacWriterProvider),
+    ),
+    saveMediaItem: SaveMediaItemUseCase(
+      repository: ref.read(mediaItemRepositoryProvider),
+      resolveSeries: ResolveSeriesUseCase(
+        seriesRepository: ref.read(seriesRepositoryProvider),
+        mediaItemRepository: ref.read(mediaItemRepositoryProvider),
+      ),
+    ),
+    repository: ref.read(ripLibraryRepositoryProvider),
+  );
+}
+
+/// Status of the GnuDB lookup state machine.
+enum GnudbLookupStatus {
+  idle,
+  computing,
+  fetching,
+  ambiguous,
+  applying,
+  complete,
+  error,
+  noMatch,
+}
+
+/// Immutable state for the GnuDB lookup flow.
+class GnudbLookupState {
+  const GnudbLookupState({
+    this.status = GnudbLookupStatus.idle,
+    this.candidates = const [],
+    this.appliedCandidate,
+    this.outcome,
+    this.error,
+  });
+
+  final GnudbLookupStatus status;
+  final List<GnudbCandidate> candidates;
+  final GnudbCandidate? appliedCandidate;
+  final GnudbApplyOutcome? outcome;
+  final String? error;
+
+  GnudbLookupState copyWith({
+    GnudbLookupStatus? status,
+    List<GnudbCandidate>? candidates,
+    GnudbCandidate? appliedCandidate,
+    GnudbApplyOutcome? outcome,
+    String? error,
+  }) =>
+      GnudbLookupState(
+        status: status ?? this.status,
+        candidates: candidates ?? this.candidates,
+        appliedCandidate: appliedCandidate ?? this.appliedCandidate,
+        outcome: outcome ?? this.outcome,
+        error: error,
+      );
+}
+
+/// Notifier driving the GnuDB lookup button and dialog. Singleton — only
+/// one rip album is in the lookup flow at a time.
+final gnudbLookupNotifierProvider =
+    NotifierProvider<GnudbLookupNotifier, GnudbLookupState>(
+  GnudbLookupNotifier.new,
+);
+
+class GnudbLookupNotifier extends Notifier<GnudbLookupState> {
+  @override
+  GnudbLookupState build() {
+    return const GnudbLookupState();
+  }
+
+  /// Runs the full lookup → apply pipeline for [album] and its [tracks].
+  ///
+  /// For single-match and cached results the apply step runs automatically.
+  /// For multi-match the notifier transitions to [GnudbLookupStatus.ambiguous]
+  /// and waits for [selectCandidate] to apply a chosen one.
+  Future<void> lookup(RipAlbum album, List<dynamic> tracks) async {
+    if (state.status == GnudbLookupStatus.computing ||
+        state.status == GnudbLookupStatus.fetching ||
+        state.status == GnudbLookupStatus.applying) {
+      return;
+    }
+
+    state = const GnudbLookupState(status: GnudbLookupStatus.computing);
+
+    final rootPath =
+        ref.read(ripLibraryPathProvider).maybeWhen(
+                data: (p) => p, orElse: () => null) ??
+            '';
+    if (rootPath.isEmpty) {
+      state = state.copyWith(
+        status: GnudbLookupStatus.error,
+        error: 'No rip library root configured',
+      );
+      return;
+    }
+
+    final lookupUseCase = _buildLookupUseCase(ref, rootPath);
+    state = state.copyWith(status: GnudbLookupStatus.fetching);
+
+    GnudbLookupResult result;
+    try {
+      result = await lookupUseCase.execute(
+        album: album,
+        tracks: tracks.cast(),
+      );
+    } catch (e) {
+      state = state.copyWith(
+        status: GnudbLookupStatus.error,
+        error: e.toString(),
+      );
+      return;
+    }
+
+    switch (result) {
+      case GnudbLookupNoMatch():
+        state = state.copyWith(status: GnudbLookupStatus.noMatch);
+      case GnudbLookupError(:final message):
+        state = state.copyWith(
+          status: GnudbLookupStatus.error,
+          error: message,
+        );
+      case GnudbLookupSingle(:final candidate):
+        await _apply(album, tracks.cast(), candidate);
+      case GnudbLookupMulti(:final candidates):
+        state = state.copyWith(
+          status: GnudbLookupStatus.ambiguous,
+          candidates: candidates,
+        );
+    }
+  }
+
+  /// Called from the disambiguation dialog when the user picks a candidate.
+  Future<void> selectCandidate(
+    RipAlbum album,
+    List<dynamic> tracks,
+    GnudbCandidate candidate,
+  ) async {
+    await _apply(album, tracks.cast(), candidate);
+  }
+
+  Future<void> _apply(
+    RipAlbum album,
+    List tracks,
+    GnudbCandidate candidate,
+  ) async {
+    state = state.copyWith(status: GnudbLookupStatus.applying);
+    try {
+      final apply = _buildApplyUseCase(ref);
+      final outcome = await apply.execute(
+        album: album,
+        tracks: tracks.cast(),
+        candidate: candidate,
+      );
+      state = state.copyWith(
+        status: GnudbLookupStatus.complete,
+        appliedCandidate: candidate,
+        outcome: outcome,
+      );
+      // Force UI refresh of rip album and track providers.
+      ref.invalidate(allRipAlbumsProvider);
+      ref.invalidate(ripTracksProvider(album.id));
+    } catch (e) {
+      state = state.copyWith(
+        status: GnudbLookupStatus.error,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Clears the state back to idle.
+  void reset() {
+    state = const GnudbLookupState();
+  }
+}

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -36,6 +36,37 @@ class ThemeModeNotifier extends Notifier<ThemeMode> {
 final themeModeProvider =
     NotifierProvider<ThemeModeNotifier, ThemeMode>(ThemeModeNotifier.new);
 
+// ── GnuDB username (identifier sent in the CDDB "hello" string) ──────
+
+class GnudbUsernameNotifier extends Notifier<String> {
+  static const _key = 'gnudb_username';
+  static const _default = 'mymediascanner';
+
+  @override
+  String build() {
+    _load();
+    return _default;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_key);
+    if (stored != null && stored.isNotEmpty) {
+      state = stored;
+    }
+  }
+
+  Future<void> setUsername(String value) async {
+    final trimmed = value.trim();
+    state = trimmed.isEmpty ? _default : trimmed;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, state);
+  }
+}
+
+final gnudbUsernameProvider =
+    NotifierProvider<GnudbUsernameNotifier, String>(GnudbUsernameNotifier.new);
+
 // ── Secure storage ───────────────────────────────────────────────────
 
 final secureStorageProvider = Provider<FlutterSecureStorage>((ref) {

--- a/lib/presentation/screens/rips/widgets/gnudb_candidate_picker_dialog.dart
+++ b/lib/presentation/screens/rips/widgets/gnudb_candidate_picker_dialog.dart
@@ -1,0 +1,63 @@
+/// Modal dialog for disambiguating multiple GnuDB matches.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:flutter/material.dart';
+import 'package:mymediascanner/data/mappers/gnudb_mapper.dart';
+import 'package:mymediascanner/domain/usecases/lookup_gnudb_for_rip_usecase.dart';
+import 'package:mymediascanner/presentation/screens/disambiguation/widgets/candidate_card.dart';
+
+/// Shows a dialog listing GnuDB [candidates] and returns the user's
+/// selection, or `null` if cancelled.
+Future<GnudbCandidate?> showGnudbCandidatePicker({
+  required BuildContext context,
+  required List<GnudbCandidate> candidates,
+}) {
+  return showDialog<GnudbCandidate>(
+    context: context,
+    builder: (ctx) => GnudbCandidatePickerDialog(candidates: candidates),
+  );
+}
+
+class GnudbCandidatePickerDialog extends StatelessWidget {
+  const GnudbCandidatePickerDialog({
+    super.key,
+    required this.candidates,
+  });
+
+  final List<GnudbCandidate> candidates;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Choose a GnuDB match'),
+      content: SizedBox(
+        width: 460,
+        child: ListView.separated(
+          shrinkWrap: true,
+          itemCount: candidates.length,
+          separatorBuilder: (_, _) => const SizedBox(height: 8),
+          itemBuilder: (context, i) {
+            final c = candidates[i];
+            final candidate = GnudbMapper.toCandidate(
+              c.dto,
+              category: c.category,
+            );
+            return CandidateCard(
+              candidate: candidate,
+              onTap: () => Navigator.of(context).pop(c),
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/screens/rips/widgets/gnudb_lookup_button.dart
+++ b/lib/presentation/screens/rips/widgets/gnudb_lookup_button.dart
@@ -1,0 +1,158 @@
+/// Icon button that triggers a GnuDB metadata lookup for a rip album.
+///
+/// Placed in the rip album detail dialog beside the edit and close
+/// actions. The button is disabled when the album has no CUE sheet or
+/// is a multi-disc set, since both are preconditions for a per-disc
+/// CDDB Disc ID lookup.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/presentation/providers/gnudb_provider.dart';
+import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+import 'package:mymediascanner/presentation/screens/rips/widgets/gnudb_candidate_picker_dialog.dart';
+
+class GnudbLookupButton extends ConsumerStatefulWidget {
+  const GnudbLookupButton({
+    super.key,
+    required this.album,
+  });
+
+  final RipAlbum album;
+
+  @override
+  ConsumerState<GnudbLookupButton> createState() =>
+      _GnudbLookupButtonState();
+}
+
+class _GnudbLookupButtonState extends ConsumerState<GnudbLookupButton> {
+  GnudbLookupStatus? _lastSeenStatus;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(gnudbLookupNotifierProvider);
+    _handleStateChanges(state);
+
+    final isBusy = state.status == GnudbLookupStatus.computing ||
+        state.status == GnudbLookupStatus.fetching ||
+        state.status == GnudbLookupStatus.applying;
+
+    final disabledReason = _disabledReason();
+    final onPressed = (disabledReason != null || isBusy)
+        ? null
+        : () => _start();
+
+    if (isBusy) {
+      return const SizedBox(
+        width: 36,
+        height: 36,
+        child: Center(
+          child: SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ),
+      );
+    }
+
+    return IconButton(
+      icon: const Icon(Icons.cloud_download_outlined, size: 20),
+      tooltip: disabledReason ?? 'Look up on GnuDB',
+      onPressed: onPressed,
+    );
+  }
+
+  String? _disabledReason() {
+    if (widget.album.cueFilePath == null) {
+      return 'GnuDB needs a CUE sheet (none found for this album)';
+    }
+    if (widget.album.discCount != 1) {
+      return 'GnuDB lookup is per-disc; multi-disc sets are not supported';
+    }
+    return null;
+  }
+
+  Future<void> _start() async {
+    final tracks =
+        ref.read(ripTracksProvider(widget.album.id)).value ?? const [];
+    if (tracks.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Tracks not loaded yet — try again')),
+      );
+      return;
+    }
+    final notifier = ref.read(gnudbLookupNotifierProvider.notifier);
+    notifier.reset();
+    await notifier.lookup(widget.album, tracks);
+  }
+
+  /// Reacts to state transitions into terminal states (complete, noMatch,
+  /// error) and to ambiguous (opens the picker dialog). Uses
+  /// _lastSeenStatus to fire side effects only on transitions.
+  void _handleStateChanges(GnudbLookupState state) {
+    if (state.status == _lastSeenStatus) return;
+    _lastSeenStatus = state.status;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
+      switch (state.status) {
+        case GnudbLookupStatus.ambiguous:
+          final selected = await showGnudbCandidatePicker(
+            context: context,
+            candidates: state.candidates,
+          );
+          if (!mounted) return;
+          if (selected != null) {
+            final tracks = ref
+                    .read(ripTracksProvider(widget.album.id))
+                    .value ??
+                const [];
+            await ref
+                .read(gnudbLookupNotifierProvider.notifier)
+                .selectCandidate(widget.album, tracks, selected);
+          } else {
+            ref.read(gnudbLookupNotifierProvider.notifier).reset();
+          }
+        case GnudbLookupStatus.complete:
+          final updated = state.outcome?.tracksUpdated ?? 0;
+          final created = state.outcome?.mediaItemCreated ?? false;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                created
+                    ? 'Metadata applied from GnuDB. $updated tracks updated and added to collection.'
+                    : 'Metadata applied from GnuDB. $updated tracks updated.',
+              ),
+            ),
+          );
+          ref.read(gnudbLookupNotifierProvider.notifier).reset();
+        case GnudbLookupStatus.noMatch:
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+                content:
+                    Text('GnuDB found no match for this disc')),
+          );
+          ref.read(gnudbLookupNotifierProvider.notifier).reset();
+        case GnudbLookupStatus.error:
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                  'GnuDB lookup failed: ${state.error ?? 'unknown error'}'),
+            ),
+          );
+          ref.read(gnudbLookupNotifierProvider.notifier).reset();
+        case GnudbLookupStatus.idle:
+        case GnudbLookupStatus.computing:
+        case GnudbLookupStatus.fetching:
+        case GnudbLookupStatus.applying:
+          // Transient states — no side effect.
+          break;
+      }
+    });
+  }
+}

--- a/lib/presentation/screens/rips/widgets/rip_album_detail_dialog.dart
+++ b/lib/presentation/screens/rips/widgets/rip_album_detail_dialog.dart
@@ -12,6 +12,7 @@ import 'package:mymediascanner/presentation/providers/playlist_provider.dart';
 import 'package:mymediascanner/presentation/providers/queue_provider.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+import 'package:mymediascanner/presentation/screens/rips/widgets/gnudb_lookup_button.dart';
 import 'package:mymediascanner/presentation/screens/rips/widgets/playback_widgets.dart';
 import 'package:mymediascanner/presentation/screens/rips/widgets/quality_widgets.dart';
 import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
@@ -251,6 +252,7 @@ class _RipAlbumDetailDialogState extends ConsumerState<RipAlbumDetailDialog> {
                     ),
                   ] else ...[
                     PlayAlbumButton(album: widget.album),
+                    GnudbLookupButton(album: widget.album),
                     IconButton(
                       icon: const Icon(Icons.edit, size: 20),
                       tooltip: 'Edit metadata',

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:mymediascanner/core/utils/platform_utils.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 import 'package:mymediascanner/presentation/providers/replay_gain_provider.dart';
 import 'package:mymediascanner/presentation/screens/settings/widgets/api_key_form.dart';
+import 'package:mymediascanner/presentation/screens/settings/widgets/gnudb_settings_section.dart';
 import 'package:mymediascanner/presentation/providers/settings_provider.dart';
 import 'package:mymediascanner/presentation/screens/settings/widgets/sync_status_tile.dart';
 import 'package:mymediascanner/presentation/widgets/screen_header.dart';
@@ -67,6 +68,15 @@ class SettingsScreen extends ConsumerWidget {
             colors: colors,
             theme: theme,
             children: const [ApiKeyForm()],
+          ),
+          const SizedBox(height: 16),
+
+          // GnuDB section — per-disc metadata lookup configuration
+          _SectionCard(
+            title: 'GnuDB',
+            colors: colors,
+            theme: theme,
+            children: const [GnudbSettingsSection()],
           ),
           const SizedBox(height: 16),
 

--- a/lib/presentation/screens/settings/widgets/gnudb_settings_section.dart
+++ b/lib/presentation/screens/settings/widgets/gnudb_settings_section.dart
@@ -1,0 +1,98 @@
+/// Settings form for the GnuDB integration.
+///
+/// GnuDB does not use an API key — it identifies clients via a
+/// "hello" string containing the user's name and the application
+/// name/version. This form lets the user customise the first part.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+
+class GnudbSettingsSection extends ConsumerStatefulWidget {
+  const GnudbSettingsSection({super.key});
+
+  @override
+  ConsumerState<GnudbSettingsSection> createState() =>
+      _GnudbSettingsSectionState();
+}
+
+class _GnudbSettingsSectionState
+    extends ConsumerState<GnudbSettingsSection> {
+  late final TextEditingController _controller;
+  String? _lastApplied;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final current = ref.watch(gnudbUsernameProvider);
+    if (_lastApplied != current) {
+      _controller.text = current;
+      _lastApplied = current;
+    }
+
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'GnuDB username',
+            style: theme.textTheme.titleSmall,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Identifies you to the gnudb.org CDDB server. The default is '
+            'fine; change it only if you have a reason.',
+            style: theme.textTheme.bodySmall,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'mymediascanner',
+                    isDense: true,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              FilledButton(
+                onPressed: () async {
+                  final messenger = ScaffoldMessenger.of(context);
+                  await ref
+                      .read(gnudbUsernameProvider.notifier)
+                      .setUsername(_controller.text);
+                  if (!mounted) return;
+                  messenger.showSnackBar(
+                    const SnackBar(
+                        content: Text('GnuDB username saved')),
+                  );
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -53,10 +53,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_defect_detector
-      sha256: ac085bfc7f9fc6e01df2954dc2ec0ca46c2a4c9e1490c06699558c583b353b16
+      sha256: "0fa5d7eddf042d810071d86509b1ea621a2f81b1a904fa0b812b27451b9ee984"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3"
   audio_session:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: camera_platform_interface
-      sha256: "98cfc9357e04bad617671b4c1f78a597f25f08003089dd94050709ae54effc63"
+      sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   camera_web:
     dependency: transitive
     description:
@@ -365,10 +365,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_cue
-      sha256: f49a5c3ad459cf466ff784adbbfd92b9f1bdadbbe7c3c7221a531c7e5f893491
+      sha256: b34e7d5265e841b246595ad198ca9fe6817dfc2ea5c4431150bee1b9e26a38af
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.6"
   dart_metaflac:
     dependency: "direct main"
     description:
@@ -381,10 +381,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_rip_log
-      sha256: "16c601fca0475a78d95ab4c510c5425ca56a47658ba1e4fc0a86ceb16df6b3b1"
+      sha256: a13953ad961e0c4286786192129ed42261bf38cf885e8797187532176b2501ed
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1"
+    version: "0.0.5"
   dart_style:
     dependency: transitive
     description:
@@ -750,10 +750,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: "48fb2f42ad057476fa4b733cb95e9f9ea7b0b010bb349ea491dca7dbdb18ffc4"
+      sha256: "5540e4a3f416dd4a93458257b908eb88353cbd0fb5b0a3d1bd7d849ba1e88735"
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.0"
+    version: "17.2.1"
   google_mlkit_commons:
     dependency: transitive
     description:
@@ -1592,10 +1592,10 @@ packages:
     dependency: "direct dev"
     description:
       name: sqlite3
-      sha256: b3fe250b4ebd681a8ba20b12794c42b00c1375e5b51005568f0b8731265beb03
+      sha256: "56da3e13ed7d28a66f930aa2b2b29db6736a233f08283326e96321dd812030f5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1824,10 +1824,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "046d3928e16fa4dc46e8350415661755ab759d9fc97fc21b5ab295f71e4f0499"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.1.0"
   watcher:
     dependency: transitive
     description:

--- a/test/fixtures/gnudb/query_200_single.txt
+++ b/test/fixtures/gnudb/query_200_single.txt
@@ -1,0 +1,1 @@
+200 rock 08025603 Example Artist / Example Album

--- a/test/fixtures/gnudb/query_202_nomatch.txt
+++ b/test/fixtures/gnudb/query_202_nomatch.txt
@@ -1,0 +1,1 @@
+202 No match found

--- a/test/fixtures/gnudb/query_210_multi.txt
+++ b/test/fixtures/gnudb/query_210_multi.txt
@@ -1,0 +1,5 @@
+210 Found exact matches, list follows (until terminating `.')
+rock 08025603 Example Artist / Example Album
+pop a0b1c2d3 Example Artist / Example Album (2009 Remaster)
+jazz feedface Example Artist / Example Album (Deluxe Edition)
+.

--- a/test/fixtures/gnudb/read_disc_full.txt
+++ b/test/fixtures/gnudb/read_disc_full.txt
@@ -1,0 +1,26 @@
+210 rock 08025603 CD database entry follows (until terminating `.')
+# xmcd
+#
+# Track frame offsets:
+#	150
+#	15000
+#	30000
+#
+# Disc length: 600 seconds
+#
+# Revision: 1
+# Processed by: cddbd v1.5.2PL0
+DISCID=08025603
+DTITLE=Example Artist / Example Album
+DYEAR=2023
+DGENRE=Rock
+TTITLE0=First Song
+TTITLE1=Second Song with a much longer title that wraps
+TTITLE1=  across two lines
+TTITLE2=Third Song
+EXTD=Album-level notes here
+EXTT0=
+EXTT1=Track 2 notes
+EXTT2=
+PLAYORDER=
+.

--- a/test/fixtures/gnudb/sample.cue
+++ b/test/fixtures/gnudb/sample.cue
@@ -1,0 +1,19 @@
+REM GENRE "Rock"
+REM DATE "2023"
+REM DISCID 08025603
+PERFORMER "Example Artist"
+TITLE "Example Album"
+FILE "album.flac" WAVE
+  TRACK 01 AUDIO
+    TITLE "First Song"
+    PERFORMER "Example Artist"
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    TITLE "Second Song"
+    PERFORMER "Example Artist"
+    INDEX 00 03:18:00
+    INDEX 01 03:20:00
+  TRACK 03 AUDIO
+    TITLE "Third Song"
+    PERFORMER "Example Artist"
+    INDEX 01 06:40:00

--- a/test/unit/core/gnudb/cddb_disc_id_calculator_test.dart
+++ b/test/unit/core/gnudb/cddb_disc_id_calculator_test.dart
@@ -1,0 +1,146 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/core/gnudb/cddb_disc_id_calculator.dart';
+
+/// Tests for the CDDB Disc ID algorithm.
+///
+/// The CDDB Disc ID is a 32-bit integer encoded as eight lowercase hex
+/// characters. It is calculated from per-track starting frame offsets
+/// (LBA, including the standard 150-frame pregap) and the leadout frame
+/// offset. Formula:
+///
+///   offset_seconds_i = frameOffsets[i] ~/ 75
+///   sum_of_digits(x) = digit-sum of x's base-10 representation
+///   n = Σ sum_of_digits(offset_seconds_i)   (across all tracks, not leadout)
+///   t = (leadoutFrame ~/ 75) - offset_seconds_0
+///   discid = ((n % 255) << 24) | (t << 8) | numTracks
+///
+/// Vectors below are hand-computed.
+void main() {
+  group('CddbDiscIdCalculator.calculate', () {
+    test('three-track synthetic disc produces expected id', () {
+      // Offsets in frames. 150 = 2s pregap. 15000 = 200s. 30000 = 400s.
+      // Leadout 45000 = 600s.
+      // cddb_sum(2)+cddb_sum(200)+cddb_sum(400) = 2+2+4 = 8
+      // t = 600 - 2 = 598
+      // discid = (8 << 24) | (598 << 8) | 3 = 0x08025603
+      final id = CddbDiscIdCalculator.calculate(
+        frameOffsets: const [150, 15000, 30000],
+        leadoutFrame: 45000,
+      );
+      expect(id, '08025603');
+    });
+
+    test('ten-track synthetic disc produces expected id', () {
+      // Ten tracks, 40s apart, starting at 150 frames; leadout at 30150.
+      // Seconds: 2, 42, 82, 122, 162, 202, 242, 282, 322, 362
+      // Digit sums: 2, 6, 10, 5, 9, 4, 8, 12, 7, 11 → n = 74
+      // t = 402 - 2 = 400
+      // discid = (74 << 24) | (400 << 8) | 10 = 0x4a01900a
+      final id = CddbDiscIdCalculator.calculate(
+        frameOffsets: const [
+          150, 3150, 6150, 9150, 12150, 15150, 18150, 21150, 24150, 27150,
+        ],
+        leadoutFrame: 30150,
+      );
+      expect(id, '4a01900a');
+    });
+
+    test('single-track disc produces expected id', () {
+      // Offset 150 = 2s, leadout 30000 = 400s.
+      // n = 2, t = 398, tracks = 1
+      // discid = (2 << 24) | (398 << 8) | 1 = 0x02018e01
+      final id = CddbDiscIdCalculator.calculate(
+        frameOffsets: const [150],
+        leadoutFrame: 30000,
+      );
+      expect(id, '02018e01');
+    });
+
+    test('n wraps at 255 (digit-sum reduction)', () {
+      // Craft offsets whose second-values have digit sums summing to 256.
+      // 255 tracks is impractical; use two tracks whose digit-sums total 256.
+      // Offset with seconds = 9999999... too large. Instead, verify the
+      // modulus branch by direct arithmetic: construct a case where the
+      // raw n is 256 and check the id's top byte is 1 (256 % 255 = 1).
+      // Seconds with digit-sum 256: use 30 tracks each with digit-sum ≈ 9.
+      // Simpler: synthesise 100 tracks at 10s apart starting at 150.
+      final offsets = List<int>.generate(100, (i) => 150 + i * 750);
+      // Digit sums of (2, 12, 22, …, 992): computed below.
+      int expectedN = 0;
+      for (var i = 0; i < 100; i++) {
+        var s = 2 + i * 10;
+        var ds = 0;
+        while (s > 0) {
+          ds += s % 10;
+          s ~/= 10;
+        }
+        expectedN += ds;
+      }
+      const leadoutSec = 2 + 100 * 10; // one extra 10s past last offset
+      const leadoutFrame = leadoutSec * 75;
+      const t = leadoutSec - 2;
+      final expectedTopByte = (expectedN % 255) & 0xFF;
+      final expected =
+          (expectedTopByte << 24) | (t << 8) | 100;
+      final id = CddbDiscIdCalculator.calculate(
+        frameOffsets: offsets,
+        leadoutFrame: leadoutFrame,
+      );
+      expect(id, expected.toRadixString(16).padLeft(8, '0'));
+    });
+
+    test('throws when frameOffsets is empty', () {
+      expect(
+        () => CddbDiscIdCalculator.calculate(
+          frameOffsets: const [],
+          leadoutFrame: 1000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when leadoutFrame is not after last offset', () {
+      expect(
+        () => CddbDiscIdCalculator.calculate(
+          frameOffsets: const [150, 15000],
+          leadoutFrame: 15000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('throws when offsets are not strictly ascending', () {
+      expect(
+        () => CddbDiscIdCalculator.calculate(
+          frameOffsets: const [150, 15000, 10000],
+          leadoutFrame: 20000,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('result is lowercase 8-char hex', () {
+      final id = CddbDiscIdCalculator.calculate(
+        frameOffsets: const [150, 15000, 30000],
+        leadoutFrame: 45000,
+      );
+      expect(id.length, 8);
+      expect(id, id.toLowerCase());
+      expect(RegExp(r'^[0-9a-f]{8}$').hasMatch(id), isTrue);
+    });
+  });
+
+  group('CddbDiscIdCalculator.cddbSum (digit sum)', () {
+    test('returns 0 for 0', () {
+      expect(CddbDiscIdCalculator.cddbSum(0), 0);
+    });
+    test('single-digit numbers return themselves', () {
+      expect(CddbDiscIdCalculator.cddbSum(7), 7);
+    });
+    test('multi-digit numbers sum digits', () {
+      expect(CddbDiscIdCalculator.cddbSum(123), 6);
+      expect(CddbDiscIdCalculator.cddbSum(999), 27);
+      expect(CddbDiscIdCalculator.cddbSum(2025), 9);
+    });
+  });
+}

--- a/test/unit/core/gnudb/cue_frame_offsets_parser_test.dart
+++ b/test/unit/core/gnudb/cue_frame_offsets_parser_test.dart
@@ -1,0 +1,164 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/core/gnudb/cue_frame_offsets_parser.dart';
+
+void main() {
+  group('CueFrameOffsetsParser.parse', () {
+    test('extracts INDEX 01 offsets from a single-file image CUE', () {
+      const cue = '''
+REM GENRE "Rock"
+REM DATE "2023"
+PERFORMER "Example Artist"
+TITLE "Example Album"
+FILE "album.flac" WAVE
+  TRACK 01 AUDIO
+    TITLE "First Song"
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    TITLE "Second Song"
+    INDEX 00 03:18:00
+    INDEX 01 03:20:00
+  TRACK 03 AUDIO
+    TITLE "Third Song"
+    INDEX 01 06:40:00
+''';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets, hasLength(3));
+      expect(offsets[0].trackNumber, 1);
+      expect(offsets[0].filePath, 'album.flac');
+      expect(offsets[0].inFileFrameOffset, 0);
+      expect(offsets[1].trackNumber, 2);
+      expect(offsets[1].filePath, 'album.flac');
+      // 3:20.00 -> (3*60 + 20)*75 = 15000
+      expect(offsets[1].inFileFrameOffset, 15000);
+      expect(offsets[2].trackNumber, 3);
+      expect(offsets[2].inFileFrameOffset, 30000);
+    });
+
+    test('extracts offsets from a multi-file CUE (one file per track)', () {
+      const cue = '''
+PERFORMER "Foo"
+TITLE "Bar"
+FILE "track01.flac" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+FILE "track02.flac" WAVE
+  TRACK 02 AUDIO
+    INDEX 01 00:00:00
+FILE "track03.flac" WAVE
+  TRACK 03 AUDIO
+    INDEX 01 00:00:00
+''';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets, hasLength(3));
+      expect(offsets.map((o) => o.filePath).toList(),
+          ['track01.flac', 'track02.flac', 'track03.flac']);
+      expect(offsets.every((o) => o.inFileFrameOffset == 0), isTrue);
+    });
+
+    test('ignores data tracks (non-AUDIO)', () {
+      const cue = '''
+FILE "album.flac" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+  TRACK 02 MODE1/2352
+    INDEX 01 01:00:00
+  TRACK 03 AUDIO
+    INDEX 01 02:00:00
+''';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets, hasLength(2));
+      expect(offsets.map((o) => o.trackNumber).toList(), [1, 3]);
+    });
+
+    test('prefers INDEX 01 over INDEX 00 (pregap)', () {
+      const cue = '''
+FILE "album.flac" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+  TRACK 02 AUDIO
+    INDEX 00 01:58:00
+    INDEX 01 02:00:00
+''';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets[1].inFileFrameOffset, (2 * 60) * 75); // 9000
+    });
+
+    test('handles quoted file paths with spaces', () {
+      const cue = '''
+FILE "My Album.flac" WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+''';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets.first.filePath, 'My Album.flac');
+    });
+
+    test('handles unquoted single-token file paths', () {
+      const cue = '''
+FILE album.flac WAVE
+  TRACK 01 AUDIO
+    INDEX 01 00:00:00
+''';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets.first.filePath, 'album.flac');
+    });
+
+    test('accepts CRLF line endings', () {
+      const cue =
+          'FILE "album.flac" WAVE\r\n  TRACK 01 AUDIO\r\n    INDEX 01 00:00:00\r\n';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets, hasLength(1));
+      expect(offsets.first.inFileFrameOffset, 0);
+    });
+
+    test('throws when a track has no INDEX 01', () {
+      const cue = '''
+FILE "album.flac" WAVE
+  TRACK 01 AUDIO
+    INDEX 00 00:00:00
+''';
+      expect(
+        () => CueFrameOffsetsParser.parse(cue),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('returns empty list for a CUE with no audio tracks', () {
+      const cue = '''
+REM GENRE "Rock"
+''';
+      final offsets = CueFrameOffsetsParser.parse(cue);
+      expect(offsets, isEmpty);
+    });
+  });
+
+  group('CueFrameOffsetsParser.parseFile', () {
+    test('reads from disk and parses', () async {
+      final tempDir = await Directory.systemTemp.createTemp('cue_parse_');
+      addTearDown(() async {
+        if (await tempDir.exists()) await tempDir.delete(recursive: true);
+      });
+      final cueFile = File('${tempDir.path}/sample.cue');
+      await cueFile.writeAsString(
+        await File(
+                'test/fixtures/gnudb/sample.cue')
+            .readAsString(),
+      );
+      final offsets = await CueFrameOffsetsParser.parseFile(cueFile.path);
+      expect(offsets, hasLength(3));
+      expect(offsets.first.filePath, 'album.flac');
+    });
+  });
+
+  group('CueFrameOffsetsParser.msfToFrames', () {
+    test('converts MM:SS:FF to absolute frames', () {
+      expect(CueFrameOffsetsParser.msfToFrames(0, 0, 0), 0);
+      expect(CueFrameOffsetsParser.msfToFrames(0, 1, 0), 75);
+      expect(CueFrameOffsetsParser.msfToFrames(1, 0, 0), 60 * 75);
+      expect(CueFrameOffsetsParser.msfToFrames(3, 20, 0), 15000);
+      expect(CueFrameOffsetsParser.msfToFrames(6, 40, 25), 30025);
+    });
+  });
+}

--- a/test/unit/data/mappers/gnudb_mapper_test.dart
+++ b/test/unit/data/mappers/gnudb_mapper_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/mappers/gnudb_mapper.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+
+void main() {
+  const sampleDto = GnudbDiscDto(
+    discId: '08025603',
+    artist: 'Example Artist',
+    albumTitle: 'Example Album',
+    year: 2023,
+    genre: 'Rock',
+    trackTitles: ['First Song', 'Second Song', 'Third Song'],
+    extendedAlbum: 'Album notes',
+  );
+
+  group('GnudbMapper.toMetadataResult', () {
+    test('maps core fields to a music-typed MetadataResult', () {
+      final result = GnudbMapper.toMetadataResult(
+        sampleDto,
+        category: 'rock',
+      );
+      expect(result.barcode, 'gnudb:08025603');
+      expect(result.barcodeType, 'cddb');
+      expect(result.mediaType, MediaType.music);
+      expect(result.title, 'Example Album');
+      expect(result.subtitle, 'Example Artist');
+      expect(result.year, 2023);
+      expect(result.genres, ['Rock']);
+      expect(result.sourceApis, ['gnudb']);
+    });
+
+    test('stashes gnudb-specific identifiers in extraMetadata', () {
+      final result = GnudbMapper.toMetadataResult(
+        sampleDto,
+        category: 'rock',
+      );
+      expect(result.extraMetadata['gnudb_disc_id'], '08025603');
+      expect(result.extraMetadata['gnudb_category'], 'rock');
+      expect(result.extraMetadata['gnudb_track_titles'], [
+        'First Song',
+        'Second Song',
+        'Third Song',
+      ]);
+      expect(result.extraMetadata['gnudb_album_notes'], 'Album notes');
+    });
+
+    test('produces empty genres list when genre is null', () {
+      const dto = GnudbDiscDto(
+        discId: 'deadbeef',
+        artist: 'A',
+        albumTitle: 'B',
+        trackTitles: ['One'],
+      );
+      final result = GnudbMapper.toMetadataResult(dto, category: 'misc');
+      expect(result.genres, isEmpty);
+      expect(result.year, isNull);
+    });
+
+    test('track listing is included in extraMetadata', () {
+      final result = GnudbMapper.toMetadataResult(
+        sampleDto,
+        category: 'rock',
+      );
+      final listing = result.extraMetadata['track_listing']
+          as List<Map<String, dynamic>>;
+      expect(listing, hasLength(3));
+      expect(listing[0]['position'], 1);
+      expect(listing[0]['title'], 'First Song');
+      expect(listing[2]['position'], 3);
+    });
+  });
+
+  group('GnudbMapper.toCandidate', () {
+    test('builds a MetadataCandidate with source=gnudb', () {
+      final candidate = GnudbMapper.toCandidate(
+        sampleDto,
+        category: 'rock',
+      );
+      expect(candidate.sourceApi, 'gnudb');
+      expect(candidate.sourceId, 'rock:08025603');
+      expect(candidate.title, 'Example Album');
+      expect(candidate.subtitle, 'Example Artist');
+      expect(candidate.year, 2023);
+      expect(candidate.mediaType, MediaType.music);
+    });
+  });
+}

--- a/test/unit/data/remote/api/gnudb/gnudb_api_test.dart
+++ b/test/unit/data/remote/api/gnudb/gnudb_api_test.dart
@@ -1,0 +1,142 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_api.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_response_parser.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<String> _textResponse(String body) => Response<String>(
+      requestOptions: RequestOptions(path: '/~cddb/cddb.cgi'),
+      data: body,
+      statusCode: 200,
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: ''));
+  });
+
+  group('GnudbApi.query', () {
+    late _MockDio dio;
+    late GnudbApi api;
+
+    setUp(() {
+      dio = _MockDio();
+      api = GnudbApi(
+        dio: dio,
+        user: 'paul',
+        host: 'localhost',
+      );
+    });
+
+    test('sends hello, proto=6 and correctly-formatted cmd', () async {
+      when(() => dio.get<String>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => _textResponse('202 No match found\n'));
+
+      await api.query(
+        discId: '08025603',
+        frameOffsets: const [150, 15000, 30000],
+        totalSeconds: 600,
+      );
+
+      final captured = verify(() => dio.get<String>(
+            captureAny(),
+            queryParameters: captureAny(named: 'queryParameters'),
+          )).captured;
+      final path = captured[0] as String;
+      final params = captured[1] as Map<String, dynamic>;
+
+      expect(path, '/~cddb/cddb.cgi');
+      expect(params['hello'],
+          'paul localhost MyMediaScanner 1.0');
+      expect(params['proto'], '6');
+      expect(params['cmd'],
+          'cddb query 08025603 3 150 15000 30000 600');
+    });
+
+    test('returns parsed no-match when server replies 202', () async {
+      when(() => dio.get<String>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => _textResponse('202 No match found\n'));
+
+      final result = await api.query(
+        discId: 'deadbeef',
+        frameOffsets: const [150],
+        totalSeconds: 60,
+      );
+
+      expect(result, isA<GnudbQueryNoMatch>());
+    });
+
+    test('returns parsed single-match for 200', () async {
+      when(() => dio.get<String>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => _textResponse(
+          '200 rock 08025603 Example Artist / Example Album\n'));
+
+      final result = await api.query(
+        discId: '08025603',
+        frameOffsets: const [150],
+        totalSeconds: 60,
+      );
+
+      expect(result, isA<GnudbQuerySingle>());
+      final single = result as GnudbQuerySingle;
+      expect(single.match.category, 'rock');
+      expect(single.match.discId, '08025603');
+    });
+  });
+
+  group('GnudbApi.read', () {
+    late _MockDio dio;
+    late GnudbApi api;
+
+    setUp(() {
+      dio = _MockDio();
+      api = GnudbApi(dio: dio, user: 'paul', host: 'localhost');
+    });
+
+    test('issues a cddb read command with category and discid', () async {
+      when(() => dio.get<String>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => _textResponse(
+          '210 rock 08025603 CD database entry follows (until terminating `.\')\n'
+          'DISCID=08025603\n'
+          'DTITLE=Artist / Album\n'
+          'TTITLE0=One\n'
+          'TTITLE1=Two\n'
+          '.\n'));
+
+      final dto = await api.read(category: 'rock', discId: '08025603');
+
+      expect(dto, isNotNull);
+      expect(dto!.artist, 'Artist');
+      expect(dto.albumTitle, 'Album');
+      expect(dto.trackTitles, ['One', 'Two']);
+
+      final captured = verify(() => dio.get<String>(
+            any(),
+            queryParameters: captureAny(named: 'queryParameters'),
+          )).captured;
+      final params = captured.first as Map<String, dynamic>;
+      expect(params['cmd'], 'cddb read rock 08025603');
+      expect(params['proto'], '6');
+    });
+
+    test('returns null when server returns an error body', () async {
+      when(() => dio.get<String>(
+            any(),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => _textResponse('401 Not authorised\n'));
+
+      final dto = await api.read(category: 'rock', discId: '08025603');
+      expect(dto, isNull);
+    });
+  });
+}

--- a/test/unit/data/remote/api/gnudb/gnudb_response_parser_test.dart
+++ b/test/unit/data/remote/api/gnudb/gnudb_response_parser_test.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_response_parser.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+
+Future<String> _loadFixture(String name) =>
+    File('test/fixtures/gnudb/$name').readAsString();
+
+void main() {
+  group('GnudbResponseParser.parseQuery', () {
+    test('200 returns a single match', () async {
+      final body = await _loadFixture('query_200_single.txt');
+      final result = GnudbResponseParser.parseQuery(body);
+
+      expect(result, isA<GnudbQuerySingle>());
+      final single = result as GnudbQuerySingle;
+      expect(single.match.category, 'rock');
+      expect(single.match.discId, '08025603');
+      expect(single.match.title, 'Example Artist / Example Album');
+    });
+
+    test('210 returns multiple matches terminated by dot', () async {
+      final body = await _loadFixture('query_210_multi.txt');
+      final result = GnudbResponseParser.parseQuery(body);
+
+      expect(result, isA<GnudbQueryMulti>());
+      final multi = result as GnudbQueryMulti;
+      expect(multi.matches, hasLength(3));
+      expect(multi.matches[0].category, 'rock');
+      expect(multi.matches[0].discId, '08025603');
+      expect(multi.matches[0].title, 'Example Artist / Example Album');
+      expect(multi.matches[1].category, 'pop');
+      expect(multi.matches[1].discId, 'a0b1c2d3');
+      expect(multi.matches[2].category, 'jazz');
+      expect(multi.matches[2].discId, 'feedface');
+    });
+
+    test('211 is handled as multi (inexact matches)', () {
+      const body = '''
+211 Close matches, list follows (until terminating `.')
+rock 11111111 Foo / Bar
+pop  22222222 Baz / Qux
+.
+''';
+      final result = GnudbResponseParser.parseQuery(body);
+      expect(result, isA<GnudbQueryMulti>());
+      expect((result as GnudbQueryMulti).matches, hasLength(2));
+    });
+
+    test('202 returns no-match', () async {
+      final body = await _loadFixture('query_202_nomatch.txt');
+      final result = GnudbResponseParser.parseQuery(body);
+      expect(result, isA<GnudbQueryNoMatch>());
+    });
+
+    test('5xx returns error with status code and message', () {
+      const body = '500 Internal server error';
+      final result = GnudbResponseParser.parseQuery(body);
+      expect(result, isA<GnudbQueryError>());
+      final err = result as GnudbQueryError;
+      expect(err.code, 500);
+      expect(err.message, contains('Internal server error'));
+    });
+
+    test('empty body produces an error', () {
+      final result = GnudbResponseParser.parseQuery('');
+      expect(result, isA<GnudbQueryError>());
+    });
+  });
+
+  group('GnudbResponseParser.parseDisc', () {
+    test('parses DTITLE, DYEAR, DGENRE, and numbered TTITLEs', () async {
+      final body = await _loadFixture('read_disc_full.txt');
+      final dto = GnudbResponseParser.parseDisc(body);
+
+      expect(dto, isA<GnudbDiscDto>());
+      expect(dto!.discId, '08025603');
+      expect(dto.artist, 'Example Artist');
+      expect(dto.albumTitle, 'Example Album');
+      expect(dto.year, 2023);
+      expect(dto.genre, 'Rock');
+      // TTITLE1 appears twice and should be joined, per CDDB spec.
+      expect(dto.trackTitles, [
+        'First Song',
+        'Second Song with a much longer title that wraps  across two lines',
+        'Third Song',
+      ]);
+    });
+
+    test('returns null for non-2xx status', () {
+      const body = '401 Not authorised';
+      final dto = GnudbResponseParser.parseDisc(body);
+      expect(dto, isNull);
+    });
+
+    test('handles DTITLE with no slash (artist == album)', () {
+      const body = '''
+210 rock 12345678 CD database entry follows (until terminating `.')
+DISCID=12345678
+DTITLE=Various Artists Compilation
+DYEAR=
+DGENRE=
+TTITLE0=One
+.
+''';
+      final dto = GnudbResponseParser.parseDisc(body)!;
+      expect(dto.artist, 'Various Artists Compilation');
+      expect(dto.albumTitle, 'Various Artists Compilation');
+      expect(dto.year, isNull);
+      expect(dto.genre, isNull);
+      expect(dto.trackTitles, ['One']);
+    });
+
+    test('is tolerant to unexpected keys and blank lines', () {
+      const body = '''
+210 misc abcdef01 CD database entry follows (until terminating `.')
+# comment
+DISCID=abcdef01
+DTITLE=A / B
+
+TTITLE0=Track A
+UNKNOWN_KEY=whatever
+TTITLE1=Track B
+.
+''';
+      final dto = GnudbResponseParser.parseDisc(body)!;
+      expect(dto.trackTitles, ['Track A', 'Track B']);
+    });
+
+    test('returns discId from status line when DISCID= absent', () {
+      const body = '''
+210 rock deadbeef CD database entry follows (until terminating `.')
+DTITLE=Foo / Bar
+TTITLE0=One
+.
+''';
+      final dto = GnudbResponseParser.parseDisc(body)!;
+      expect(dto.discId, 'deadbeef');
+    });
+  });
+}

--- a/test/unit/domain/usecases/apply_gnudb_result_usecase_test.dart
+++ b/test/unit/domain/usecases/apply_gnudb_result_usecase_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/metadata_result.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
+import 'package:mymediascanner/domain/repositories/i_rip_library_repository.dart';
+import 'package:mymediascanner/domain/usecases/apply_gnudb_result_usecase.dart';
+import 'package:mymediascanner/domain/usecases/edit_rip_metadata_usecase.dart';
+import 'package:mymediascanner/domain/usecases/lookup_gnudb_for_rip_usecase.dart';
+import 'package:mymediascanner/domain/usecases/save_media_item_usecase.dart';
+
+class _MockEdit extends Mock implements EditRipMetadataUseCase {}
+
+class _MockSave extends Mock implements SaveMediaItemUseCase {}
+
+class _MockRepo extends Mock implements IRipLibraryRepository {}
+
+RipAlbum _album({String? mediaItemId}) => RipAlbum(
+      id: 'album-1',
+      libraryPath: '/lib',
+      trackCount: 3,
+      discCount: 1,
+      totalSizeBytes: 0,
+      cueFilePath: 'x.cue',
+      lastScannedAt: 0,
+      updatedAt: 0,
+      mediaItemId: mediaItemId,
+    );
+
+List<RipTrack> _tracks() => [
+      const RipTrack(
+          id: 't1',
+          ripAlbumId: 'album-1',
+          trackNumber: 1,
+          filePath: '/lib/t1.flac',
+          fileSizeBytes: 0,
+          updatedAt: 0),
+      const RipTrack(
+          id: 't2',
+          ripAlbumId: 'album-1',
+          trackNumber: 2,
+          title: 'Old Title',
+          filePath: '/lib/t2.flac',
+          fileSizeBytes: 0,
+          updatedAt: 0),
+      const RipTrack(
+          id: 't3',
+          ripAlbumId: 'album-1',
+          trackNumber: 3,
+          filePath: '/lib/t3.flac',
+          fileSizeBytes: 0,
+          updatedAt: 0),
+    ];
+
+GnudbCandidate _candidate({
+  List<String> titles = const ['One', 'Two', 'Three'],
+  String category = 'rock',
+  String discId = 'abcdef01',
+}) =>
+    GnudbCandidate(
+      discId: discId,
+      category: category,
+      dto: GnudbDiscDto(
+        discId: discId,
+        artist: 'Artist',
+        albumTitle: 'Album',
+        year: 2023,
+        genre: 'Rock',
+        trackTitles: titles,
+      ),
+    );
+
+MediaItem _mediaItem(String id) => MediaItem(
+      id: id,
+      barcode: 'gnudb:abcdef01',
+      barcodeType: 'cddb',
+      mediaType: MediaType.music,
+      title: 'Album',
+      ownershipStatus: OwnershipStatus.owned,
+      dateAdded: 0,
+      dateScanned: 0,
+      updatedAt: 0,
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const RipTrack(
+      id: 'fallback',
+      ripAlbumId: 'fallback',
+      trackNumber: 0,
+      filePath: '',
+      fileSizeBytes: 0,
+      updatedAt: 0,
+    ));
+    registerFallbackValue(const MetadataResult(
+      barcode: 'fallback',
+      barcodeType: 'fallback',
+    ));
+    registerFallbackValue(const RipAlbum(
+      id: 'fallback',
+      libraryPath: '',
+      trackCount: 0,
+      totalSizeBytes: 0,
+      lastScannedAt: 0,
+      updatedAt: 0,
+    ));
+    registerFallbackValue(<RipTrack>[]);
+  });
+
+  late _MockEdit edit;
+  late _MockSave save;
+  late _MockRepo repo;
+  late ApplyGnudbResultUseCase useCase;
+
+  setUp(() {
+    edit = _MockEdit();
+    save = _MockSave();
+    repo = _MockRepo();
+    when(() => edit.editAlbumMetadata(
+          album: any(named: 'album'),
+          tracks: any(named: 'tracks'),
+          artist: any(named: 'artist'),
+          albumTitle: any(named: 'albumTitle'),
+        )).thenAnswer((_) async {});
+    when(() => edit.editTrackTitle(
+          track: any(named: 'track'),
+          title: any(named: 'title'),
+        )).thenAnswer((_) async {});
+    when(() => repo.linkToMediaItem(any(), any())).thenAnswer((_) async {});
+
+    useCase = ApplyGnudbResultUseCase(
+      editRipMetadata: edit,
+      saveMediaItem: save,
+      repository: repo,
+    );
+  });
+
+  test('updates album-level metadata via EditRipMetadataUseCase', () async {
+    when(() => save.execute(any())).thenAnswer((_) async => _mediaItem('mi-1'));
+
+    await useCase.execute(
+      album: _album(),
+      tracks: _tracks(),
+      candidate: _candidate(),
+    );
+
+    verify(() => edit.editAlbumMetadata(
+          album: any(named: 'album'),
+          tracks: any(named: 'tracks'),
+          artist: 'Artist',
+          albumTitle: 'Album',
+        )).called(1);
+  });
+
+  test('updates each track title except when unchanged or out of range',
+      () async {
+    when(() => save.execute(any())).thenAnswer((_) async => _mediaItem('mi-1'));
+
+    final outcome = await useCase.execute(
+      album: _album(),
+      tracks: _tracks(),
+      candidate: _candidate(titles: const ['One', 'Old Title', 'Three']),
+    );
+
+    // Track 2 kept its existing title; only tracks 1 and 3 are written.
+    expect(outcome.tracksUpdated, 2);
+    verify(() => edit.editTrackTitle(
+          track: any(named: 'track'),
+          title: 'One',
+        )).called(1);
+    verify(() => edit.editTrackTitle(
+          track: any(named: 'track'),
+          title: 'Three',
+        )).called(1);
+    verifyNever(() => edit.editTrackTitle(
+          track: any(named: 'track'),
+          title: 'Old Title',
+        ));
+  });
+
+  test('creates and links a MediaItem when album is unlinked', () async {
+    when(() => save.execute(any())).thenAnswer((_) async => _mediaItem('mi-1'));
+
+    final outcome = await useCase.execute(
+      album: _album(),
+      tracks: _tracks(),
+      candidate: _candidate(),
+    );
+
+    expect(outcome.mediaItemCreated, isTrue);
+    expect(outcome.mediaItemId, 'mi-1');
+    verify(() => save.execute(any())).called(1);
+    verify(() => repo.linkToMediaItem('album-1', 'mi-1')).called(1);
+  });
+
+  test('skips MediaItem creation when already linked', () async {
+    final outcome = await useCase.execute(
+      album: _album(mediaItemId: 'existing'),
+      tracks: _tracks(),
+      candidate: _candidate(),
+    );
+
+    expect(outcome.mediaItemCreated, isFalse);
+    expect(outcome.mediaItemId, 'existing');
+    verifyNever(() => save.execute(any()));
+    verifyNever(() => repo.linkToMediaItem(any(), any()));
+  });
+
+  test('respects createMediaItemIfUnlinked=false', () async {
+    final outcome = await useCase.execute(
+      album: _album(),
+      tracks: _tracks(),
+      candidate: _candidate(),
+      createMediaItemIfUnlinked: false,
+    );
+    expect(outcome.mediaItemCreated, isFalse);
+    verifyNever(() => save.execute(any()));
+  });
+
+  test('ignores empty trackTitles entries', () async {
+    when(() => save.execute(any())).thenAnswer((_) async => _mediaItem('mi-1'));
+
+    final outcome = await useCase.execute(
+      album: _album(),
+      tracks: _tracks(),
+      candidate: _candidate(titles: const ['One', '', 'Three']),
+    );
+    expect(outcome.tracksUpdated, 2);
+  });
+}

--- a/test/unit/domain/usecases/lookup_gnudb_for_rip_usecase_test.dart
+++ b/test/unit/domain/usecases/lookup_gnudb_for_rip_usecase_test.dart
@@ -1,0 +1,329 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/core/gnudb/cue_frame_offsets_parser.dart';
+import 'package:mymediascanner/data/local/dao/barcode_cache_dao.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_api.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/gnudb_response_parser.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_query_match.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
+import 'package:mymediascanner/domain/repositories/i_rip_library_repository.dart';
+import 'package:mymediascanner/domain/usecases/lookup_gnudb_for_rip_usecase.dart';
+
+class _MockApi extends Mock implements GnudbApi {}
+
+class _MockRepo extends Mock implements IRipLibraryRepository {}
+
+RipAlbum _album({
+  String? cueFilePath = '/lib/album/album.cue',
+  int discCount = 1,
+}) =>
+    RipAlbum(
+      id: 'album-1',
+      libraryPath: '/lib/album',
+      trackCount: 3,
+      discCount: discCount,
+      totalSizeBytes: 0,
+      cueFilePath: cueFilePath,
+      lastScannedAt: 0,
+      updatedAt: 0,
+    );
+
+List<RipTrack> _tracks({int count = 3, int durationMs = 200000}) => [
+      for (var i = 1; i <= count; i++)
+        RipTrack(
+          id: 'track-$i',
+          ripAlbumId: 'album-1',
+          discNumber: 1,
+          trackNumber: i,
+          filePath: '/lib/album/track$i.flac',
+          durationMs: durationMs,
+          fileSizeBytes: 0,
+          updatedAt: 0,
+        ),
+    ];
+
+/// CUE offsets for a single-file image (3 tracks at 0, 15000, 30000 frames).
+List<CueTrackOffset> _singleImageOffsets() => const [
+      CueTrackOffset(
+          trackNumber: 1,
+          filePath: 'album.flac',
+          inFileFrameOffset: 0),
+      CueTrackOffset(
+          trackNumber: 2,
+          filePath: 'album.flac',
+          inFileFrameOffset: 15000),
+      CueTrackOffset(
+          trackNumber: 3,
+          filePath: 'album.flac',
+          inFileFrameOffset: 30000),
+    ];
+
+/// CUE offsets for a per-track multi-file CUE.
+List<CueTrackOffset> _perTrackOffsets() => const [
+      CueTrackOffset(
+          trackNumber: 1, filePath: 't1.flac', inFileFrameOffset: 0),
+      CueTrackOffset(
+          trackNumber: 2, filePath: 't2.flac', inFileFrameOffset: 0),
+      CueTrackOffset(
+          trackNumber: 3, filePath: 't3.flac', inFileFrameOffset: 0),
+    ];
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const <int>[]);
+  });
+
+  late AppDatabase db;
+  late BarcodeCacheDao cacheDao;
+  late _MockApi api;
+  late _MockRepo repo;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    cacheDao = BarcodeCacheDao(db);
+    api = _MockApi();
+    repo = _MockRepo();
+    when(() => repo.updateGnudbDiscId(any(), any()))
+        .thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  LookupGnudbForRipUseCase buildUseCase(
+      {CueFrameOffsetsLoader? loader}) =>
+      LookupGnudbForRipUseCase(
+        api: api,
+        cacheDao: cacheDao,
+        repository: repo,
+        rootPath: '/lib/album',
+        loader: loader ?? (path) async => _singleImageOffsets(),
+      );
+
+  group('early validation errors', () {
+    test('no cue => error', () async {
+      final result = await buildUseCase().execute(
+        album: _album(cueFilePath: null),
+        tracks: _tracks(),
+      );
+      expect(result, isA<GnudbLookupError>());
+    });
+
+    test('multi-disc => error', () async {
+      final result = await buildUseCase().execute(
+        album: _album(discCount: 2),
+        tracks: _tracks(),
+      );
+      expect(result, isA<GnudbLookupError>());
+    });
+
+    test('empty tracks => error', () async {
+      final result = await buildUseCase().execute(
+        album: _album(),
+        tracks: const [],
+      );
+      expect(result, isA<GnudbLookupError>());
+    });
+
+    test('missing duration => error', () async {
+      final tracks = _tracks()
+          .map((t) => t.copyWith(durationMs: null))
+          .toList();
+      final result = await buildUseCase().execute(
+        album: _album(),
+        tracks: tracks,
+      );
+      expect(result, isA<GnudbLookupError>());
+    });
+
+    test('track count mismatch => error', () async {
+      final uc = buildUseCase(
+        loader: (_) async => _singleImageOffsets().take(2).toList(),
+      );
+      final result = await uc.execute(album: _album(), tracks: _tracks());
+      expect(result, isA<GnudbLookupError>());
+    });
+  });
+
+  group('successful flows', () {
+    test('single match returns GnudbLookupSingle, writes cache and discid',
+        () async {
+      when(() => api.query(
+            discId: any(named: 'discId'),
+            frameOffsets: any(named: 'frameOffsets'),
+            totalSeconds: any(named: 'totalSeconds'),
+          )).thenAnswer((_) async => const GnudbQuerySingle(
+            GnudbQueryMatch(
+              category: 'rock',
+              discId: '08025603',
+              title: 'Example Artist / Example Album',
+            ),
+          ));
+
+      when(() => api.read(
+            category: any(named: 'category'),
+            discId: any(named: 'discId'),
+          )).thenAnswer((_) async => const GnudbDiscDto(
+            discId: '08025603',
+            artist: 'Example Artist',
+            albumTitle: 'Example Album',
+            year: 2023,
+            genre: 'Rock',
+            trackTitles: ['One', 'Two', 'Three'],
+          ));
+
+      final result = await buildUseCase().execute(
+        album: _album(),
+        tracks: _tracks(),
+      );
+
+      expect(result, isA<GnudbLookupSingle>());
+      final single = result as GnudbLookupSingle;
+      expect(single.candidate.discId, '08025603');
+      verify(() => repo.updateGnudbDiscId('album-1', any())).called(1);
+
+      // Cache is keyed by the *computed* disc id. With 3 tracks of 200s
+      // each and LBAs [150, 15150, 30150], the disc id is 0c025803.
+      final cached = await cacheDao.getByBarcode('gnudb:0c025803');
+      expect(cached, isNotNull);
+      expect(cached!.sourceApi, 'gnudb');
+    });
+
+    test('multi match returns at most _maxMultiCandidates candidates',
+        () async {
+      when(() => api.query(
+            discId: any(named: 'discId'),
+            frameOffsets: any(named: 'frameOffsets'),
+            totalSeconds: any(named: 'totalSeconds'),
+          )).thenAnswer((_) async => GnudbQueryMulti([
+            for (var i = 0; i < 8; i++)
+              GnudbQueryMatch(
+                category: 'misc',
+                discId: '0000000$i',
+                title: 'Artist $i / Album $i',
+              ),
+          ]));
+
+      when(() => api.read(
+            category: any(named: 'category'),
+            discId: any(named: 'discId'),
+          )).thenAnswer((invocation) async {
+        final discId =
+            invocation.namedArguments[const Symbol('discId')] as String;
+        return GnudbDiscDto(
+          discId: discId,
+          artist: 'A',
+          albumTitle: 'B',
+          trackTitles: const ['x', 'y', 'z'],
+        );
+      });
+
+      final result = await buildUseCase().execute(
+        album: _album(),
+        tracks: _tracks(),
+      );
+
+      expect(result, isA<GnudbLookupMulti>());
+      expect((result as GnudbLookupMulti).candidates, hasLength(5));
+    });
+
+    test('no-match from server', () async {
+      when(() => api.query(
+            discId: any(named: 'discId'),
+            frameOffsets: any(named: 'frameOffsets'),
+            totalSeconds: any(named: 'totalSeconds'),
+          )).thenAnswer((_) async => const GnudbQueryNoMatch());
+
+      final result = await buildUseCase().execute(
+        album: _album(),
+        tracks: _tracks(),
+      );
+
+      expect(result, isA<GnudbLookupNoMatch>());
+    });
+
+    test('server error bubbles up as GnudbLookupError', () async {
+      when(() => api.query(
+            discId: any(named: 'discId'),
+            frameOffsets: any(named: 'frameOffsets'),
+            totalSeconds: any(named: 'totalSeconds'),
+          )).thenAnswer((_) async => const GnudbQueryError(
+              code: 500, message: 'Internal server error'));
+
+      final result = await buildUseCase().execute(
+        album: _album(),
+        tracks: _tracks(),
+      );
+      expect(result, isA<GnudbLookupError>());
+    });
+  });
+
+  group('caching', () {
+    test('cache hit short-circuits API', () async {
+      // Seed cache first via a single-match round-trip.
+      when(() => api.query(
+            discId: any(named: 'discId'),
+            frameOffsets: any(named: 'frameOffsets'),
+            totalSeconds: any(named: 'totalSeconds'),
+          )).thenAnswer((_) async => const GnudbQuerySingle(
+            GnudbQueryMatch(
+              category: 'rock',
+              discId: '08025603',
+              title: 'A / B',
+            ),
+          ));
+      when(() => api.read(
+            category: any(named: 'category'),
+            discId: any(named: 'discId'),
+          )).thenAnswer((_) async => const GnudbDiscDto(
+            discId: '08025603',
+            artist: 'A',
+            albumTitle: 'B',
+            trackTitles: ['1', '2', '3'],
+          ));
+
+      await buildUseCase().execute(album: _album(), tracks: _tracks());
+
+      // Now second run — API should not be called.
+      clearInteractions(api);
+      final second =
+          await buildUseCase().execute(album: _album(), tracks: _tracks());
+      expect(second, isA<GnudbLookupSingle>());
+      verifyNever(() => api.query(
+            discId: any(named: 'discId'),
+            frameOffsets: any(named: 'frameOffsets'),
+            totalSeconds: any(named: 'totalSeconds'),
+          ));
+    });
+  });
+
+  group('multi-file CUE produces correct LBAs', () {
+    test('per-track file cue yields cumulative offsets', () async {
+      // 3 tracks of 200s each → 15000 frames each.
+      // Expected LBAs: 150, 15150, 30150 → identical to single-image case,
+      // which means the Disc ID should match the first test's 08025603.
+      when(() => api.query(
+            discId: any(named: 'discId'),
+            frameOffsets: any(named: 'frameOffsets'),
+            totalSeconds: any(named: 'totalSeconds'),
+          )).thenAnswer((_) async => const GnudbQueryNoMatch());
+
+      final uc = buildUseCase(loader: (_) async => _perTrackOffsets());
+      await uc.execute(album: _album(), tracks: _tracks());
+
+      final captured = verify(() => api.query(
+            discId: captureAny(named: 'discId'),
+            frameOffsets: captureAny(named: 'frameOffsets'),
+            totalSeconds: captureAny(named: 'totalSeconds'),
+          )).captured;
+      expect(captured[0], '0c025803');
+      expect(captured[1], [150, 15150, 30150]);
+      expect(captured[2], 602);
+    });
+  });
+}

--- a/test/unit/presentation/providers/gnudb_provider_test.dart
+++ b/test/unit/presentation/providers/gnudb_provider_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/domain/usecases/lookup_gnudb_for_rip_usecase.dart';
+import 'package:mymediascanner/presentation/providers/gnudb_provider.dart';
+
+void main() {
+  GnudbLookupState readState(ProviderContainer container) =>
+      container.read(gnudbLookupNotifierProvider);
+
+  test('initial state is idle', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final s = readState(container);
+    expect(s.status, GnudbLookupStatus.idle);
+    expect(s.candidates, isEmpty);
+  });
+
+  test('reset returns state to idle', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    // Force a non-idle state via direct assignment helper: we test the
+    // reset() method using the notifier's public API.
+    final notifier = container.read(gnudbLookupNotifierProvider.notifier);
+    notifier.reset();
+    expect(container.read(gnudbLookupNotifierProvider).status,
+        GnudbLookupStatus.idle);
+  });
+
+  test('GnudbLookupState.copyWith preserves defaults', () {
+    const s = GnudbLookupState();
+    final updated =
+        s.copyWith(status: GnudbLookupStatus.fetching);
+    expect(updated.status, GnudbLookupStatus.fetching);
+    expect(updated.candidates, isEmpty);
+  });
+
+  test(
+      'GnudbLookupState.copyWith carries candidates across status changes',
+      () {
+    const dto = GnudbDiscDto(
+      discId: 'abcdef01',
+      artist: 'A',
+      albumTitle: 'B',
+      trackTitles: ['x'],
+    );
+    const candidate = GnudbCandidate(
+      discId: 'abcdef01',
+      category: 'rock',
+      dto: dto,
+    );
+    const s = GnudbLookupState();
+    final withCandidates = s.copyWith(
+      status: GnudbLookupStatus.ambiguous,
+      candidates: [candidate],
+    );
+    expect(withCandidates.candidates, hasLength(1));
+    final applying =
+        withCandidates.copyWith(status: GnudbLookupStatus.applying);
+    // candidates are carried over because copyWith does not clear them.
+    expect(applying.candidates, hasLength(1));
+  });
+}

--- a/test/widget/presentation/screens/rips/widgets/gnudb_candidate_picker_dialog_test.dart
+++ b/test/widget/presentation/screens/rips/widgets/gnudb_candidate_picker_dialog_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/remote/api/gnudb/models/gnudb_disc_dto.dart';
+import 'package:mymediascanner/domain/usecases/lookup_gnudb_for_rip_usecase.dart';
+import 'package:mymediascanner/presentation/screens/disambiguation/widgets/candidate_card.dart';
+import 'package:mymediascanner/presentation/screens/rips/widgets/gnudb_candidate_picker_dialog.dart';
+
+GnudbCandidate _candidate(int i) => GnudbCandidate(
+      discId: 'abc0000$i',
+      category: 'rock',
+      dto: GnudbDiscDto(
+        discId: 'abc0000$i',
+        artist: 'Artist $i',
+        albumTitle: 'Album $i',
+        year: 2020 + i,
+        trackTitles: const ['One', 'Two'],
+      ),
+    );
+
+void main() {
+  testWidgets('renders a CandidateCard per candidate', (tester) async {
+    final candidates = [_candidate(1), _candidate(2), _candidate(3)];
+
+    await tester.pumpWidget(MaterialApp(
+      home: GnudbCandidatePickerDialog(candidates: candidates),
+    ));
+
+    expect(find.byType(CandidateCard), findsNWidgets(3));
+    expect(find.text('Album 1'), findsOneWidget);
+    expect(find.text('Artist 3'), findsOneWidget);
+  });
+
+  testWidgets('tapping a card pops the dialog with that candidate',
+      (tester) async {
+    final candidates = [_candidate(1), _candidate(2)];
+    GnudbCandidate? selected;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (ctx) {
+          return ElevatedButton(
+            onPressed: () async {
+              selected = await showGnudbCandidatePicker(
+                context: ctx,
+                candidates: candidates,
+              );
+            },
+            child: const Text('open'),
+          );
+        }),
+      ),
+    ));
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(GnudbCandidatePickerDialog), findsOneWidget);
+
+    await tester.tap(find.text('Album 2'));
+    await tester.pumpAndSettle();
+
+    expect(selected, isNotNull);
+    expect(selected!.discId, 'abc00002');
+  });
+
+  testWidgets('Cancel dismisses without selecting', (tester) async {
+    GnudbCandidate? selected;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Builder(builder: (ctx) {
+          return ElevatedButton(
+            onPressed: () async {
+              selected = await showGnudbCandidatePicker(
+                context: ctx,
+                candidates: [_candidate(1)],
+              );
+            },
+            child: const Text('open'),
+          );
+        }),
+      ),
+    ));
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(selected, isNull);
+  });
+}

--- a/test/widget/presentation/screens/rips/widgets/gnudb_lookup_button_test.dart
+++ b/test/widget/presentation/screens/rips/widgets/gnudb_lookup_button_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/presentation/screens/rips/widgets/gnudb_lookup_button.dart';
+
+RipAlbum _album({String? cue = 'x.cue', int discCount = 1}) => RipAlbum(
+      id: 'a',
+      libraryPath: '/lib',
+      trackCount: 1,
+      discCount: discCount,
+      totalSizeBytes: 0,
+      cueFilePath: cue,
+      lastScannedAt: 0,
+      updatedAt: 0,
+    );
+
+Widget _pumpable(Widget child) => ProviderScope(
+      child: MaterialApp(
+        home: Scaffold(body: child),
+      ),
+    );
+
+void main() {
+  testWidgets('button is disabled when album has no CUE', (tester) async {
+    await tester.pumpWidget(
+      _pumpable(GnudbLookupButton(album: _album(cue: null))),
+    );
+    final button = tester.widget<IconButton>(find.byType(IconButton));
+    expect(button.onPressed, isNull);
+    expect(button.tooltip, contains('CUE sheet'));
+  });
+
+  testWidgets('button is disabled for multi-disc albums', (tester) async {
+    await tester.pumpWidget(
+      _pumpable(GnudbLookupButton(album: _album(discCount: 2))),
+    );
+    final button = tester.widget<IconButton>(find.byType(IconButton));
+    expect(button.onPressed, isNull);
+    expect(button.tooltip, contains('multi-disc'));
+  });
+
+  testWidgets('button is enabled for valid single-disc rip album',
+      (tester) async {
+    await tester.pumpWidget(
+      _pumpable(GnudbLookupButton(album: _album())),
+    );
+    final button = tester.widget<IconButton>(find.byType(IconButton));
+    expect(button.onPressed, isNotNull);
+    expect(button.tooltip, 'Look up on GnuDB');
+  });
+}

--- a/test/widget/presentation/screens/settings/widgets/gnudb_settings_section_test.dart
+++ b/test/widget/presentation/screens/settings/widgets/gnudb_settings_section_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+import 'package:mymediascanner/presentation/screens/settings/widgets/gnudb_settings_section.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('displays the default username and saves edits',
+      (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(body: GnudbSettingsSection()),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    expect(textField.controller?.text, 'mymediascanner');
+
+    await tester.enterText(find.byType(TextField), 'paul');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    // Provider was updated.
+    final element = tester.element(find.byType(GnudbSettingsSection));
+    final container = ProviderScope.containerOf(element);
+    expect(container.read(gnudbUsernameProvider), 'paul');
+
+    // Snackbar shown.
+    expect(find.text('GnuDB username saved'), findsOneWidget);
+  });
+
+  testWidgets('empty input reverts to default on save', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(body: GnudbSettingsSection()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final element = tester.element(find.byType(GnudbSettingsSection));
+    final container = ProviderScope.containerOf(element);
+    expect(container.read(gnudbUsernameProvider), 'mymediascanner');
+  });
+}


### PR DESCRIPTION
## Summary

Closes #52.

Adds a user-triggered **"Look up on GnuDB"** action to the rip album detail dialog. Computes a CDDB Disc ID from the album's CUE sheet, queries gnudb.org, and applies the returned metadata to:

- `rip_albums.artist` / `rip_albums.albumTitle`
- `rip_tracks.title` per-track (plus FLAC `ALBUMARTIST` / `ALBUM` / `TITLE` Vorbis Comments via the existing `EditRipMetadataUseCase`)
- A newly created linked `MediaItem` in the main collection when the rip album is not already linked

## Scope

- **Input source:** CUE files only — no physical CD drive reading.
- **Trigger:** manual button in the rip album detail dialog; disabled (with tooltip) when no CUE is present or the rip is multi-disc.
- **Cache:** reuses `barcode_cache` keyed `gnudb:<discid>`, 7-day TTL.
- **Schema:** bumps to `v16` adding `rip_albums.gnudbDiscId`. No migration block — v1 is unreleased.

## Architecture

- `CddbDiscIdCalculator` + `CueFrameOffsetsParser` — pure-Dart, TDD-first with hand-computed vectors
- `GnudbApi` + `GnudbResponseParser` — manual Dio (`ResponseType.plain`), `RateLimiter(1100ms)`, `hello` + `proto=6` on every request
- `GnudbMapper`, `LookupGnudbForRipUseCase`, `ApplyGnudbResultUseCase`
- `gnudbLookupNotifierProvider` state machine (`idle → computing → fetching → ambiguous → applying → complete`)
- `GnudbLookupButton`, `GnudbCandidatePickerDialog` (reuses the existing `CandidateCard`)
- `GnudbSettingsSection` with `gnudbUsernameProvider` persisted to `SharedPreferences`

## Tests

72 new unit / widget tests. Full suite: **1077 tests pass**. `flutter analyze` clean.

## Test plan

- [ ] Place a CUE + FLAC rip of a disc with a known gnudb.org disc id.
- [ ] Open its detail dialog — cloud-download icon appears next to the edit button.
- [ ] Tap — spinner shows, then either auto-apply (single match) or candidate picker (multi match).
- [ ] Confirm album artist / album title update in the dialog; track titles update in the list.
- [ ] Run `metaflac --list <track>.flac` — `ALBUMARTIST` / `ALBUM` / `TITLE` populated.
- [ ] Navigate to the collection — a new music `MediaItem` exists and the rip is linked to it.
- [ ] Re-tap the button — cache hit (no network call; verify via logs).
- [ ] Point at an unidentifiable rip — "No match" snackbar, zero DB changes.
- [ ] Multi-disc album — tooltip explains why the button is disabled.
- [ ] No-CUE album — tooltip explains why the button is disabled.

## Known limitations

- **Multi-disc sets** are deferred to a follow-up issue — CDDB Disc IDs are per-disc.
- **MP3 tags** are not written (inherited from `EditRipMetadataUseCase`; `metaflac` is FLAC-only). DB updates still apply.
- **Cleartext HTTP** — `gnudb.gnudb.org` is HTTP-only. Android may need `android:usesCleartextTraffic` for that host if not already permitted.