### PR TITLE
Address code review: sync field gaps, lifecycle, secret hygiene

### DIFF
--- a/lib/core/services/camera/native_camera_service.dart
+++ b/lib/core/services/camera/native_camera_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:camera/camera.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'package:mymediascanner/core/services/camera/barcode_detector.dart';
@@ -129,7 +130,12 @@ class NativeCameraService implements CameraService {
       final xFile = await ctrl.takePicture();
       final result = await BarcodeDetector.detectFromFile(xFile.path);
       if (result != null) {
-        debugPrint('[scan] DECODED ${result.format} -> ${result.rawValue}');
+        // Don't log the raw barcode value in release builds — it's user
+        // media data and there's no need for it to land in device logs.
+        if (kDebugMode) {
+          debugPrint(
+              '[scan] DECODED ${result.format} (${result.rawValue.length} chars)');
+        }
         if (!_barcodeController.isClosed) {
           _barcodeController.add(result);
         }

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -381,12 +381,27 @@ class SyncRepositoryImpl implements ISyncRepository {
       pricePaid: Value(data['price_paid'] as double?),
       acquiredAt: Value(data['acquired_at'] as int?),
       retailer: Value(data['retailer'] as String?),
+      locationId: Value(data['location_id'] as String?),
+      seriesId: Value(data['series_id'] as String?),
+      seriesPosition: Value(data['series_position'] as int?),
+      progressCurrent: Value(data['progress_current'] as int?),
+      progressTotal: Value(data['progress_total'] as int?),
+      progressUnit: Value(data['progress_unit'] as String?),
+      startedAt: Value(data['started_at'] as int?),
+      completedAt: Value(data['completed_at'] as int?),
+      consumed: Value(_resolveConsumed(data['consumed'])),
       dateAdded: Value(data['date_added'] as int? ?? 0),
       dateScanned: Value(data['date_scanned'] as int? ?? 0),
       updatedAt: Value(data['updated_at'] as int? ?? 0),
       syncedAt: Value(data['synced_at'] as int?),
       deleted: Value(data['deleted'] as int? ?? 0),
     );
+  }
+
+  int _resolveConsumed(Object? raw) {
+    if (raw is int) return raw == 0 ? 0 : 1;
+    if (raw is bool) return raw ? 1 : 0;
+    return 0;
   }
 
   SyncLogEntry _toSyncLogEntry(SyncLogTableData row) {

--- a/lib/presentation/providers/repository_providers.dart
+++ b/lib/presentation/providers/repository_providers.dart
@@ -57,19 +57,24 @@ final shelfRepositoryProvider = Provider<IShelfRepository>((ref) {
 final metadataRepositoryProvider = Provider<IMetadataRepository>((ref) {
   final apiKeys = ref.watch(apiKeysProvider).value ?? {};
 
-  final tmdbKey = apiKeys['tmdb'];
-  final discogsKey = apiKeys['discogs'];
-  final upcKey = apiKeys['upcitemdb'];
-  final googleBooksKey = apiKeys['google_books'];
-  final tvdbKey = apiKeys['tvdb'];
-  final fanartKey = apiKeys['fanart'];
-  final twitchClientId = apiKeys['twitch_client_id'];
-  final twitchClientSecret = apiKeys['twitch_client_secret'];
+  // Normalise so that an empty/whitespace key is treated as unconfigured —
+  // otherwise a cleared field stored as '' would still spin up an
+  // authenticated client with empty credentials and trigger 401 storms.
+  String? key(String name) {
+    final value = apiKeys[name]?.trim();
+    return (value == null || value.isEmpty) ? null : value;
+  }
 
-  final igdbApi = (twitchClientId != null &&
-          twitchClientId.isNotEmpty &&
-          twitchClientSecret != null &&
-          twitchClientSecret.isNotEmpty)
+  final tmdbKey = key('tmdb');
+  final discogsKey = key('discogs');
+  final upcKey = key('upcitemdb');
+  final googleBooksKey = key('google_books');
+  final tvdbKey = key('tvdb');
+  final fanartKey = key('fanart');
+  final twitchClientId = key('twitch_client_id');
+  final twitchClientSecret = key('twitch_client_secret');
+
+  final igdbApi = (twitchClientId != null && twitchClientSecret != null)
       ? IgdbApi(
           tokenManager: IgdbTokenManager(
             clientId: twitchClientId,
@@ -155,9 +160,17 @@ final syncRepositoryProvider = Provider<ISyncRepository?>((ref) {
   final config = ref.watch(postgresConfigProvider).value;
   if (config == null) return null;
 
-  return SyncRepositoryImpl(
+  final client = PostgresSyncClient(config: config);
+  final repo = SyncRepositoryImpl(
     mediaItemsDao: ref.watch(mediaItemsDaoProvider),
     syncLogDao: ref.watch(syncLogDaoProvider),
-    syncClient: PostgresSyncClient(config: config),
+    syncClient: client,
   );
+
+  ref.onDispose(() async {
+    await repo.dispose();
+    await client.close();
+  });
+
+  return repo;
 });

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -183,49 +183,41 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
     };
   }
 
-  Future<void> setTmdbKey(String key) async {
-    await ref.read(secureStorageProvider).write(key: _tmdbKey, value: key);
+  /// Writes [value] under [storageKey], or deletes the entry when the
+  /// trimmed value is empty. Without the delete branch a cleared field
+  /// would persist as `''`, which the metadata provider previously
+  /// treated as configured and used to spin up authenticated clients
+  /// with empty credentials.
+  Future<void> _writeOrDelete(String storageKey, String value) async {
+    final trimmed = value.trim();
+    final storage = ref.read(secureStorageProvider);
+    if (trimmed.isEmpty) {
+      await storage.delete(key: storageKey);
+    } else {
+      await storage.write(key: storageKey, value: trimmed);
+    }
     ref.invalidateSelf();
   }
 
-  Future<void> setDiscogsKey(String key) async {
-    await ref.read(secureStorageProvider).write(key: _discogsKey, value: key);
-    ref.invalidateSelf();
-  }
+  Future<void> setTmdbKey(String key) => _writeOrDelete(_tmdbKey, key);
 
-  Future<void> setUpcitemdbKey(String key) async {
-    await ref.read(secureStorageProvider).write(
-        key: _upcitemdbKey, value: key);
-    ref.invalidateSelf();
-  }
+  Future<void> setDiscogsKey(String key) => _writeOrDelete(_discogsKey, key);
 
-  Future<void> setGoogleBooksKey(String key) async {
-    await ref.read(secureStorageProvider).write(
-        key: _googleBooksKey, value: key);
-    ref.invalidateSelf();
-  }
+  Future<void> setUpcitemdbKey(String key) =>
+      _writeOrDelete(_upcitemdbKey, key);
 
-  Future<void> setTvdbKey(String key) async {
-    await ref.read(secureStorageProvider).write(key: _tvdbKey, value: key);
-    ref.invalidateSelf();
-  }
+  Future<void> setGoogleBooksKey(String key) =>
+      _writeOrDelete(_googleBooksKey, key);
 
-  Future<void> setFanartKey(String key) async {
-    await ref.read(secureStorageProvider).write(key: _fanartKey, value: key);
-    ref.invalidateSelf();
-  }
+  Future<void> setTvdbKey(String key) => _writeOrDelete(_tvdbKey, key);
 
-  Future<void> setTwitchClientId(String key) async {
-    await ref.read(secureStorageProvider).write(
-        key: _twitchClientIdKey, value: key);
-    ref.invalidateSelf();
-  }
+  Future<void> setFanartKey(String key) => _writeOrDelete(_fanartKey, key);
 
-  Future<void> setTwitchClientSecret(String key) async {
-    await ref.read(secureStorageProvider).write(
-        key: _twitchClientSecretKey, value: key);
-    ref.invalidateSelf();
-  }
+  Future<void> setTwitchClientId(String key) =>
+      _writeOrDelete(_twitchClientIdKey, key);
+
+  Future<void> setTwitchClientSecret(String key) =>
+      _writeOrDelete(_twitchClientSecretKey, key);
 }
 
 final postgresConfigProvider =

--- a/lib/presentation/screens/metadata_confirm/metadata_confirm_screen.dart
+++ b/lib/presentation/screens/metadata_confirm/metadata_confirm_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -179,10 +180,16 @@ class MetadataConfirmScreen extends ConsumerWidget {
                   onSave: (edited) async {
                     final targetsWishlist =
                         scannerState.saveTarget == SaveTarget.wishlist;
-                    debugPrint(
-                      '[MMS-save] onSave start barcode=${edited.barcode}'
-                      ' title=${edited.title} target=${scannerState.saveTarget.name}',
-                    );
+                    // Avoid leaking the user's scanned barcode and title
+                    // into release logs — both are personal collection
+                    // data with no operational value in production.
+                    if (kDebugMode) {
+                      debugPrint(
+                        '[MMS-save] onSave start barcode=${edited.barcode}'
+                        ' title=${edited.title}'
+                        ' target=${scannerState.saveTarget.name}',
+                      );
+                    }
                     final repository = ref.read(mediaItemRepositoryProvider);
                     final proceed = await confirmSaveOrSkipIfDuplicate(
                       context: context,

--- a/lib/presentation/screens/settings/widgets/api_key_form.dart
+++ b/lib/presentation/screens/settings/widgets/api_key_form.dart
@@ -19,14 +19,13 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
   final _twitchClientIdController = TextEditingController();
   final _twitchClientSecretController = TextEditingController();
 
-  @override
-  void initState() {
-    super.initState();
-    _loadExisting();
-  }
+  /// True once the async secure-storage read has resolved and we have
+  /// populated the controllers. Used to gate saves so that hitting the
+  /// save icon while values are still loading can't overwrite a real
+  /// stored secret with an empty string.
+  bool _seeded = false;
 
-  void _loadExisting() {
-    final keys = ref.read(apiKeysProvider).value ?? {};
+  void _seedFrom(Map<String, String?> keys) {
     _tmdbController.text = keys['tmdb'] ?? '';
     _discogsController.text = keys['discogs'] ?? '';
     _upcController.text = keys['upcitemdb'] ?? '';
@@ -35,6 +34,7 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
     _fanartController.text = keys['fanart'] ?? '';
     _twitchClientIdController.text = keys['twitch_client_id'] ?? '';
     _twitchClientSecretController.text = keys['twitch_client_secret'] ?? '';
+    _seeded = true;
   }
 
   @override
@@ -52,6 +52,23 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
 
   @override
   Widget build(BuildContext context) {
+    final keysAsync = ref.watch(apiKeysProvider);
+
+    // Seed controllers exactly once, when the secure-storage read
+    // resolves. Reading from `ref.read(...).value` in initState misses
+    // late resolution and leaves the form empty, causing a hasty save
+    // to overwrite real keys with ''.
+    if (!_seeded) {
+      keysAsync.whenData(_seedFrom);
+    }
+
+    if (keysAsync.isLoading && !_seeded) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [

--- a/lib/presentation/screens/settings/widgets/postgres_config_form.dart
+++ b/lib/presentation/screens/settings/widgets/postgres_config_form.dart
@@ -22,14 +22,13 @@ class _PostgresConfigFormState extends ConsumerState<PostgresConfigForm> {
   bool _testing = false;
   String? _testResult;
 
-  @override
-  void initState() {
-    super.initState();
-    _loadExisting();
-  }
+  /// True once the async secure-storage read has resolved and we have
+  /// populated the controllers. Saves and tests stay disabled until
+  /// then so a user clicking through a still-loading form can't blank
+  /// out a real stored password.
+  bool _seeded = false;
 
-  void _loadExisting() {
-    final config = ref.read(postgresConfigProvider).value;
+  void _seedFrom(PostgresConfig? config) {
     if (config != null) {
       _hostController.text = config.host;
       _portController.text = config.port.toString();
@@ -38,6 +37,7 @@ class _PostgresConfigFormState extends ConsumerState<PostgresConfigForm> {
       _passController.text = config.password;
       _requireTls = config.requireTls;
     }
+    _seeded = true;
   }
 
   Future<void> _save() async {
@@ -92,6 +92,19 @@ class _PostgresConfigFormState extends ConsumerState<PostgresConfigForm> {
 
   @override
   Widget build(BuildContext context) {
+    final configAsync = ref.watch(postgresConfigProvider);
+
+    if (!_seeded) {
+      configAsync.whenData(_seedFrom);
+    }
+
+    if (configAsync.isLoading && !_seeded) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('PostgreSQL Configuration')),
+        body: const Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('PostgreSQL Configuration')),
       body: SingleChildScrollView(


### PR DESCRIPTION
## Summary

Five fixes from the post-merge review.

- **High** — `SyncRepositoryImpl._mapToCompanion` now reads `location_id`, `series_id`, `series_position`, `progress_current/total/unit`, `started_at`, `completed_at`, and `consumed`. Push already sent these so any remote edit to those fields was silently dropped on the next pull. Mirrors the push payload at `media_item_repository_impl.dart:280-288`.
- **Medium** — `syncRepositoryProvider` now wires `ref.onDispose` to call `SyncRepositoryImpl.dispose()` and `PostgresSyncClient.close()`, so reconfiguring sync no longer leaks stream controllers or DB connections.
- **Medium** — `ApiKeyForm` and `PostgresConfigForm` now seed controllers from the resolved `AsyncValue` (with a one-shot `_seeded` guard) and render a loading state until secure storage has resolved. A hasty save during the load window could previously persist `''` over a real secret.
- **Low** — `metadataRepositoryProvider` treats empty/whitespace keys as unconfigured (`trim().isNotEmpty`), and `ApiKeysNotifier._writeOrDelete` removes the secure-storage entry when a user saves an empty value. No more 401-storming clients built from `''` credentials.
- **Low** — Raw barcode value (camera service) and saved barcode + title (metadata confirm) are now gated behind `kDebugMode`. The camera log keeps the format and length only, since that is enough for debug triage without leaving user collection data in release device logs.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1273 tests pass
- [ ] Manual: configure Postgres credentials, sync a record edited remotely on a field like `series_id` or `consumed`, confirm the local row reflects it
- [ ] Manual: open Settings -> API keys with secure storage cold; confirm the form shows a spinner instead of a save-able blank
- [ ] Manual: clear a saved API key, save, confirm the secure-storage entry is removed (no `''` ghost) and the metadata provider rebuilds without that client

Note: no new automated coverage for the sync field-mapping fix — wiring an in-memory drift DB and `PostgresSyncClient` mock for one private method felt heavier than the change warranted. The push payload is the canonical reference and every key now round-trips.