### PR TITLE
fix(deps): use pub.dev dart_flac 0.0.1 instead of local path

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -372,9 +372,10 @@ packages:
   dart_flac:
     dependency: "direct main"
     description:
-      path: "../dart_flac"
-      relative: true
-    source: path
+      name: dart_flac
+      sha256: afbfba883d445a69f7743288b94165b96b2a811e4912cf12c448b8b58add057f
+      url: "https://pub.dev"
+    source: hosted
     version: "0.0.1"
   dart_metaflac:
     dependency: "direct main"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,8 +70,7 @@ dependencies:
   just_audio_media_kit: ^2.1.0
   ffi: ^2.2.0
   dart_metaflac: ^0.0.1
-  dart_flac:
-    path: ../dart_flac
+  dart_flac: ^0.0.1
   dart_accuraterip: ^0.0.3
   audio_defect_detector: ^0.0.2
   dart_rip_log: ^0.0.1

--- a/test/unit/data/repositories/metadata_repository_impl_test.dart
+++ b/test/unit/data/repositories/metadata_repository_impl_test.dart
@@ -932,7 +932,7 @@ void main() {
       when(() => mockCache.upsert(any())).thenAnswer((_) async {});
     });
 
-    DioException _upstream5xx() => DioException(
+    DioException upstream5xx() => DioException(
       requestOptions: RequestOptions(path: '/books/v1/volumes'),
       response: Response(
         requestOptions: RequestOptions(path: '/books/v1/volumes'),
@@ -951,7 +951,7 @@ void main() {
 
       when(
         () => mockGoogleBooksApi.searchByIsbn('Gruffalo'),
-      ).thenThrow(_upstream5xx());
+      ).thenThrow(upstream5xx());
       when(() => mockOpenLibraryApi.searchByTitle('Gruffalo')).thenAnswer(
         (_) async => const OpenLibrarySearchResponseDto(
           numFound: 1,
@@ -995,7 +995,7 @@ void main() {
 
         when(
           () => mockGoogleBooksApi.searchByIsbn('Harry'),
-        ).thenThrow(_upstream5xx());
+        ).thenThrow(upstream5xx());
         when(() => mockOpenLibraryApi.searchByTitle('Harry')).thenAnswer(
           (_) async => const OpenLibrarySearchResponseDto(
             numFound: 2,
@@ -1034,7 +1034,7 @@ void main() {
 
         when(
           () => mockGoogleBooksApi.searchByIsbn('nothing'),
-        ).thenThrow(_upstream5xx());
+        ).thenThrow(upstream5xx());
         when(() => mockOpenLibraryApi.searchByTitle('nothing')).thenAnswer(
           (_) async =>
               const OpenLibrarySearchResponseDto(numFound: 0, docs: []),

--- a/test/widget/presentation/screens/batch/batch_history_screen_test.dart
+++ b/test/widget/presentation/screens/batch/batch_history_screen_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mymediascanner/presentation/providers/batch_editor_provider.dart';
 import 'package:mymediascanner/presentation/providers/batch_history_provider.dart';
 import 'package:mymediascanner/presentation/screens/batch/batch_history_screen.dart';
 

--- a/test/widget/presentation/screens/import/import_screen_test.dart
+++ b/test/widget/presentation/screens/import/import_screen_test.dart
@@ -59,11 +59,11 @@ GoRouter _router({String initialLocation = '/import'}) => GoRouter(
       routes: [
         GoRoute(
           path: '/import',
-          builder: (_, __) => const ImportScreen(),
+          builder: (_, _) => const ImportScreen(),
         ),
         GoRoute(
           path: '/collection',
-          builder: (_, __) => const Scaffold(body: Text('collection')),
+          builder: (_, _) => const Scaffold(body: Text('collection')),
         ),
       ],
     );
@@ -161,7 +161,7 @@ void main() {
     testWidgets(
         'shows a result summary after import completes',
         (tester) async {
-      final doneState = const ImportState(
+      const doneState = ImportState(
         phase: ImportPhase.done,
         savedCount: 8,
       );
@@ -179,7 +179,7 @@ void main() {
     testWidgets(
         'singular grammar when exactly one item is imported',
         (tester) async {
-      final doneState = const ImportState(
+      const doneState = ImportState(
         phase: ImportPhase.done,
         savedCount: 1,
       );
@@ -197,7 +197,7 @@ void main() {
     testWidgets(
         'shows an error message when the import throws',
         (tester) async {
-      final errorState = const ImportState(
+      const errorState = ImportState(
         phase: ImportPhase.error,
         errorMessage: 'Could not parse file: unexpected column header',
       );
@@ -217,7 +217,7 @@ void main() {
     testWidgets(
         'shows "Unknown error" when errorMessage is null in error phase',
         (tester) async {
-      final errorState = const ImportState(
+      const errorState = ImportState(
         phase: ImportPhase.error,
         // errorMessage intentionally null.
       );
@@ -235,7 +235,7 @@ void main() {
     testWidgets(
         'shows a spinner and "Parsing file…" label during parsing',
         (tester) async {
-      final parsingState = const ImportState(
+      const parsingState = ImportState(
         phase: ImportPhase.parsing,
         source: ImportSource.discogs,
       );
@@ -257,7 +257,7 @@ void main() {
     testWidgets(
         'shows a spinner and "Saving items…" label during save',
         (tester) async {
-      final savingState = const ImportState(
+      const savingState = ImportState(
         phase: ImportPhase.saving,
         source: ImportSource.letterboxd,
       );

--- a/test/widget/presentation/screens/item_detail/widgets/borrower_picker_dialog_test.dart
+++ b/test/widget/presentation/screens/item_detail/widgets/borrower_picker_dialog_test.dart
@@ -80,7 +80,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(_borrower());
     registerFallbackValue(
-      Loan(
+      const Loan(
         id: 'l1',
         mediaItemId: 'item1',
         borrowerId: 'b1',

--- a/test/widget/presentation/screens/labels/label_print_screen_test.dart
+++ b/test/widget/presentation/screens/labels/label_print_screen_test.dart
@@ -10,7 +10,6 @@ import 'package:mymediascanner/domain/entities/ownership_status.dart';
 import 'package:mymediascanner/domain/repositories/i_location_repository.dart';
 import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
 import 'package:mymediascanner/presentation/providers/location_provider.dart';
-import 'package:mymediascanner/presentation/providers/recommendations_provider.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/screens/labels/label_print_screen.dart';
 

--- a/test/widget/presentation/screens/rips/widgets/rip_album_detail_dialog_test.dart
+++ b/test/widget/presentation/screens/rips/widgets/rip_album_detail_dialog_test.dart
@@ -81,7 +81,7 @@ Widget _buildDialog({
     child: MaterialApp(
       home: Scaffold(
         body: Builder(
-          builder: (context) => RipAlbumDetailDialog(album: _album),
+          builder: (context) => const RipAlbumDetailDialog(album: _album),
         ),
       ),
     ),

--- a/test/widget/presentation/screens/series/series_list_screen_test.dart
+++ b/test/widget/presentation/screens/series/series_list_screen_test.dart
@@ -70,7 +70,7 @@ Widget _wrap(
         routes: [
           GoRoute(
             path: '/series',
-            builder: (_, __) => const SeriesListScreen(),
+            builder: (_, _) => const SeriesListScreen(),
           ),
           GoRoute(
             path: '/series/:id',

--- a/test/widget/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen_test.dart
+++ b/test/widget/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen_test.dart
@@ -33,7 +33,7 @@ WishlistSuggestion _suggestion({
       ],
     );
 
-MediaItem _mediaItem() => MediaItem(
+MediaItem _mediaItem() => const MediaItem(
       id: 'mi1',
       barcode: 'tt001',
       barcodeType: 'TMDB',


### PR DESCRIPTION
## Summary
- CI has been red on \`main\` and all open PRs since 59935e0 because \`pubspec.yaml\` pinned \`dart_flac\` to \`path: ../dart_flac\` — a workstation-local sibling checkout GitHub Actions can't see.
- \`dart_flac 0.0.1\` is now published on pub.dev (same version as the local path), so this swaps the path dependency for a hosted constraint: \`dart_flac: ^0.0.1\`.
- \`pubspec.lock\` updated to reflect the new source (pub.dev, sha256 pinned).

## Test plan
- [x] \`flutter pub get\` resolves cleanly against pub.dev.
- [x] \`flutter analyze lib\` clean.
- [ ] CI green on this PR (the direct proof that \`pub get\` now works on the runner).

## Follow-up
Once this is merged, PR #58 (IGDB) will need a rebase onto main to pick up the fix and get its own CI green.