### PR TITLE
Fix critical data-loss bugs: sync log, rip quality, overdue loans, Postgres schema

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -173,15 +173,25 @@ MusicBrainz, Cover Art Archive, Google Books, and Open Library require no API ke
 
 To sync across devices, set up a PostgreSQL instance and configure the connection in *Settings > PostgreSQL Configuration*.
 
-. Create the database and apply migrations:
+. Create the database and apply every migration in order. Each migration
+beyond `001` is an idempotent `ALTER TABLE` block, so you can safely
+re-run the whole list after adding a new server.
 +
 [source,bash]
 ----
 createdb mymediascanner
-psql mymediascanner -f lib/data/remote/sync/migrations/001_initial_schema.sql
-psql mymediascanner -f lib/data/remote/sync/migrations/002_lending_tables.sql
-psql mymediascanner -f lib/data/remote/sync/migrations/003_critic_scores.sql
+for f in lib/data/remote/sync/migrations/*.sql; do
+  psql mymediascanner -f "$f"
+done
 ----
++
+The migrations currently shipped are:
++
+- `001_initial_schema.sql` — `media_items`, `shelves`, `tags`, and join tables
+- `002_lending_tables.sql` — `borrowers` and `loans`
+- `003_critic_scores.sql` — `critic_score`, `critic_source`
+- `004_ownership_and_purchase.sql` — `ownership_status`, `condition`, `price_paid`, `acquired_at`, `retailer`
+- `005_locations_series_progress.sql` — `location_id`, `series_id`, `series_position`, `progress_*`, `started_at`, `completed_at`, `consumed`
 
 . In the app, go to *Settings > PostgreSQL Configuration*, enter your connection details, and tap *Test Connection*.
 

--- a/lib/data/local/dao/loans_dao.dart
+++ b/lib/data/local/dao/loans_dao.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/data/local/database/tables/loans_table.dart';
@@ -55,25 +57,50 @@ class LoansDao extends DatabaseAccessor<AppDatabase> with _$LoansDaoMixin {
   /// captured at stream-creation time and embedded in the SQL `WHERE`,
   /// so a loan that silently became overdue mid-session never appeared
   /// until some row mutated.
+  ///
+  /// The previous implementation merged source and ticks via
+  /// `asyncExpand` over an inner periodic generator, which never
+  /// completes — so subsequent source events queued forever and the
+  /// overdue list froze after first emission. We now drive both inputs
+  /// from a single controller so source updates and minute ticks each
+  /// trigger an emission against the latest cached row set.
   Stream<List<LoansTableData>> watchOverdueLoans() {
-    final source = (select(loansTable)
-          ..where((t) =>
-              t.returnedAt.isNull() &
-              t.deleted.equals(0) &
-              t.dueAt.isNotNull()))
-        .watch();
+    final controller = StreamController<List<LoansTableData>>();
+    StreamSubscription<List<LoansTableData>>? sub;
+    Timer? timer;
+    var latest = const <LoansTableData>[];
 
-    // Combine with a 60-second tick so passage of time alone causes
-    // re-emission. Start with an immediate tick so the first frame has
-    // the overdue set without waiting a minute.
-    final ticks =
-        Stream<void>.periodic(const Duration(seconds: 60)).cast<void>();
-    return source.asyncExpand((rows) async* {
-      yield _filterOverdue(rows);
-      await for (final _ in ticks) {
-        yield _filterOverdue(rows);
+    void emit() {
+      if (!controller.isClosed) {
+        controller.add(_filterOverdue(latest));
       }
-    });
+    }
+
+    controller.onListen = () {
+      sub = (select(loansTable)
+            ..where((t) =>
+                t.returnedAt.isNull() &
+                t.deleted.equals(0) &
+                t.dueAt.isNotNull()))
+          .watch()
+          .listen(
+        (rows) {
+          latest = rows;
+          emit();
+        },
+        onError: controller.addError,
+      );
+      timer = Timer.periodic(const Duration(seconds: 60), (_) => emit());
+    };
+
+    controller.onCancel = () async {
+      await sub?.cancel();
+      timer?.cancel();
+      sub = null;
+      timer = null;
+    };
+
+    return controller.stream;
   }
 
   static List<LoansTableData> _filterOverdue(List<LoansTableData> rows) {

--- a/lib/data/local/dao/rip_library_dao.dart
+++ b/lib/data/local/dao/rip_library_dao.dart
@@ -112,6 +112,12 @@ class RipLibraryDao extends DatabaseAccessor<AppDatabase>
   }
 
   /// Update quality-related columns for a single track.
+  ///
+  /// Each named argument is treated as "leave alone" when null. Drift's
+  /// `Value(null)` would otherwise mean "set this column to NULL", which
+  /// caused a partial update such as `updateTrackQuality(id,
+  /// arStatus: 'not_checked')` to clobber a previously-recorded
+  /// `peakLevel`, `clickCount`, `arCrcV1/V2` etc.
   Future<void> updateTrackQuality(
     String trackId, {
     String? arStatus,
@@ -127,16 +133,25 @@ class RipLibraryDao extends DatabaseAccessor<AppDatabase>
   }) {
     return (update(ripTracksTable)..where((t) => t.id.equals(trackId))).write(
       RipTracksTableCompanion(
-        accurateripStatus: Value(arStatus),
-        accurateripConfidence: Value(arConfidence),
-        accurateripCrcV1: Value(arCrcV1),
-        accurateripCrcV2: Value(arCrcV2),
-        peakLevel: Value(peakLevel),
-        trackQuality: Value(trackQuality),
-        copyCrc: Value(copyCrc),
-        clickCount: Value(clickCount),
-        ripLogSource: Value(ripLogSource),
-        qualityCheckedAt: Value(qualityCheckedAt),
+        accurateripStatus:
+            arStatus != null ? Value(arStatus) : const Value.absent(),
+        accurateripConfidence:
+            arConfidence != null ? Value(arConfidence) : const Value.absent(),
+        accurateripCrcV1:
+            arCrcV1 != null ? Value(arCrcV1) : const Value.absent(),
+        accurateripCrcV2:
+            arCrcV2 != null ? Value(arCrcV2) : const Value.absent(),
+        peakLevel: peakLevel != null ? Value(peakLevel) : const Value.absent(),
+        trackQuality:
+            trackQuality != null ? Value(trackQuality) : const Value.absent(),
+        copyCrc: copyCrc != null ? Value(copyCrc) : const Value.absent(),
+        clickCount:
+            clickCount != null ? Value(clickCount) : const Value.absent(),
+        ripLogSource:
+            ripLogSource != null ? Value(ripLogSource) : const Value.absent(),
+        qualityCheckedAt: qualityCheckedAt != null
+            ? Value(qualityCheckedAt)
+            : const Value.absent(),
       ),
     );
   }

--- a/lib/data/local/dao/sync_log_dao.dart
+++ b/lib/data/local/dao/sync_log_dao.dart
@@ -34,6 +34,25 @@ class SyncLogDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
+  /// Replace the payload of every pending (unsynced) log entry for
+  /// [entityType]/[entityId] with [payloadJson].
+  ///
+  /// Used after `pullChanges` has merged a remote row into a row that
+  /// also has local edits queued for push: the merged state — not the
+  /// pre-pull snapshot the log was originally captured from — is what
+  /// should land on the server when the pending push fires. Without
+  /// this refresh the next push silently overwrites whichever fields
+  /// remote just contributed.
+  Future<int> updatePendingPayload(
+      String entityType, String entityId, String payloadJson) {
+    return (update(syncLogTable)
+          ..where((t) =>
+              t.entityType.equals(entityType) &
+              t.entityId.equals(entityId) &
+              t.synced.equals(0)))
+        .write(SyncLogTableCompanion(payloadJson: Value(payloadJson)));
+  }
+
   Future<void> deleteAll() {
     return delete(syncLogTable).go();
   }

--- a/lib/data/remote/sync/migrations/005_locations_series_progress.sql
+++ b/lib/data/remote/sync/migrations/005_locations_series_progress.sql
@@ -1,0 +1,28 @@
+-- Migration 005: locations, series, progress tracking, and consumed flag
+--
+-- The Dart client at `MediaItemRepositoryImpl._toSyncPayload` has been
+-- pushing these columns since the in-app locations/series/progress
+-- features shipped, but the corresponding server-side schema migration
+-- was missing — so every save against a server that had only run
+-- migrations 001..004 was rejected with `column "..." does not exist`.
+--
+-- All columns are nullable except `consumed`, which mirrors the local
+-- Drift schema's `INTEGER DEFAULT 0` (0 = not consumed, 1 = consumed).
+-- IF NOT EXISTS guards make this idempotent so it's safe to re-run on
+-- a server that has already had these columns hand-applied.
+
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS location_id TEXT;
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS series_id TEXT;
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS series_position INTEGER;
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS progress_current INTEGER;
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS progress_total INTEGER;
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS progress_unit TEXT;
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS started_at BIGINT;
+ALTER TABLE media_items ADD COLUMN IF NOT EXISTS completed_at BIGINT;
+ALTER TABLE media_items
+  ADD COLUMN IF NOT EXISTS consumed INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_media_items_location_id
+  ON media_items(location_id) WHERE location_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_media_items_series_id
+  ON media_items(series_id) WHERE series_id IS NOT NULL;

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -172,6 +172,17 @@ class SyncRepositoryImpl implements ISyncRepository {
         // re-flagged as dirty on the next push.
         merged['synced_at'] = DateTime.now().millisecondsSinceEpoch;
         await _mediaItemsDao.updateItem(_mapToCompanion(merged));
+
+        // If we had pending pushes for this row, their payload reflects
+        // the pre-pull local snapshot — pushing that would silently
+        // clobber whichever fields remote just contributed. Refresh the
+        // payload to the merged state so the next push is a no-op for
+        // remote-newer fields and only writes our local-newer fields.
+        await _syncLogDao.updatePendingPayload(
+          'media_item',
+          remoteId,
+          jsonEncode(merged),
+        );
       }
 
       // Auto-purge old sync log entries (30 days)
@@ -257,6 +268,15 @@ class SyncRepositoryImpl implements ISyncRepository {
       merged['synced_at'] = DateTime.now().millisecondsSinceEpoch;
 
       await _mediaItemsDao.updateItem(_mapToCompanion(merged));
+
+      // Same reasoning as in pullChanges: any pending push for this
+      // entity must now reflect the user-resolved merged state, not
+      // whatever pre-conflict snapshot the log was captured from.
+      await _syncLogDao.updatePendingPayload(
+        'media_item',
+        entityId,
+        jsonEncode(merged),
+      );
 
       // Log the resolution
       for (final res in entityResolutions) {

--- a/test/unit/data/dao/loans_dao_test.dart
+++ b/test/unit/data/dao/loans_dao_test.dart
@@ -109,5 +109,61 @@ void main() {
       active = await dao.watchActiveLoans().first;
       expect(active, isEmpty);
     });
+
+    test(
+      'watchOverdueLoans re-emits when a new loan is inserted after the first emission',
+      () async {
+        // Regression test for the bug where the overdue stream froze
+        // after first emission because asyncExpand wrapped an inner
+        // generator that never completed. Subsequent source events
+        // (a brand-new loan) were never observed by the stream.
+        await insertMediaItem('item-1');
+        await insertMediaItem('item-2');
+        await insertBorrower('borrower-1');
+
+        final now = DateTime.now().millisecondsSinceEpoch;
+        final pastDue = now - const Duration(days: 1).inMilliseconds;
+
+        // First overdue loan exists at subscription time.
+        await dao.insertLoan(LoansTableCompanion(
+          id: const Value('loan-1'),
+          mediaItemId: const Value('item-1'),
+          borrowerId: const Value('borrower-1'),
+          lentAt: Value(pastDue),
+          dueAt: Value(pastDue),
+          updatedAt: Value(now),
+        ));
+
+        final emissions = <List<int>>[];
+        final sub = dao.watchOverdueLoans().listen(
+          (rows) => emissions.add(rows.map((r) => r.dueAt!).toList()),
+        );
+
+        // Wait for first emission to land.
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(emissions, isNotEmpty,
+            reason: 'first emission should fire on subscribe');
+        expect(emissions.last.length, 1);
+
+        // Insert a second overdue loan — the source stream should fire
+        // and the merged stream should emit the new combined set.
+        await dao.insertLoan(LoansTableCompanion(
+          id: const Value('loan-2'),
+          mediaItemId: const Value('item-2'),
+          borrowerId: const Value('borrower-1'),
+          lentAt: Value(pastDue),
+          dueAt: Value(pastDue),
+          updatedAt: Value(now),
+        ));
+
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        await sub.cancel();
+
+        expect(emissions.last.length, 2,
+            reason:
+                'second insert must reach the stream (the asyncExpand bug '
+                'previously kept the stream stuck at the first emission)');
+      },
+    );
   });
 }

--- a/test/unit/data/dao/rip_library_dao_test.dart
+++ b/test/unit/data/dao/rip_library_dao_test.dart
@@ -538,5 +538,70 @@ void main() {
         expect(ids.length, 1);
       });
     });
+
+    group('updateTrackQuality preserves unspecified columns', () {
+      test(
+        'partial update of qualityCheckedAt does not clobber existing log-derived metrics',
+        () async {
+          // Regression test for the bug where every named arg was wrapped
+          // unconditionally in `Value(arg)` — passing `null` then meant
+          // "set to NULL" rather than "leave alone", so a follow-up
+          // partial update wiped previously-recorded peakLevel/clickCount/
+          // CRCs. The fix uses `Value.absent()` for null args.
+          final now = DateTime.now().millisecondsSinceEpoch;
+
+          await dao.insertAlbum(RipAlbumsTableCompanion(
+            id: const Value('rip-1'),
+            libraryPath: const Value('Artist/Album1'),
+            trackCount: const Value(1),
+            totalSizeBytes: const Value(50000000),
+            lastScannedAt: Value(now),
+            updatedAt: Value(now),
+          ));
+          await dao.insertTracks([
+            RipTracksTableCompanion(
+              id: const Value('track-1'),
+              ripAlbumId: const Value('rip-1'),
+              trackNumber: const Value(1),
+              filePath: const Value('/music/track1.flac'),
+              fileSizeBytes: const Value(50000000),
+              updatedAt: Value(now),
+            ),
+          ]);
+
+          // First call: log parser fills in quality metrics.
+          await dao.updateTrackQuality(
+            'track-1',
+            peakLevel: -0.123,
+            trackQuality: 99.7,
+            copyCrc: 'CAFEBABE',
+            ripLogSource: 'EAC',
+            arCrcV1: 'DEADBEEF',
+            arCrcV2: 'BEEFDEAD',
+          );
+
+          // Second call: AccurateRip path can't run, so only arStatus and
+          // qualityCheckedAt get set. The log-derived metrics from the
+          // first call must survive.
+          await dao.updateTrackQuality(
+            'track-1',
+            arStatus: 'not_checked',
+            qualityCheckedAt: now,
+          );
+
+          final tracks = await dao.getTracksForAlbum('rip-1');
+          final track = tracks.single;
+
+          expect(track.peakLevel, closeTo(-0.123, 1e-9));
+          expect(track.trackQuality, closeTo(99.7, 1e-9));
+          expect(track.copyCrc, 'CAFEBABE');
+          expect(track.ripLogSource, 'EAC');
+          expect(track.accurateripCrcV1, 'DEADBEEF');
+          expect(track.accurateripCrcV2, 'BEEFDEAD');
+          expect(track.accurateripStatus, 'not_checked');
+          expect(track.qualityCheckedAt, now);
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary

Four data-loss-class bugs surfaced by the post-merge code review. Each can silently corrupt or drop user data; all need to land before the next sync.

### 1. Sync pull lets the next push clobber merged remote fields
`pullChanges` merged remote rows into local Drift but never refreshed the pending sync-log payload. The next `pushChanges` then re-uploaded the pre-pull snapshot, silently overwriting whichever fields remote had just contributed. Fixed by `SyncLogDao.updatePendingPayload` after every successful merge — both in `pullChanges` and in `resolveConflicts`.

### 2. `RipLibraryDao.updateTrackQuality` erases unspecified columns
Drift reads `Value(null)` as "set to NULL", not "leave alone". A partial update like `updateTrackQuality(id, arStatus: 'not_checked')` after an earlier log-parser write erased `peakLevel`, `trackQuality`, `copyCrc`, `ripLogSource`, `arCrcV1`, `arCrcV2`. Switched every named arg to `Value.absent()` semantics.

### 3. `LoansDao.watchOverdueLoans` froze after first emission
`asyncExpand` over a `Stream.periodic` inner generator that never completes left subsequent source events queued forever. Replaced with a `StreamController` driven by the source watch + `Timer.periodic(60s)`.

### 4. Postgres sync schema is behind the client payload
The client has been pushing `location_id`, `series_id`, `series_position`, `progress_current/total/unit`, `started_at`, `completed_at`, and `consumed` for several releases, but server-side migrations stopped at `004_ownership_and_purchase.sql`. Every save against a freshly-set-up server hit `column "..." does not exist`. Worse, the README setup only ran 001-003, so even migration 004 was skipped. Added migration `005_locations_series_progress.sql` and rewrote the README to apply every migration via a glob loop.

## Tests

- `test/unit/data/dao/loans_dao_test.dart` — new regression test asserting a second loan insert reaches the overdue stream.
- `test/unit/data/dao/rip_library_dao_test.dart` — new regression test asserting a partial `updateTrackQuality` preserves earlier-recorded log metrics.
- No automated coverage for the sync-log payload refresh — would require a `PostgresSyncClient` mock that's heavier than the change. Manual test plan covers it.

## Verification

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1275 tests pass (2 new)
- [ ] Manual: edit field A locally and field B remotely, sync, confirm both A and B land on the server (the broken-pull-then-push scenario)
- [ ] Manual: parse a rip log, then run AccurateRip on a track that fails to decode — confirm the log-derived `peakLevel`/`copyCrc` survive on the second update
- [ ] Manual: load the overdue tab, leave it open, lend a new item with a past `dueAt`, confirm it appears within 60s
- [ ] Manual: set up a fresh Postgres server, run the new glob-loop setup, save an item with a `location_id` and `progress_current`, confirm sync succeeds and round-trips

## Notes

Migration 005 is idempotent (`ADD COLUMN IF NOT EXISTS`) and safe to re-run on servers where the columns were hand-applied during development.