### PR TITLE
feat(games): IGDB online lookup for Manual Add and barcode enrichment

### DIFF
--- a/lib/core/constants/api_constants.dart
+++ b/lib/core/constants/api_constants.dart
@@ -39,6 +39,10 @@ abstract final class ApiConstants {
   // UPCitemdb
   static const upcItemDbBaseUrl = 'https://api.upcitemdb.com/prod/trial';
 
+  // IGDB (Twitch-authenticated games database)
+  static const igdbBaseUrl = 'https://api.igdb.com/v4';
+  static const twitchOAuthBaseUrl = 'https://id.twitch.tv';
+
   // GnuDB — CDDB-compatible disc metadata lookup. The service is HTTP only.
   static const gnudbBaseUrl = 'http://gnudb.gnudb.org';
   static const gnudbCgiPath = '/~cddb/cddb.cgi';

--- a/lib/data/mappers/igdb_mapper.dart
+++ b/lib/data/mappers/igdb_mapper.dart
@@ -1,0 +1,113 @@
+import 'package:mymediascanner/data/remote/api/igdb/models/igdb_game_dto.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/metadata_candidate.dart';
+import 'package:mymediascanner/domain/entities/metadata_result.dart';
+
+/// Maps IGDB game DTOs onto the app's domain metadata types.
+abstract final class IgdbMapper {
+  /// Build a [MetadataResult] from a single IGDB game.
+  ///
+  /// - `title` ← `name`
+  /// - `subtitle` ← first platform name (chip UI lets the user change it)
+  /// - `description` ← `summary`
+  /// - `coverUrl` ← `cover.url` upgraded from `t_thumb` to `t_cover_big`
+  ///   and scheme-fixed to `https:`
+  /// - `year` ← derived from `first_release_date` (UTC)
+  /// - `publisher` ← first involved company flagged as publisher
+  /// - `genres` ← `genres[].name`
+  /// - `criticScore` ← `aggregated_rating`, falling back to `rating`
+  /// - `criticSource` ← `'IGDB'` when a score exists
+  /// - `extraMetadata['developer']` ← first involved company flagged as developer
+  /// - `extraMetadata['platforms']` ← full platform-name list
+  /// - `extraMetadata['igdb_id']` ← numeric IGDB id
+  static MetadataResult fromGame(
+    IgdbGameDto dto,
+    String barcode,
+    String barcodeType,
+  ) {
+    final platformNames = dto.platforms
+            ?.map((p) => p.name)
+            .whereType<String>()
+            .toList() ??
+        const <String>[];
+
+    final developer = _findCompany(dto.involvedCompanies, developer: true);
+    final publisher = _findCompany(dto.involvedCompanies, publisher: true);
+    final score = dto.aggregatedRating ?? dto.rating;
+
+    return MetadataResult(
+      barcode: barcode,
+      barcodeType: barcodeType,
+      mediaType: MediaType.game,
+      title: dto.name,
+      subtitle: platformNames.isNotEmpty ? platformNames.first : null,
+      description: dto.summary,
+      coverUrl: _coverUrl(dto.cover?.url),
+      year: _releaseYear(dto.firstReleaseDate),
+      publisher: publisher,
+      genres: dto.genres?.map((g) => g.name).whereType<String>().toList() ??
+          const <String>[],
+      extraMetadata: {
+        'igdb_id': ?dto.id,
+        'developer': ?developer,
+        if (platformNames.isNotEmpty) 'platforms': platformNames,
+      },
+      sourceApis: const ['igdb'],
+      criticScore: score,
+      criticSource: score != null ? 'IGDB' : null,
+    );
+  }
+
+  /// Build a [MetadataCandidate] from an IGDB search-result game for the
+  /// multi-match disambiguation sheet.
+  static MetadataCandidate toCandidate(IgdbGameDto dto) {
+    final platform = dto.platforms
+        ?.map((p) => p.name)
+        .whereType<String>()
+        .firstOrNull;
+    return MetadataCandidate(
+      sourceApi: 'igdb',
+      sourceId: dto.id?.toString() ?? '',
+      title: dto.name ?? '',
+      subtitle: platform,
+      coverUrl: _coverUrl(dto.cover?.url),
+      year: _releaseYear(dto.firstReleaseDate),
+      mediaType: MediaType.game,
+    );
+  }
+
+  static String? _findCompany(
+    List<IgdbInvolvedCompanyDto>? companies, {
+    bool developer = false,
+    bool publisher = false,
+  }) {
+    if (companies == null || companies.isEmpty) return null;
+    for (final entry in companies) {
+      if (developer && entry.developer == true) {
+        return entry.company?.name;
+      }
+      if (publisher && entry.publisher == true) {
+        return entry.company?.name;
+      }
+    }
+    return null;
+  }
+
+  /// IGDB cover URLs come back as scheme-less `//images.igdb.com/.../t_thumb/<hash>.jpg`.
+  /// Swap to the bigger `t_cover_big` size and add an `https:` scheme.
+  static String? _coverUrl(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    final upgraded = raw.replaceFirst('t_thumb', 't_cover_big');
+    if (upgraded.startsWith('//')) return 'https:$upgraded';
+    return upgraded;
+  }
+
+  static int? _releaseYear(int? unixSeconds) {
+    if (unixSeconds == null) return null;
+    final dt = DateTime.fromMillisecondsSinceEpoch(
+      unixSeconds * 1000,
+      isUtc: true,
+    );
+    return dt.year;
+  }
+}

--- a/lib/data/remote/api/igdb/igdb_api.dart
+++ b/lib/data/remote/api/igdb/igdb_api.dart
@@ -1,0 +1,90 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:mymediascanner/core/constants/api_constants.dart';
+import 'package:mymediascanner/data/remote/api/dio_factory.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_token_manager.dart';
+import 'package:mymediascanner/data/remote/api/igdb/models/igdb_game_dto.dart';
+
+/// Thin wrapper around the IGDB `/v4/games` endpoint.
+///
+/// IGDB speaks [Apicalypse](https://api-docs.igdb.com/#apicalypse-1) — a
+/// text body format where you list fields, filters, and limits in a single
+/// string. We build the query here and send it as the POST body; IGDB
+/// returns a JSON array of matching games.
+///
+/// Auth is a Twitch Client-ID header plus a bearer token sourced from
+/// [IgdbTokenManager]. On a 401 the token is invalidated and the request
+/// retried exactly once.
+class IgdbApi {
+  IgdbApi({
+    required this.tokenManager,
+    Dio? dio,
+  }) : _dio = dio ??
+            DioFactory.create(
+              baseUrl: ApiConstants.igdbBaseUrl,
+              defaultHeaders: const {'Content-Type': 'text/plain'},
+            );
+
+  final IgdbTokenManager tokenManager;
+  final Dio _dio;
+
+  /// Fields requested on every game lookup. Kept centralised so the shape
+  /// of the returned DTO and the shape of the query can't drift.
+  static const _fields = 'name, summary, cover.url, platforms.name, '
+      'involved_companies.company.name, involved_companies.developer, '
+      'involved_companies.publisher, genres.name, first_release_date, '
+      'aggregated_rating, rating';
+
+  /// Search IGDB by free-text title. Results are ordered by IGDB's default
+  /// relevance for `search`.
+  Future<List<IgdbGameDto>> searchByTitle(String title, {int limit = 10}) {
+    final query = 'fields $_fields; search "${_escape(title)}"; limit $limit;';
+    return _postGames(query);
+  }
+
+  /// Fetch a single game by its IGDB id.
+  Future<IgdbGameDto?> getById(int id) async {
+    final query = 'fields $_fields; where id = $id;';
+    final results = await _postGames(query);
+    return results.isEmpty ? null : results.first;
+  }
+
+  Future<List<IgdbGameDto>> _postGames(String apicalypse) async {
+    try {
+      return await _send(apicalypse);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        // Token likely revoked server-side — clear the cache and try once
+        // more with a fresh exchange.
+        tokenManager.invalidate();
+        return _send(apicalypse);
+      }
+      debugPrint('IGDB games lookup failed: $e');
+      rethrow;
+    }
+  }
+
+  Future<List<IgdbGameDto>> _send(String apicalypse) async {
+    final token = await tokenManager.getToken();
+    final response = await _dio.post<List<dynamic>>(
+      '/games',
+      data: apicalypse,
+      options: Options(
+        headers: {
+          'Client-ID': tokenManager.clientId,
+          'Authorization': 'Bearer $token',
+          'Accept': 'application/json',
+        },
+      ),
+    );
+    final raw = response.data ?? const [];
+    return raw
+        .whereType<Map<String, dynamic>>()
+        .map(IgdbGameDto.fromJson)
+        .toList(growable: false);
+  }
+
+  /// Escapes embedded double-quotes in a search term so the Apicalypse
+  /// `search "..."` literal stays well-formed.
+  static String _escape(String raw) => raw.replaceAll('"', r'\"');
+}

--- a/lib/data/remote/api/igdb/igdb_token_manager.dart
+++ b/lib/data/remote/api/igdb/igdb_token_manager.dart
@@ -1,0 +1,95 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:mymediascanner/core/constants/api_constants.dart';
+import 'package:mymediascanner/data/remote/api/dio_factory.dart';
+import 'package:mymediascanner/data/remote/api/igdb/models/twitch_token_dto.dart';
+
+/// Manages the Twitch OAuth bearer-token lifecycle for IGDB.
+///
+/// IGDB is gated behind Twitch's `client_credentials` OAuth flow: the
+/// user's Client ID + Client Secret are exchanged at
+/// `https://id.twitch.tv/oauth2/token` for a bearer token that typically
+/// lives around 60 days. This manager caches the token in memory, refreshes
+/// it lazily when expired, and de-duplicates concurrent refresh attempts.
+class IgdbTokenManager {
+  IgdbTokenManager({
+    required this.clientId,
+    required this.clientSecret,
+    Dio? authDio,
+  }) : _authDio = authDio ??
+            DioFactory.create(baseUrl: ApiConstants.twitchOAuthBaseUrl);
+
+  final String clientId;
+  final String clientSecret;
+  final Dio _authDio;
+
+  String? _cachedToken;
+  DateTime? _tokenExpiry;
+
+  /// De-duplicates concurrent `getToken()` calls. Without this, parallel
+  /// callers whose cached token has expired would each issue their own
+  /// `POST /oauth2/token`, wasting quota and racing each other's writes.
+  Future<String>? _inFlight;
+
+  /// Returns a valid bearer token, refreshing if needed.
+  Future<String> getToken() async {
+    if (_cachedToken != null &&
+        _tokenExpiry != null &&
+        DateTime.now().isBefore(_tokenExpiry!)) {
+      return _cachedToken!;
+    }
+
+    final existing = _inFlight;
+    if (existing != null) return existing;
+
+    final future = _exchange();
+    _inFlight = future;
+    try {
+      return await future;
+    } finally {
+      if (identical(_inFlight, future)) _inFlight = null;
+    }
+  }
+
+  Future<String> _exchange() async {
+    try {
+      final response = await _authDio.post<Map<String, dynamic>>(
+        '/oauth2/token',
+        queryParameters: {
+          'client_id': clientId,
+          'client_secret': clientSecret,
+          'grant_type': 'client_credentials',
+        },
+      );
+
+      final dto = TwitchTokenDto.fromJson(response.data ?? {});
+      final token = dto.accessToken;
+      if (token == null || token.isEmpty) {
+        throw Exception('Twitch token exchange returned no access_token');
+      }
+
+      _cachedToken = token;
+      // Refresh one hour before the advertised expiry to avoid racing the
+      // boundary. `expiresIn` is seconds; fall back to 24 hours if the
+      // response omits it (it shouldn't).
+      final lifetime = Duration(
+        seconds: (dto.expiresIn ?? 86400) - 3600,
+      );
+      _tokenExpiry = DateTime.now().add(
+        lifetime.isNegative ? const Duration(seconds: 60) : lifetime,
+      );
+      return token;
+    } on Exception catch (e) {
+      debugPrint('Twitch OAuth token exchange failed: $e');
+      rethrow;
+    }
+  }
+
+  /// Clears the cached token, forcing a refresh on next call. Use when the
+  /// API returns 401 — the token was likely revoked server-side before its
+  /// advertised expiry.
+  void invalidate() {
+    _cachedToken = null;
+    _tokenExpiry = null;
+  }
+}

--- a/lib/data/remote/api/igdb/models/igdb_game_dto.dart
+++ b/lib/data/remote/api/igdb/models/igdb_game_dto.dart
@@ -1,0 +1,124 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'igdb_game_dto.g.dart';
+
+/// Response model for an IGDB game returned by `POST /v4/games` with an
+/// Apicalypse query that field-expands cover, platforms, involved_companies,
+/// and genres.
+@JsonSerializable()
+class IgdbGameDto {
+  const IgdbGameDto({
+    this.id,
+    this.name,
+    this.summary,
+    this.cover,
+    this.platforms,
+    this.involvedCompanies,
+    this.genres,
+    this.firstReleaseDate,
+    this.aggregatedRating,
+    this.rating,
+  });
+
+  factory IgdbGameDto.fromJson(Map<String, dynamic> json) =>
+      _$IgdbGameDtoFromJson(json);
+
+  final int? id;
+  final String? name;
+  final String? summary;
+  final IgdbCoverDto? cover;
+  final List<IgdbPlatformDto>? platforms;
+
+  @JsonKey(name: 'involved_companies')
+  final List<IgdbInvolvedCompanyDto>? involvedCompanies;
+
+  final List<IgdbGenreDto>? genres;
+
+  /// Seconds since Unix epoch. IGDB returns this as an integer.
+  @JsonKey(name: 'first_release_date')
+  final int? firstReleaseDate;
+
+  /// Critic average (0–100). Null when IGDB has no aggregated critic data.
+  @JsonKey(name: 'aggregated_rating')
+  final double? aggregatedRating;
+
+  /// User score (0–100). Fallback when aggregatedRating is null.
+  final double? rating;
+
+  Map<String, dynamic> toJson() => _$IgdbGameDtoToJson(this);
+}
+
+@JsonSerializable()
+class IgdbCoverDto {
+  const IgdbCoverDto({this.id, this.url});
+
+  factory IgdbCoverDto.fromJson(Map<String, dynamic> json) =>
+      _$IgdbCoverDtoFromJson(json);
+
+  final int? id;
+
+  /// IGDB returns scheme-less URLs like `//images.igdb.com/igdb/image/upload/t_thumb/...`
+  /// The `t_thumb` size is upgraded to `t_cover_big` during mapping.
+  final String? url;
+
+  Map<String, dynamic> toJson() => _$IgdbCoverDtoToJson(this);
+}
+
+@JsonSerializable()
+class IgdbPlatformDto {
+  const IgdbPlatformDto({this.id, this.name});
+
+  factory IgdbPlatformDto.fromJson(Map<String, dynamic> json) =>
+      _$IgdbPlatformDtoFromJson(json);
+
+  final int? id;
+  final String? name;
+
+  Map<String, dynamic> toJson() => _$IgdbPlatformDtoToJson(this);
+}
+
+@JsonSerializable()
+class IgdbGenreDto {
+  const IgdbGenreDto({this.id, this.name});
+
+  factory IgdbGenreDto.fromJson(Map<String, dynamic> json) =>
+      _$IgdbGenreDtoFromJson(json);
+
+  final int? id;
+  final String? name;
+
+  Map<String, dynamic> toJson() => _$IgdbGenreDtoToJson(this);
+}
+
+@JsonSerializable()
+class IgdbInvolvedCompanyDto {
+  const IgdbInvolvedCompanyDto({
+    this.id,
+    this.company,
+    this.developer,
+    this.publisher,
+  });
+
+  factory IgdbInvolvedCompanyDto.fromJson(Map<String, dynamic> json) =>
+      _$IgdbInvolvedCompanyDtoFromJson(json);
+
+  final int? id;
+  final IgdbCompanyDto? company;
+  final bool? developer;
+  final bool? publisher;
+
+  Map<String, dynamic> toJson() => _$IgdbInvolvedCompanyDtoToJson(this);
+}
+
+@JsonSerializable()
+class IgdbCompanyDto {
+  const IgdbCompanyDto({this.id, this.name});
+
+  factory IgdbCompanyDto.fromJson(Map<String, dynamic> json) =>
+      _$IgdbCompanyDtoFromJson(json);
+
+  final int? id;
+  final String? name;
+
+  Map<String, dynamic> toJson() => _$IgdbCompanyDtoToJson(this);
+}

--- a/lib/data/remote/api/igdb/models/igdb_game_dto.g.dart
+++ b/lib/data/remote/api/igdb/models/igdb_game_dto.g.dart
@@ -1,0 +1,96 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'igdb_game_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+IgdbGameDto _$IgdbGameDtoFromJson(Map<String, dynamic> json) => IgdbGameDto(
+  id: (json['id'] as num?)?.toInt(),
+  name: json['name'] as String?,
+  summary: json['summary'] as String?,
+  cover: json['cover'] == null
+      ? null
+      : IgdbCoverDto.fromJson(json['cover'] as Map<String, dynamic>),
+  platforms: (json['platforms'] as List<dynamic>?)
+      ?.map((e) => IgdbPlatformDto.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  involvedCompanies: (json['involved_companies'] as List<dynamic>?)
+      ?.map((e) => IgdbInvolvedCompanyDto.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  genres: (json['genres'] as List<dynamic>?)
+      ?.map((e) => IgdbGenreDto.fromJson(e as Map<String, dynamic>))
+      .toList(),
+  firstReleaseDate: (json['first_release_date'] as num?)?.toInt(),
+  aggregatedRating: (json['aggregated_rating'] as num?)?.toDouble(),
+  rating: (json['rating'] as num?)?.toDouble(),
+);
+
+Map<String, dynamic> _$IgdbGameDtoToJson(IgdbGameDto instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'summary': instance.summary,
+      'cover': instance.cover,
+      'platforms': instance.platforms,
+      'involved_companies': instance.involvedCompanies,
+      'genres': instance.genres,
+      'first_release_date': instance.firstReleaseDate,
+      'aggregated_rating': instance.aggregatedRating,
+      'rating': instance.rating,
+    };
+
+IgdbCoverDto _$IgdbCoverDtoFromJson(Map<String, dynamic> json) => IgdbCoverDto(
+  id: (json['id'] as num?)?.toInt(),
+  url: json['url'] as String?,
+);
+
+Map<String, dynamic> _$IgdbCoverDtoToJson(IgdbCoverDto instance) =>
+    <String, dynamic>{'id': instance.id, 'url': instance.url};
+
+IgdbPlatformDto _$IgdbPlatformDtoFromJson(Map<String, dynamic> json) =>
+    IgdbPlatformDto(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$IgdbPlatformDtoToJson(IgdbPlatformDto instance) =>
+    <String, dynamic>{'id': instance.id, 'name': instance.name};
+
+IgdbGenreDto _$IgdbGenreDtoFromJson(Map<String, dynamic> json) => IgdbGenreDto(
+  id: (json['id'] as num?)?.toInt(),
+  name: json['name'] as String?,
+);
+
+Map<String, dynamic> _$IgdbGenreDtoToJson(IgdbGenreDto instance) =>
+    <String, dynamic>{'id': instance.id, 'name': instance.name};
+
+IgdbInvolvedCompanyDto _$IgdbInvolvedCompanyDtoFromJson(
+  Map<String, dynamic> json,
+) => IgdbInvolvedCompanyDto(
+  id: (json['id'] as num?)?.toInt(),
+  company: json['company'] == null
+      ? null
+      : IgdbCompanyDto.fromJson(json['company'] as Map<String, dynamic>),
+  developer: json['developer'] as bool?,
+  publisher: json['publisher'] as bool?,
+);
+
+Map<String, dynamic> _$IgdbInvolvedCompanyDtoToJson(
+  IgdbInvolvedCompanyDto instance,
+) => <String, dynamic>{
+  'id': instance.id,
+  'company': instance.company,
+  'developer': instance.developer,
+  'publisher': instance.publisher,
+};
+
+IgdbCompanyDto _$IgdbCompanyDtoFromJson(Map<String, dynamic> json) =>
+    IgdbCompanyDto(
+      id: (json['id'] as num?)?.toInt(),
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$IgdbCompanyDtoToJson(IgdbCompanyDto instance) =>
+    <String, dynamic>{'id': instance.id, 'name': instance.name};

--- a/lib/data/remote/api/igdb/models/twitch_token_dto.dart
+++ b/lib/data/remote/api/igdb/models/twitch_token_dto.dart
@@ -1,0 +1,32 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'twitch_token_dto.g.dart';
+
+/// Response from `POST https://id.twitch.tv/oauth2/token` for the
+/// `client_credentials` grant.
+///
+/// The returned `accessToken` is the bearer token to send to IGDB (along
+/// with the Twitch Client-ID as a separate header). `expiresIn` is the
+/// lifetime in seconds — typically around 60 days.
+@JsonSerializable()
+class TwitchTokenDto {
+  const TwitchTokenDto({
+    this.accessToken,
+    this.expiresIn,
+    this.tokenType,
+  });
+
+  factory TwitchTokenDto.fromJson(Map<String, dynamic> json) =>
+      _$TwitchTokenDtoFromJson(json);
+
+  @JsonKey(name: 'access_token')
+  final String? accessToken;
+
+  @JsonKey(name: 'expires_in')
+  final int? expiresIn;
+
+  @JsonKey(name: 'token_type')
+  final String? tokenType;
+
+  Map<String, dynamic> toJson() => _$TwitchTokenDtoToJson(this);
+}

--- a/lib/data/remote/api/igdb/models/twitch_token_dto.g.dart
+++ b/lib/data/remote/api/igdb/models/twitch_token_dto.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'twitch_token_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+TwitchTokenDto _$TwitchTokenDtoFromJson(Map<String, dynamic> json) =>
+    TwitchTokenDto(
+      accessToken: json['access_token'] as String?,
+      expiresIn: (json['expires_in'] as num?)?.toInt(),
+      tokenType: json['token_type'] as String?,
+    );
+
+Map<String, dynamic> _$TwitchTokenDtoToJson(TwitchTokenDto instance) =>
+    <String, dynamic>{
+      'access_token': instance.accessToken,
+      'expires_in': instance.expiresIn,
+      'token_type': instance.tokenType,
+    };

--- a/lib/data/repositories/metadata_repository_impl.dart
+++ b/lib/data/repositories/metadata_repository_impl.dart
@@ -12,6 +12,7 @@ import 'package:mymediascanner/data/local/dao/barcode_cache_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/data/mappers/discogs_mapper.dart';
 import 'package:mymediascanner/data/mappers/enrichment_merger.dart';
+import 'package:mymediascanner/data/mappers/igdb_mapper.dart';
 import 'package:mymediascanner/data/mappers/musicbrainz_mapper.dart';
 import 'package:mymediascanner/data/mappers/google_books_mapper.dart';
 import 'package:mymediascanner/data/mappers/open_library_mapper.dart';
@@ -20,6 +21,8 @@ import 'package:mymediascanner/data/mappers/tvdb_mapper.dart';
 import 'package:mymediascanner/data/mappers/upc_mapper.dart';
 import 'package:mymediascanner/data/remote/api/discogs/discogs_api.dart';
 import 'package:mymediascanner/data/remote/api/fanart/fanart_api.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_api.dart';
+import 'package:mymediascanner/data/remote/api/igdb/models/igdb_game_dto.dart';
 import 'package:mymediascanner/data/remote/api/theaudiodb/theaudiodb_api.dart';
 import 'package:mymediascanner/data/remote/api/musicbrainz/cover_art_archive_api.dart';
 import 'package:mymediascanner/data/remote/api/musicbrainz/models/musicbrainz_release_dto.dart';
@@ -54,6 +57,7 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     this.upcitemdbApi,
     this.theAudioDbApi,
     this.fanartApi,
+    this.igdbApi,
     ApiCircuitBreaker? googleBooksBreaker,
   }) : _cacheDao = cacheDao,
        googleBooksBreaker = googleBooksBreaker ?? ApiCircuitBreaker();
@@ -69,6 +73,7 @@ class MetadataRepositoryImpl implements IMetadataRepository {
   final UpcitemdbApi? upcitemdbApi;
   final TheAudioDbApi? theAudioDbApi;
   final FanartApi? fanartApi;
+  final IgdbApi? igdbApi;
 
   /// Circuit breaker for Google Books API — trips on 429 responses.
   final ApiCircuitBreaker googleBooksBreaker;
@@ -102,6 +107,8 @@ class MetadataRepositoryImpl implements IMetadataRepository {
       result = await _lookupFilm(barcode, barcodeTypeStr, typeHint: typeHint);
     } else if (typeHint == MediaType.music) {
       result = await _lookupMusic(barcode, barcodeTypeStr);
+    } else if (typeHint == MediaType.game) {
+      result = await _lookupGame(barcode, barcodeTypeStr);
     } else {
       // Unknown type — try UPCitemdb first to classify
       result = await _lookupGeneral(barcode, barcodeTypeStr);
@@ -148,6 +155,8 @@ class MetadataRepositoryImpl implements IMetadataRepository {
       result = await _searchMusicByTitle(title, barcode, barcodeType);
     } else if (typeHint == MediaType.book) {
       result = await _searchBookByTitle(title, barcode, barcodeType);
+    } else if (typeHint == MediaType.game) {
+      result = await _searchIgdbByTitle(title, barcode, barcodeType);
     } else {
       // No type hint — try TMDB first, then MusicBrainz, then Google Books
       result =
@@ -388,6 +397,79 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     return null;
   }
 
+  Future<ScanResult?> _searchIgdbByTitle(
+    String title,
+    String barcode,
+    String barcodeType,
+  ) async {
+    if (igdbApi == null) return null;
+    try {
+      final games = await igdbApi!.searchByTitle(title);
+      if (games.isEmpty) return null;
+
+      if (games.length == 1) {
+        await _cacheResponse(barcode, 'game', 'igdb', games.first.toJson());
+        return ScanResult.single(
+          metadata: IgdbMapper.fromGame(games.first, barcode, barcodeType),
+          isDuplicate: false,
+        );
+      }
+
+      final candidates = games
+          .take(AppConstants.maxCandidates)
+          .map(IgdbMapper.toCandidate)
+          .toList();
+      return ScanResult.multiMatch(
+        candidates: candidates,
+        barcode: barcode,
+        barcodeType: barcodeType,
+      );
+    } on Exception catch (e) {
+      debugPrint('IGDB title search failed: $e');
+    }
+    return null;
+  }
+
+  /// Look up a game by barcode. IGDB has no barcode endpoint, so we fetch
+  /// the title from UPCitemdb first and then enrich via IGDB title search.
+  /// If IGDB finds nothing, the UPC result stands on its own.
+  Future<ScanResult?> _lookupGame(String barcode, String barcodeType) async {
+    final upcResult = await _lookupUpcMetadata(barcode, barcodeType);
+    if (upcResult?.title == null) return null;
+
+    if (igdbApi == null) {
+      return ScanResult.single(metadata: upcResult!, isDuplicate: false);
+    }
+
+    try {
+      final games = await igdbApi!.searchByTitle(upcResult!.title!);
+      if (games.isEmpty) {
+        return ScanResult.single(metadata: upcResult, isDuplicate: false);
+      }
+
+      if (games.length == 1) {
+        await _cacheResponse(barcode, 'game', 'igdb', games.first.toJson());
+        return ScanResult.single(
+          metadata: IgdbMapper.fromGame(games.first, barcode, barcodeType),
+          isDuplicate: false,
+        );
+      }
+
+      final candidates = games
+          .take(AppConstants.maxCandidates)
+          .map(IgdbMapper.toCandidate)
+          .toList();
+      return ScanResult.multiMatch(
+        candidates: candidates,
+        barcode: barcode,
+        barcodeType: barcodeType,
+      );
+    } on Exception catch (e) {
+      debugPrint('IGDB enrichment for game barcode failed: $e');
+      return ScanResult.single(metadata: upcResult!, isDuplicate: false);
+    }
+  }
+
   @override
   Future<MetadataResult?> fetchCandidateDetail(
     MetadataCandidate candidate,
@@ -410,8 +492,27 @@ class MetadataRepositoryImpl implements IMetadataRepository {
         barcodeType,
       ),
       'upcitemdb' => _fetchUpcDetail(candidate, barcode, barcodeType),
+      'igdb' => _fetchIgdbDetail(candidate, barcode, barcodeType),
       _ => null,
     };
+  }
+
+  Future<MetadataResult?> _fetchIgdbDetail(
+    MetadataCandidate candidate,
+    String barcode,
+    String barcodeType,
+  ) async {
+    if (igdbApi == null) return null;
+    try {
+      final id = int.parse(candidate.sourceId);
+      final game = await igdbApi!.getById(id);
+      if (game == null) return null;
+      await _cacheResponse(barcode, 'game', 'igdb', game.toJson());
+      return IgdbMapper.fromGame(game, barcode, barcodeType);
+    } on Exception catch (e) {
+      debugPrint('IGDB detail fetch failed: $e');
+    }
+    return null;
   }
 
   // -- Detail fetchers for disambiguation --
@@ -717,6 +818,11 @@ class MetadataRepositoryImpl implements IMetadataRepository {
         ),
         'tvdb' => TvdbMapper.fromSeries(
           TvdbSeriesDto.fromJson(json),
+          barcode,
+          barcodeType,
+        ),
+        'igdb' => IgdbMapper.fromGame(
+          IgdbGameDto.fromJson(json),
           barcode,
           barcodeType,
         ),

--- a/lib/presentation/providers/repository_providers.dart
+++ b/lib/presentation/providers/repository_providers.dart
@@ -3,6 +3,8 @@ import 'package:mymediascanner/core/constants/api_constants.dart';
 import 'package:mymediascanner/data/remote/api/dio_factory.dart';
 import 'package:mymediascanner/data/remote/api/discogs/discogs_api.dart';
 import 'package:mymediascanner/data/remote/api/fanart/fanart_api.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_api.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_token_manager.dart';
 import 'package:mymediascanner/data/remote/api/theaudiodb/theaudiodb_api.dart';
 import 'package:mymediascanner/data/remote/api/musicbrainz/cover_art_archive_api.dart';
 import 'package:mymediascanner/data/remote/api/musicbrainz/musicbrainz_api.dart';
@@ -61,6 +63,20 @@ final metadataRepositoryProvider = Provider<IMetadataRepository>((ref) {
   final googleBooksKey = apiKeys['google_books'];
   final tvdbKey = apiKeys['tvdb'];
   final fanartKey = apiKeys['fanart'];
+  final twitchClientId = apiKeys['twitch_client_id'];
+  final twitchClientSecret = apiKeys['twitch_client_secret'];
+
+  final igdbApi = (twitchClientId != null &&
+          twitchClientId.isNotEmpty &&
+          twitchClientSecret != null &&
+          twitchClientSecret.isNotEmpty)
+      ? IgdbApi(
+          tokenManager: IgdbTokenManager(
+            clientId: twitchClientId,
+            clientSecret: twitchClientSecret,
+          ),
+        )
+      : null;
 
   return MetadataRepositoryImpl(
     cacheDao: ref.watch(barcodeCacheDaoProvider),
@@ -113,6 +129,7 @@ final metadataRepositoryProvider = Provider<IMetadataRepository>((ref) {
             apiKey: fanartKey,
           ))
         : null,
+    igdbApi: igdbApi,
   );
 });
 

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -165,6 +165,8 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
   static const _googleBooksKey = 'api_key_google_books';
   static const _tvdbKey = 'api_key_tvdb';
   static const _fanartKey = 'api_key_fanart';
+  static const _twitchClientIdKey = 'api_key_twitch_client_id';
+  static const _twitchClientSecretKey = 'api_key_twitch_client_secret';
 
   @override
   Future<Map<String, String?>> build() async {
@@ -176,6 +178,8 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
       'google_books': await storage.read(key: _googleBooksKey),
       'tvdb': await storage.read(key: _tvdbKey),
       'fanart': await storage.read(key: _fanartKey),
+      'twitch_client_id': await storage.read(key: _twitchClientIdKey),
+      'twitch_client_secret': await storage.read(key: _twitchClientSecretKey),
     };
   }
 
@@ -208,6 +212,18 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
 
   Future<void> setFanartKey(String key) async {
     await ref.read(secureStorageProvider).write(key: _fanartKey, value: key);
+    ref.invalidateSelf();
+  }
+
+  Future<void> setTwitchClientId(String key) async {
+    await ref.read(secureStorageProvider).write(
+        key: _twitchClientIdKey, value: key);
+    ref.invalidateSelf();
+  }
+
+  Future<void> setTwitchClientSecret(String key) async {
+    await ref.read(secureStorageProvider).write(
+        key: _twitchClientSecretKey, value: key);
     ref.invalidateSelf();
   }
 }

--- a/lib/presentation/screens/metadata_confirm/widgets/editable_metadata_form.dart
+++ b/lib/presentation/screens/metadata_confirm/widgets/editable_metadata_form.dart
@@ -240,9 +240,10 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
   /// lookup can proceed.
   ///
   /// Film/TV title search only routes to TMDB; without a TMDB key the
-  /// repository returns `notFound` without trying anything else. Games have
-  /// no API yet (tracked in #57). Music, book, and unknown always have at
-  /// least one key-free fallback (MusicBrainz / Open Library).
+  /// repository returns `notFound` without trying anything else. Game
+  /// search routes to IGDB, which requires a Twitch Client ID + Secret.
+  /// Music, book, and unknown always have at least one key-free fallback
+  /// (MusicBrainz / Open Library).
   String? _missingApiMessage(MediaType type, Map<String, String?> apiKeys) {
     switch (type) {
       case MediaType.film:
@@ -252,7 +253,12 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
         }
         return null;
       case MediaType.game:
-        return 'Online lookup for games is not yet supported.';
+        if ((apiKeys['twitch_client_id'] ?? '').isEmpty ||
+            (apiKeys['twitch_client_secret'] ?? '').isEmpty) {
+          return 'Twitch Client ID and Secret required in Settings to '
+              'search for games (IGDB).';
+        }
+        return null;
       case MediaType.music:
       case MediaType.book:
       case MediaType.unknown:

--- a/lib/presentation/screens/settings/widgets/api_key_form.dart
+++ b/lib/presentation/screens/settings/widgets/api_key_form.dart
@@ -16,6 +16,8 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
   final _googleBooksController = TextEditingController();
   final _tvdbController = TextEditingController();
   final _fanartController = TextEditingController();
+  final _twitchClientIdController = TextEditingController();
+  final _twitchClientSecretController = TextEditingController();
 
   @override
   void initState() {
@@ -31,6 +33,8 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
     _googleBooksController.text = keys['google_books'] ?? '';
     _tvdbController.text = keys['tvdb'] ?? '';
     _fanartController.text = keys['fanart'] ?? '';
+    _twitchClientIdController.text = keys['twitch_client_id'] ?? '';
+    _twitchClientSecretController.text = keys['twitch_client_secret'] ?? '';
   }
 
   @override
@@ -41,6 +45,8 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
     _googleBooksController.dispose();
     _tvdbController.dispose();
     _fanartController.dispose();
+    _twitchClientIdController.dispose();
+    _twitchClientSecretController.dispose();
     super.dispose();
   }
 
@@ -78,6 +84,30 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
         const SizedBox(height: 12),
         _keyField('UPCitemdb Key', _upcController, (key) {
           ref.read(apiKeysProvider.notifier).setUpcitemdbKey(key);
+        }),
+
+        const SizedBox(height: 24),
+
+        // IGDB (games) — uses Twitch OAuth
+        Text('IGDB / Games',
+            style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 4),
+        Text(
+          'IGDB uses Twitch OAuth. Register an app at dev.twitch.tv to get '
+          'a Client ID and Client Secret — both are required for online '
+          'game lookup.',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.outline,
+              ),
+        ),
+        const SizedBox(height: 8),
+        _keyField('Twitch Client ID', _twitchClientIdController, (key) {
+          ref.read(apiKeysProvider.notifier).setTwitchClientId(key);
+        }),
+        const SizedBox(height: 12),
+        _keyField('Twitch Client Secret', _twitchClientSecretController,
+            (key) {
+          ref.read(apiKeysProvider.notifier).setTwitchClientSecret(key);
         }),
 
         const SizedBox(height: 24),

--- a/src/docs/modules/ROOT/pages/api-configuration.adoc
+++ b/src/docs/modules/ROOT/pages/api-configuration.adoc
@@ -50,11 +50,16 @@ image::screenshots/08-settings.png[Settings screen showing the API keys section,
 | Book metadata fallback when Google Books returns no result
 | Yes (no key required)
 | No
+
+| https://dev.twitch.tv/console[IGDB via Twitch]
+| Video game metadata lookup and enrichment
+| Yes (free developer account)
+| Yes (for game lookup)
 |===
 
 MusicBrainz and Cover Art Archive are queried without authentication and require no registration.
 Discogs is optional — if you supply a token it is used as a music fallback and enrichment source, but the app works without it.
-Only TMDB and UPCitemdb keys are strictly required for full functionality.
+TMDB, UPCitemdb, and Twitch credentials (for IGDB) are required for their respective media types.
 
 NOTE: MusicBrainz asks all clients to identify themselves via a `User-Agent` header containing the application name and version.
 The app sends this header automatically — no configuration is needed.
@@ -67,6 +72,13 @@ TMDB:: Create a free account at https://www.themoviedb.org/, then go to *Setting
 Discogs:: Registration is optional. If you want Discogs as a music fallback, register at https://www.discogs.com/settings/developers and generate a personal access token. OAuth is not required.
 
 UPCitemdb:: Sign up at https://www.upcitemdb.com/ and copy the trial or paid API key from your dashboard.
+
+IGDB / Twitch:: Register or log in at https://dev.twitch.tv/console[dev.twitch.tv/console].
+Create an application (choose "Website Integration" as the category and set the OAuth redirect URL to `http://localhost`).
+Copy the *Client ID* shown on the application page, then click *New Secret* to generate a *Client Secret*.
+Paste both values into the *IGDB / Games* group in *Settings → API Keys*.
+The app exchanges these credentials for a Twitch OAuth bearer token on-device; no browser redirect or OAuth callback is needed.
+The token has an approximately 60-day lifetime and is refreshed automatically when it expires.
 
 === Entering Keys in the App
 
@@ -190,6 +202,49 @@ Once enabled, sync covers all tables that carry an `updated_at` column:
 * `barcode_cache`
 
 See xref:sync-strategy.adoc[] for full details of the conflict resolution strategy.
+
+== IGDB / Games Configuration
+
+IGDB is operated by Twitch and uses the Twitch OAuth *client_credentials* flow for machine-to-machine authentication.
+Unlike the other API keys in the app, you supply a *Twitch Client ID* and a *Twitch Client Secret* rather than a single pre-issued token.
+The app exchanges those credentials for a short-lived bearer token entirely on-device; no browser window or callback URL is involved.
+
+=== How token exchange works
+
+. On the first game lookup after credentials are saved, `IgdbTokenManager` calls `POST https://id.twitch.tv/oauth2/token` with the Client ID, Client Secret, and `grant_type=client_credentials`.
+. Twitch returns a bearer token with an `expires_in` value (typically around 60 days).
+. The token and its expiry timestamp are persisted in the platform-native secure storage vault alongside your other API keys.
+. Subsequent game lookups read the cached token.
+  When the token is within a short refresh window of expiry — or has already expired — `IgdbTokenManager` requests a new token lazily before the IGDB call proceeds.
+
+You do not need to renew credentials manually.
+If Twitch invalidates the token (for example, because you regenerated the Client Secret on the developer console), the next game lookup will attempt a fresh exchange; if that also fails, the lookup returns `NotFoundScanResult` and a snackbar prompts you to check your credentials in Settings.
+
+=== Setting up a Twitch application
+
+. Log in at `https://dev.twitch.tv/console`.
+. Click *Register Your Application*.
+. Fill in a name (e.g. `MyMediaScanner`), set the OAuth redirect URL to `http://localhost`, and choose *Website Integration* as the category.
+. Click *Create*, then open the newly created application.
+. Copy the *Client ID* displayed on the page.
+. Click *New Secret* and copy the generated *Client Secret* before navigating away — Twitch does not show it again.
+
+NOTE: The Client Secret is shown only once.
+If you navigate away without copying it, click *New Secret* again to invalidate the old secret and generate a replacement.
+
+=== Entering credentials in the app
+
+. Open *Settings* from the desktop sidebar or the mobile navigation bar.
+. Scroll to the *IGDB / Games* section.
+. Enter your *Twitch Client ID* in the first field and tap *Save*.
+. Enter your *Twitch Client Secret* in the second field and tap *Save*.
+
+Both values are stored in the platform-native secure storage vault.
+A masked preview is displayed after saving.
+The bearer token fetched from Twitch is also stored in secure storage and is never exposed in the UI.
+
+WARNING: Treat the Twitch Client Secret with the same care as a password.
+If you believe it has been compromised, regenerate it immediately on the Twitch developer console and update the value in Settings.
 
 == Related Pages
 

--- a/src/docs/modules/ROOT/pages/integrations.adoc
+++ b/src/docs/modules/ROOT/pages/integrations.adoc
@@ -417,9 +417,9 @@ UPCitemdb is a commercial product database that indexes retail barcodes (UPC-A a
 
 ==== Role in the app
 
-*General barcode fallback and primary video game source.*
+*General barcode fallback.*
 UPCitemdb is queried when no specialist provider satisfies the barcode lookup — for example, when a music barcode is not found in MusicBrainz or Discogs, or when a film barcode returns nothing from TMDB.
-It is also the primary metadata source for video games until a dedicated game database integration is added in a future release.
+For video games it acts as the barcode-to-title resolver; IGDB subsequently enriches the discovered title with game-specific metadata.
 
 ==== Setup
 
@@ -445,6 +445,111 @@ Each scan that reaches the fallback stage counts against your monthly allowance.
   Edit the item's metadata manually after saving.
 * *No result from UPCitemdb* — some barcodes, particularly older or regional pressings, are not indexed.
   The item will be saved with only the barcode; you can add metadata manually.
+
+---
+
+== Games
+
+=== IGDB
+
+IGDB (Internet Games Database) is a comprehensive video game database operated by Twitch, covering titles across all platforms with rich metadata including genres, platforms, companies, ratings, and artwork.
+
+==== Role in the app
+
+*Primary video game metadata source.*
+IGDB is used in two ways:
+
+. *Title search (Manual Add):* When you type a game title and tap *Search online*, the repository calls `POST /v4/games` with an Apicalypse search query and returns a ranked list of matches.
+. *Barcode-based enrichment:* When you scan a game barcode, UPCitemdb first resolves the barcode to a product title.
+  That title is then passed to IGDB as a search query to enrich the result with game-specific metadata — platforms, genres, companies, critic scores, and cover art.
+
+IGDB requires Twitch credentials (Client ID and Client Secret); if these are not configured, both flows return `NotFoundScanResult` and a snackbar directs you to Settings.
+
+==== Authentication model
+
+IGDB uses the Twitch OAuth *client_credentials* flow.
+The app calls `POST https://id.twitch.tv/oauth2/token` on-device to exchange the Client ID and Client Secret for a bearer token.
+The token (typical lifetime approximately 60 days) is cached in platform-native secure storage by `IgdbTokenManager` and refreshed lazily when it approaches expiry.
+No browser redirect or callback URL is involved.
+
+==== Setup
+
+See xref:api-configuration.adoc#_igdb_games_configuration[API Configuration — IGDB / Games Configuration] for step-by-step instructions on registering a Twitch application and entering credentials.
+
+==== Endpoint and query shape
+
+The app calls `POST https://api.igdb.com/v4/games` with an Apicalypse body.
+Two query patterns are used:
+
+*Title search* (Manual Add / barcode enrichment):
+[source]
+----
+search "<title>";
+fields name, summary, cover.url, platforms.name,
+       involved_companies.company.name,
+       involved_companies.developer,
+       involved_companies.publisher,
+       genres.name, first_release_date,
+       aggregated_rating, rating;
+limit 5;
+----
+
+==== Field mapping into MetadataResult
+
+[cols="2,3", options="header"]
+|===
+| MetadataResult field
+| Mapped from IGDB
+
+| `title`
+| `name`
+
+| `subtitle`
+| First entry in `platforms.name` (primary platform)
+
+| `description`
+| `summary`
+
+| `coverImageUrl`
+| `cover.url` with the thumbnail segment (`t_thumb`) replaced by `t_cover_big`
+
+| `year`
+| `first_release_date` (Unix timestamp) converted to a four-digit year
+
+| `publisher`
+| Name from `involved_companies` where `publisher == true`
+
+| `criticScore`
+| `aggregated_rating` if present; falls back to `rating`
+
+| `extraMetadata.developer`
+| Name from `involved_companies` where `developer == true`
+
+| `extraMetadata.platforms`
+| All entries in `platforms.name` as a comma-separated string
+
+| `extraMetadata.igdbId`
+| IGDB numeric game identifier
+|===
+
+==== Rate limits / usage policy
+
+IGDB's free tier allows up to 4 requests per second and 500 requests per month per application under the standard developer plan.
+Under normal personal scanning use this limit is not reached.
+The app does not apply additional throttling for IGDB.
+
+==== Troubleshooting
+
+* *Snackbar "Twitch Client ID and Secret required in Settings to search for games (IGDB)"* — open *Settings → API Keys → IGDB / Games* and ensure both the Client ID and Client Secret fields are filled and saved.
+* *Game search returns no results* — confirm your device can reach `https://api.igdb.com` and `https://id.twitch.tv`.
+  Also verify that the Twitch credentials are correct; an invalid Client Secret causes the token exchange to fail silently and the lookup to short-circuit.
+* *Cover art is missing* — IGDB may not have a cover image for that title, or the `cover.url` field was absent in the response.
+  You can add cover art manually from the item detail screen.
+* *Critic score is absent* — `aggregated_rating` and `rating` are community-calculated and may not be present for niche or very recent releases.
+* *Wrong game returned for a scanned barcode* — the UPCitemdb product title used to drive the IGDB search may be ambiguous (e.g. a regional subtitle or edition label).
+  Use Manual Add to search by a cleaner title, or edit the item's metadata after saving.
+* *HTTP 401 after credentials were working* — the Client Secret may have been regenerated on the Twitch developer console.
+  Update the Client Secret in *Settings → API Keys → IGDB / Games*; the app will request a new bearer token on the next game lookup.
 
 ---
 

--- a/src/docs/modules/ROOT/pages/manual-add.adoc
+++ b/src/docs/modules/ROOT/pages/manual-add.adoc
@@ -135,7 +135,7 @@ The selected Media Type determines which API clients are used:
 | Google Books, then Open Library
 
 | Game
-| No routed source — always returns `NotFoundScanResult` (IGDB integration tracked as issue #57)
+| IGDB (title search via `POST /v4/games`; requires Twitch Client ID and Secret in Settings)
 
 | Unknown
 | Cascades through TMDB, MusicBrainz, and Google Books in order
@@ -176,8 +176,8 @@ If a required key is missing, the search is short-circuited and a specific snack
 | "TMDB API key required in Settings to search for films and TV."
 
 | Game
-| _(no key — feature unsupported)_
-| "Online lookup for games is not yet supported."
+| Twitch Client ID and Secret
+| "Twitch Client ID and Secret required in Settings to search for games (IGDB)."
 
 | Music
 | None (MusicBrainz is key-free; Discogs key optional)

--- a/src/docs/modules/ROOT/pages/metadata-lookup.adoc
+++ b/src/docs/modules/ROOT/pages/metadata-lookup.adoc
@@ -74,7 +74,7 @@ The detected type, combined with any media type hint supplied by the user on the
 
 | Video Games
 | EAN-13, UPC-A
-| UPCitemdb (IGDB planned for v2)
+| UPCitemdb (barcode → title) → IGDB enrichment
 |===
 
 Routing rules:
@@ -84,7 +84,8 @@ Routing rules:
 * An **EAN-13 or UPC-A** with a film or TV hint is routed to TMDB search.
 * An **EAN-13 or UPC-A** with a music hint is routed to MusicBrainz first.
 If MusicBrainz returns nothing, is rate-limited, or gives only low-quality data, the repository falls back to Discogs and finally UPCitemdb.
-* An **EAN-13 or UPC-A** with a game hint is sent directly to UPCitemdb.
+* An **EAN-13 or UPC-A** with a game hint is sent to UPCitemdb first to resolve the barcode to a product title.
+  If Twitch credentials are configured, the resolved title is then passed to IGDB for enrichment with game-specific metadata.
 
 For MusicBrainz matches, the repository ranks candidates by status (Official preferred), format (CD, vinyl, and cassette preferred over digital), completeness (label, catalogue number, track count, date, and country) and the MusicBrainz server score.
 A clearly dominant match is auto-accepted; otherwise the user sees the disambiguation screen with country, label, catalogue number, track count, and status on each candidate card.
@@ -96,7 +97,7 @@ A dedicated `RateLimitAwareClient` throttles requests to approximately 1 req/s a
 
 If the specialist API returns no results, the use case falls back to UPCitemdb.
 UPCitemdb is a general-purpose product database and can resolve many retail barcodes even when specialist sources lack coverage.
-It is also the primary source for video games until IGDB integration is added in a later release.
+For video games it acts as the barcode-to-title resolver; IGDB then enriches the discovered title with game-specific metadata when Twitch credentials are available.
 
 === 5. Cache and Map
 
@@ -137,9 +138,13 @@ Each external API is represented by a dedicated client class backed by its own D
 
 | `UpcItemDbApiClient`
 | `https://api.upcitemdb.com/prod/trial`
+
+| `IgdbApiClient`
+| `https://api.igdb.com/v4`
 |===
 
 TMDB and UPCitemdb require user-supplied API keys read at runtime from `SecureStorageService` via a Riverpod provider.
+IGDB requires a Twitch Client ID and Client Secret; the app exchanges these for a bearer token on-device and caches it in secure storage.
 Discogs is optional — a key enables it as a music fallback, but the app functions without one.
 MusicBrainz, Cover Art Archive, Google Books, and Open Library need no keys.
 Users configure their keys in the Settings screen; keys are never bundled with the application.
@@ -281,7 +286,9 @@ Routing uses the same per-type specialist clients as barcode lookup:
 * Film / TV → TMDB (no fallback).
 * Music → MusicBrainz, then Discogs.
 * Books → Google Books, then Open Library.
-* Games → no routed source (UPCitemdb has no title search); title lookup always returns `NotFoundScanResult` until IGDB integration lands.
+* Games → IGDB (`POST /v4/games` with an Apicalypse title query).
+  Requires Twitch Client ID and Secret to be configured in Settings.
+  If credentials are absent, the lookup short-circuits and returns `NotFoundScanResult`.
 * Unknown → cascade through TMDB, MusicBrainz, Google Books in order.
 
 Because the film / TV route has no key-free fallback, searching for a film or TV title without a TMDB key configured would silently return `NotFoundScanResult`.

--- a/test/unit/data/mappers/igdb_mapper_test.dart
+++ b/test/unit/data/mappers/igdb_mapper_test.dart
@@ -1,0 +1,175 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/mappers/igdb_mapper.dart';
+import 'package:mymediascanner/data/remote/api/igdb/models/igdb_game_dto.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+
+void main() {
+  group('IgdbMapper.fromGame', () {
+    const barcode = '1234567890123';
+    const barcodeType = 'ean13';
+
+    test('maps a rich game payload onto MetadataResult', () {
+      // Unix ts for 2022-02-25 = Elden Ring release day.
+      const releaseTs = 1645747200;
+      const dto = IgdbGameDto(
+        id: 119133,
+        name: 'Elden Ring',
+        summary: 'Open-world action RPG.',
+        cover: IgdbCoverDto(
+          id: 1,
+          url: '//images.igdb.com/igdb/image/upload/t_thumb/co4jni.jpg',
+        ),
+        platforms: [
+          IgdbPlatformDto(id: 48, name: 'PlayStation 5'),
+          IgdbPlatformDto(id: 49, name: 'Xbox Series X|S'),
+          IgdbPlatformDto(id: 6, name: 'PC'),
+        ],
+        involvedCompanies: [
+          IgdbInvolvedCompanyDto(
+            company: IgdbCompanyDto(name: 'FromSoftware'),
+            developer: true,
+            publisher: false,
+          ),
+          IgdbInvolvedCompanyDto(
+            company: IgdbCompanyDto(name: 'Bandai Namco'),
+            developer: false,
+            publisher: true,
+          ),
+        ],
+        genres: [
+          IgdbGenreDto(name: 'RPG'),
+          IgdbGenreDto(name: 'Adventure'),
+        ],
+        firstReleaseDate: releaseTs,
+        aggregatedRating: 94.5,
+        rating: 91.3,
+      );
+
+      final result = IgdbMapper.fromGame(dto, barcode, barcodeType);
+
+      expect(result.barcode, barcode);
+      expect(result.barcodeType, barcodeType);
+      expect(result.mediaType, MediaType.game);
+      expect(result.title, 'Elden Ring');
+      expect(result.subtitle, 'PlayStation 5');
+      expect(result.description, 'Open-world action RPG.');
+      expect(
+        result.coverUrl,
+        'https://images.igdb.com/igdb/image/upload/t_cover_big/co4jni.jpg',
+      );
+      expect(result.year, 2022);
+      expect(result.publisher, 'Bandai Namco');
+      expect(result.genres, ['RPG', 'Adventure']);
+      expect(result.criticScore, 94.5);
+      expect(result.criticSource, 'IGDB');
+      expect(result.sourceApis, ['igdb']);
+      expect(result.extraMetadata['igdb_id'], 119133);
+      expect(result.extraMetadata['developer'], 'FromSoftware');
+      expect(
+        result.extraMetadata['platforms'],
+        ['PlayStation 5', 'Xbox Series X|S', 'PC'],
+      );
+    });
+
+    test('falls back to rating when aggregated_rating is null', () {
+      const dto = IgdbGameDto(
+        id: 1,
+        name: 'Indie Gem',
+        rating: 82.0,
+      );
+
+      final result = IgdbMapper.fromGame(dto, barcode, barcodeType);
+
+      expect(result.criticScore, 82.0);
+      expect(result.criticSource, 'IGDB');
+    });
+
+    test('leaves criticSource null when both scores are null', () {
+      const dto = IgdbGameDto(id: 1, name: 'Unrated Game');
+
+      final result = IgdbMapper.fromGame(dto, barcode, barcodeType);
+
+      expect(result.criticScore, isNull);
+      expect(result.criticSource, isNull);
+    });
+
+    test('copes with a cover that is already https and a different size', () {
+      const dto = IgdbGameDto(
+        id: 1,
+        name: 'Game',
+        cover: IgdbCoverDto(
+          url: 'https://images.igdb.com/igdb/image/upload/t_720p/abc.jpg',
+        ),
+      );
+
+      final result = IgdbMapper.fromGame(dto, barcode, barcodeType);
+
+      // Not t_thumb, so it's left alone but kept as https.
+      expect(
+        result.coverUrl,
+        'https://images.igdb.com/igdb/image/upload/t_720p/abc.jpg',
+      );
+    });
+
+    test('returns null coverUrl when the DTO has no cover', () {
+      const dto = IgdbGameDto(id: 1, name: 'Game');
+
+      final result = IgdbMapper.fromGame(dto, barcode, barcodeType);
+
+      expect(result.coverUrl, isNull);
+    });
+
+    test('omits subtitle when the game has no platforms', () {
+      const dto = IgdbGameDto(id: 1, name: 'Game', platforms: []);
+
+      final result = IgdbMapper.fromGame(dto, barcode, barcodeType);
+
+      expect(result.subtitle, isNull);
+      expect(result.extraMetadata.containsKey('platforms'), isFalse);
+    });
+
+    test('leaves publisher/developer null when no company has the role', () {
+      const dto = IgdbGameDto(
+        id: 1,
+        name: 'Game',
+        involvedCompanies: [
+          IgdbInvolvedCompanyDto(
+            company: IgdbCompanyDto(name: 'Porting Co.'),
+          ),
+        ],
+      );
+
+      final result = IgdbMapper.fromGame(dto, barcode, barcodeType);
+
+      expect(result.publisher, isNull);
+      expect(result.extraMetadata.containsKey('developer'), isFalse);
+    });
+  });
+
+  group('IgdbMapper.toCandidate', () {
+    test('builds a candidate with platform subtitle and upgraded cover', () {
+      const dto = IgdbGameDto(
+        id: 42,
+        name: 'Hades',
+        firstReleaseDate: 1600819200, // 2020-09-23
+        cover: IgdbCoverDto(
+          url: '//images.igdb.com/igdb/image/upload/t_thumb/hades.jpg',
+        ),
+        platforms: [IgdbPlatformDto(name: 'Switch')],
+      );
+
+      final candidate = IgdbMapper.toCandidate(dto);
+
+      expect(candidate.sourceApi, 'igdb');
+      expect(candidate.sourceId, '42');
+      expect(candidate.title, 'Hades');
+      expect(candidate.subtitle, 'Switch');
+      expect(candidate.year, 2020);
+      expect(candidate.mediaType, MediaType.game);
+      expect(
+        candidate.coverUrl,
+        'https://images.igdb.com/igdb/image/upload/t_cover_big/hades.jpg',
+      );
+    });
+  });
+}

--- a/test/unit/data/remote/api/igdb/igdb_api_test.dart
+++ b/test/unit/data/remote/api/igdb/igdb_api_test.dart
@@ -1,0 +1,167 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_api.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_token_manager.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+class _MockTokenManager extends Mock implements IgdbTokenManager {}
+
+Response<List<dynamic>> _gamesResponse(List<Map<String, dynamic>> games) =>
+    Response<List<dynamic>>(
+      requestOptions: RequestOptions(path: '/games'),
+      data: games,
+      statusCode: 200,
+    );
+
+DioException _unauthorized() => DioException(
+      requestOptions: RequestOptions(path: '/games'),
+      response: Response(
+        requestOptions: RequestOptions(path: '/games'),
+        statusCode: 401,
+      ),
+      type: DioExceptionType.badResponse,
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: ''));
+    registerFallbackValue(Options());
+  });
+
+  late _MockDio dio;
+  late _MockTokenManager tokens;
+  late IgdbApi api;
+
+  setUp(() {
+    dio = _MockDio();
+    tokens = _MockTokenManager();
+    when(() => tokens.clientId).thenReturn('cid');
+    when(() => tokens.getToken()).thenAnswer((_) async => 'tkn');
+    api = IgdbApi(tokenManager: tokens, dio: dio);
+  });
+
+  test('sends Client-ID and Bearer headers with Apicalypse body', () async {
+    when(() => dio.post<List<dynamic>>(
+          '/games',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        )).thenAnswer((_) async => _gamesResponse([
+          {'id': 1, 'name': 'Game'},
+        ]));
+
+    final results = await api.searchByTitle('Halo');
+
+    expect(results, hasLength(1));
+    expect(results.first.id, 1);
+    expect(results.first.name, 'Game');
+
+    final captured = verify(() => dio.post<List<dynamic>>(
+          '/games',
+          data: captureAny(named: 'data'),
+          options: captureAny(named: 'options'),
+        )).captured;
+    final body = captured[0] as String;
+    final options = captured[1] as Options;
+    expect(body, contains('search "Halo"'));
+    expect(body, contains('limit 10;'));
+    expect(body, contains('fields'));
+    expect(options.headers?['Client-ID'], 'cid');
+    expect(options.headers?['Authorization'], 'Bearer tkn');
+  });
+
+  test('escapes embedded double-quotes so the Apicalypse body stays valid',
+      () async {
+    when(() => dio.post<List<dynamic>>(
+          '/games',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        )).thenAnswer((_) async => _gamesResponse(const []));
+
+    await api.searchByTitle('say "hi"');
+
+    final body = verify(() => dio.post<List<dynamic>>(
+          '/games',
+          data: captureAny(named: 'data'),
+          options: any(named: 'options'),
+        )).captured.single as String;
+    expect(body, contains(r'search "say \"hi\""'));
+  });
+
+  test('uses where clause for getById', () async {
+    when(() => dio.post<List<dynamic>>(
+          '/games',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        )).thenAnswer((_) async => _gamesResponse([
+          {'id': 42, 'name': 'Found'},
+        ]));
+
+    final game = await api.getById(42);
+
+    expect(game?.id, 42);
+    final body = verify(() => dio.post<List<dynamic>>(
+          '/games',
+          data: captureAny(named: 'data'),
+          options: any(named: 'options'),
+        )).captured.single as String;
+    expect(body, contains('where id = 42'));
+    expect(body, isNot(contains('search')));
+  });
+
+  test('returns null from getById when the result list is empty', () async {
+    when(() => dio.post<List<dynamic>>(
+          '/games',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        )).thenAnswer((_) async => _gamesResponse(const []));
+
+    final game = await api.getById(1);
+
+    expect(game, isNull);
+  });
+
+  test('retries once after a 401, invalidating the cached token', () async {
+    var calls = 0;
+    when(() => dio.post<List<dynamic>>(
+          '/games',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        )).thenAnswer((_) async {
+      calls += 1;
+      if (calls == 1) throw _unauthorized();
+      return _gamesResponse([
+        {'id': 5, 'name': 'Retry'},
+      ]);
+    });
+
+    final results = await api.searchByTitle('anything');
+
+    expect(results.single.name, 'Retry');
+    expect(calls, 2);
+    verify(() => tokens.invalidate()).called(1);
+  });
+
+  test('bubbles up non-401 errors without retrying', () async {
+    final boom = DioException(
+      requestOptions: RequestOptions(path: '/games'),
+      response: Response(
+        requestOptions: RequestOptions(path: '/games'),
+        statusCode: 500,
+      ),
+      type: DioExceptionType.badResponse,
+    );
+    when(() => dio.post<List<dynamic>>(
+          '/games',
+          data: any(named: 'data'),
+          options: any(named: 'options'),
+        )).thenThrow(boom);
+
+    await expectLater(
+      api.searchByTitle('x'),
+      throwsA(isA<DioException>()),
+    );
+    verifyNever(() => tokens.invalidate());
+  });
+}

--- a/test/unit/data/remote/api/igdb/igdb_token_manager_test.dart
+++ b/test/unit/data/remote/api/igdb/igdb_token_manager_test.dart
@@ -1,0 +1,123 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_token_manager.dart';
+
+class _MockDio extends Mock implements Dio {}
+
+Response<Map<String, dynamic>> _tokenResponse({
+  String token = 'abc123',
+  int? expiresIn = 5000000,
+}) =>
+    Response<Map<String, dynamic>>(
+      requestOptions: RequestOptions(path: '/oauth2/token'),
+      data: {
+        'access_token': token,
+        'expires_in': expiresIn,
+        'token_type': 'bearer',
+      },
+      statusCode: 200,
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: ''));
+  });
+
+  late _MockDio dio;
+  late IgdbTokenManager manager;
+
+  setUp(() {
+    dio = _MockDio();
+    manager = IgdbTokenManager(
+      clientId: 'cid',
+      clientSecret: 'secret',
+      authDio: dio,
+    );
+  });
+
+  test('exchanges Client ID + Secret for a bearer token', () async {
+    when(() => dio.post<Map<String, dynamic>>(
+          '/oauth2/token',
+          queryParameters: any(named: 'queryParameters'),
+        )).thenAnswer((_) async => _tokenResponse(token: 'fresh-token'));
+
+    final token = await manager.getToken();
+
+    expect(token, 'fresh-token');
+    final captured = verify(() => dio.post<Map<String, dynamic>>(
+          '/oauth2/token',
+          queryParameters: captureAny(named: 'queryParameters'),
+        )).captured.single as Map<String, dynamic>;
+    expect(captured['client_id'], 'cid');
+    expect(captured['client_secret'], 'secret');
+    expect(captured['grant_type'], 'client_credentials');
+  });
+
+  test('caches the token so subsequent calls skip the exchange', () async {
+    when(() => dio.post<Map<String, dynamic>>(
+          '/oauth2/token',
+          queryParameters: any(named: 'queryParameters'),
+        )).thenAnswer((_) async => _tokenResponse(token: 'once-only'));
+
+    await manager.getToken();
+    await manager.getToken();
+
+    verify(() => dio.post<Map<String, dynamic>>(
+          '/oauth2/token',
+          queryParameters: any(named: 'queryParameters'),
+        )).called(1);
+  });
+
+  test('invalidate() forces a new exchange on the next call', () async {
+    var call = 0;
+    when(() => dio.post<Map<String, dynamic>>(
+          '/oauth2/token',
+          queryParameters: any(named: 'queryParameters'),
+        )).thenAnswer((_) async {
+      call += 1;
+      return _tokenResponse(token: 'token-$call');
+    });
+
+    final first = await manager.getToken();
+    manager.invalidate();
+    final second = await manager.getToken();
+
+    expect(first, 'token-1');
+    expect(second, 'token-2');
+  });
+
+  test('throws when Twitch returns no access_token', () async {
+    when(() => dio.post<Map<String, dynamic>>(
+          '/oauth2/token',
+          queryParameters: any(named: 'queryParameters'),
+        )).thenAnswer((_) async => Response<Map<String, dynamic>>(
+          requestOptions: RequestOptions(path: '/oauth2/token'),
+          data: const {},
+          statusCode: 200,
+        ));
+
+    await expectLater(manager.getToken(), throwsA(isA<Exception>()));
+  });
+
+  test('de-duplicates concurrent getToken() calls', () async {
+    var calls = 0;
+    when(() => dio.post<Map<String, dynamic>>(
+          '/oauth2/token',
+          queryParameters: any(named: 'queryParameters'),
+        )).thenAnswer((_) async {
+      calls += 1;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+      return _tokenResponse(token: 'shared');
+    });
+
+    final results = await Future.wait([
+      manager.getToken(),
+      manager.getToken(),
+      manager.getToken(),
+    ]);
+
+    expect(results, ['shared', 'shared', 'shared']);
+    expect(calls, 1);
+  });
+}

--- a/test/unit/data/repositories/metadata_repository_igdb_test.dart
+++ b/test/unit/data/repositories/metadata_repository_igdb_test.dart
@@ -1,0 +1,247 @@
+import 'package:drift/drift.dart' hide isNotNull;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/local/dao/barcode_cache_dao.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/remote/api/igdb/igdb_api.dart';
+import 'package:mymediascanner/data/remote/api/igdb/models/igdb_game_dto.dart';
+import 'package:mymediascanner/data/remote/api/upc/models/upc_item_dto.dart';
+import 'package:mymediascanner/data/remote/api/upc/upcitemdb_api.dart';
+import 'package:mymediascanner/data/repositories/metadata_repository_impl.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/scan_result.dart';
+
+class _MockCacheDao extends Mock implements BarcodeCacheDao {}
+
+class _MockIgdbApi extends Mock implements IgdbApi {}
+
+class _MockUpcApi extends Mock implements UpcitemdbApi {}
+
+IgdbGameDto _game({
+  int id = 1,
+  String name = 'Test Game',
+  String? platform = 'PC',
+  String? publisher,
+  int? year,
+}) {
+  return IgdbGameDto(
+    id: id,
+    name: name,
+    platforms: platform != null
+        ? [IgdbPlatformDto(name: platform)]
+        : const [],
+    involvedCompanies: publisher != null
+        ? [
+            IgdbInvolvedCompanyDto(
+              company: IgdbCompanyDto(name: publisher),
+              publisher: true,
+            ),
+          ]
+        : const [],
+    firstReleaseDate: year != null
+        ? DateTime.utc(year).millisecondsSinceEpoch ~/ 1000
+        : null,
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      BarcodeCacheTableCompanion(
+        barcode: const Value(''),
+        mediaTypeHint: const Value(null),
+        responseJson: const Value('{}'),
+        sourceApi: const Value(''),
+        cachedAt: Value(DateTime.now().millisecondsSinceEpoch),
+      ),
+    );
+  });
+
+  late _MockCacheDao cache;
+  late _MockIgdbApi igdb;
+  late _MockUpcApi upc;
+
+  setUp(() {
+    cache = _MockCacheDao();
+    igdb = _MockIgdbApi();
+    upc = _MockUpcApi();
+    when(() => cache.getByBarcode(any())).thenAnswer((_) async => null);
+    when(() => cache.upsert(any())).thenAnswer((_) async {});
+  });
+
+  group('searchByTitle with typeHint: game', () {
+    test('returns a single ScanResult when IGDB returns one game', () async {
+      final repo = MetadataRepositoryImpl(cacheDao: cache, igdbApi: igdb);
+      when(() => igdb.searchByTitle('Elden Ring')).thenAnswer(
+        (_) async => [
+          _game(
+            id: 119133,
+            name: 'Elden Ring',
+            platform: 'PlayStation 5',
+            publisher: 'Bandai Namco',
+            year: 2022,
+          ),
+        ],
+      );
+
+      final result = await repo.searchByTitle(
+        'Elden Ring',
+        '0722674120432',
+        'ean13',
+        typeHint: MediaType.game,
+      );
+
+      expect(result, isA<SingleScanResult>());
+      final single = result as SingleScanResult;
+      expect(single.metadata.title, 'Elden Ring');
+      expect(single.metadata.publisher, 'Bandai Namco');
+      expect(single.metadata.mediaType, MediaType.game);
+    });
+
+    test('returns a MultiMatchScanResult when IGDB returns 2+ games',
+        () async {
+      final repo = MetadataRepositoryImpl(cacheDao: cache, igdbApi: igdb);
+      when(() => igdb.searchByTitle('Zelda')).thenAnswer(
+        (_) async => [
+          _game(id: 1, name: 'The Legend of Zelda: BOTW'),
+          _game(id: 2, name: 'The Legend of Zelda: TOTK'),
+          _game(id: 3, name: 'The Legend of Zelda: Skyward Sword'),
+        ],
+      );
+
+      final result = await repo.searchByTitle(
+        'Zelda',
+        '0000000000000',
+        'ean13',
+        typeHint: MediaType.game,
+      );
+
+      expect(result, isA<MultiMatchScanResult>());
+      final multi = result as MultiMatchScanResult;
+      expect(multi.candidates.length, greaterThanOrEqualTo(3));
+      expect(multi.candidates.first.sourceApi, 'igdb');
+    });
+
+    test('returns notFound when IGDB is not configured', () async {
+      final repo = MetadataRepositoryImpl(cacheDao: cache);
+
+      final result = await repo.searchByTitle(
+        'anything',
+        '0000000000000',
+        'ean13',
+        typeHint: MediaType.game,
+      );
+
+      expect(result, isA<NotFoundScanResult>());
+    });
+  });
+
+  group('lookupBarcode with typeHint: game', () {
+    const barcode = '0711719541592';
+
+    test('UPCitemdb title → IGDB enrichment on single match', () async {
+      final repo = MetadataRepositoryImpl(
+        cacheDao: cache,
+        upcitemdbApi: upc,
+        igdbApi: igdb,
+      );
+      when(() => upc.lookup(barcode)).thenAnswer(
+        (_) async => const UpcSearchResponseDto(
+          code: 'OK',
+          total: 1,
+          items: [
+            UpcItemDto(
+              ean: barcode,
+              title: 'Horizon Zero Dawn',
+              category: 'Toys & Hobbies > Video Games',
+            ),
+          ],
+        ),
+      );
+      when(() => igdb.searchByTitle('Horizon Zero Dawn')).thenAnswer(
+        (_) async => [
+          _game(
+            id: 19560,
+            name: 'Horizon Zero Dawn',
+            platform: 'PlayStation 4',
+            publisher: 'Sony Interactive',
+            year: 2017,
+          ),
+        ],
+      );
+
+      final result = await repo.lookupBarcode(
+        barcode,
+        typeHint: MediaType.game,
+      );
+
+      expect(result, isA<SingleScanResult>());
+      final single = result as SingleScanResult;
+      expect(single.metadata.title, 'Horizon Zero Dawn');
+      expect(single.metadata.publisher, 'Sony Interactive');
+      expect(single.metadata.sourceApis, ['igdb']);
+    });
+
+    test('falls back to UPCitemdb result when IGDB finds nothing', () async {
+      final repo = MetadataRepositoryImpl(
+        cacheDao: cache,
+        upcitemdbApi: upc,
+        igdbApi: igdb,
+      );
+      when(() => upc.lookup(barcode)).thenAnswer(
+        (_) async => const UpcSearchResponseDto(
+          code: 'OK',
+          total: 1,
+          items: [
+            UpcItemDto(
+              ean: barcode,
+              title: 'Obscure Game',
+              category: 'Toys & Hobbies > Video Games',
+            ),
+          ],
+        ),
+      );
+      when(() => igdb.searchByTitle('Obscure Game'))
+          .thenAnswer((_) async => const []);
+
+      final result = await repo.lookupBarcode(
+        barcode,
+        typeHint: MediaType.game,
+      );
+
+      expect(result, isA<SingleScanResult>());
+      final single = result as SingleScanResult;
+      expect(single.metadata.title, 'Obscure Game');
+    });
+
+    test('falls back to UPCitemdb result when IGDB is not configured',
+        () async {
+      final repo = MetadataRepositoryImpl(
+        cacheDao: cache,
+        upcitemdbApi: upc,
+      );
+      when(() => upc.lookup(barcode)).thenAnswer(
+        (_) async => const UpcSearchResponseDto(
+          code: 'OK',
+          total: 1,
+          items: [
+            UpcItemDto(
+              ean: barcode,
+              title: 'Obscure Game',
+              category: 'Toys & Hobbies > Video Games',
+            ),
+          ],
+        ),
+      );
+
+      final result = await repo.lookupBarcode(
+        barcode,
+        typeHint: MediaType.game,
+      );
+
+      expect(result, isA<SingleScanResult>());
+      final single = result as SingleScanResult;
+      expect(single.metadata.title, 'Obscure Game');
+    });
+  });
+}

--- a/test/widget/presentation/screens/manual_add/manual_add_screen_test.dart
+++ b/test/widget/presentation/screens/manual_add/manual_add_screen_test.dart
@@ -375,6 +375,55 @@ void main() {
   });
 
   testWidgets(
+      'Search online for Game with no Twitch keys shows settings hint',
+      (tester) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final repo = _MockMetadataRepository();
+    when(() => repo.searchByTitle(any(), any(), any(),
+            typeHint: any(named: 'typeHint')))
+        .thenAnswer(
+      (_) async => const ScanResult.notFound(
+        barcode: 'MANUAL-x',
+        barcodeType: 'MANUAL',
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          metadataRepositoryProvider.overrideWithValue(repo),
+          apiKeysProvider.overrideWith(() => _EmptyApiKeysNotifier()),
+        ],
+        child: const MaterialApp(home: ManualAddScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DropdownButtonFormField<MediaType>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Game').last);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Title'), 'Elden Ring');
+    await tester.tap(find.text('Search online'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text(
+          'Twitch Client ID and Secret required in Settings to search '
+          'for games (IGDB).'),
+      findsOneWidget,
+    );
+    verifyNever(() => repo.searchByTitle(any(), any(), any(),
+        typeHint: any(named: 'typeHint')));
+  });
+
+  testWidgets(
       'Resolution selection is saved into extraMetadata.resolution',
       (tester) async {
     tester.view.physicalSize = const Size(1200, 2400);


### PR DESCRIPTION
## Summary
- Adds IGDB (Twitch-authenticated) as the specialist online source for the Game media type — closes the last gap in Manual Add's "Search online" button.
- Barcode lookup for games now resolves the title via UPCitemdb and enriches it via IGDB (developer, publisher, platforms, cover, summary, critic score).
- Twitch OAuth client_credentials exchange happens on-device; bearer token cached in secure storage, refreshed lazily, retried once on 401.

## Test plan
- [x] `flutter analyze` clean for all new/modified files.
- [x] `flutter test` — 1274 tests pass, including 26 new IGDB tests (mapper edge cases, token caching/de-dup/401 refresh, Apicalypse body + header injection, repository routing for `searchByTitle` and `lookupBarcode`, and a widget test for the missing-Twitch-keys snackbar).
- [x] Antora docs build (`npx antora local-antora-playbook-search.yml`) exits clean.
- [ ] Manual smoke: enter Twitch Client ID + Secret in Settings, open Manual Add, pick Game, search "Elden Ring" — form should populate with Bandai Namco, 2022, PlayStation 5 subtitle, cover art.
- [ ] Manual smoke: clear Twitch keys, repeat — snackbar should read "Twitch Client ID and Secret required in Settings to search for games (IGDB)."
- [ ] Manual smoke: scan or hand-enter a known game barcode with typeHint Game — should route through UPCitemdb then IGDB enrichment.