### PR TITLE
Fix high-priority code-review cluster: lookup, rate limit, OAuth, lifecycle

### DIFF
--- a/lib/core/utils/rate_limiter.dart
+++ b/lib/core/utils/rate_limiter.dart
@@ -1,23 +1,39 @@
+import 'dart:async';
+
 /// Enforces a minimum interval between successive calls.
 ///
 /// Used to comply with API rate limits (e.g. MusicBrainz requires
 /// a maximum of 1 request per second).
+///
+/// Concurrency-safe: N parallel callers serialise into a chain so each
+/// proceeds [minInterval] after the previous, instead of all observing
+/// the same `_lastCall` snapshot and proceeding simultaneously.
 class RateLimiter {
   RateLimiter({required this.minInterval});
 
   final Duration minInterval;
-  DateTime? _lastCall;
 
-  /// Waits until [minInterval] has elapsed since the last call.
-  /// The first call always completes immediately.
-  Future<void> throttle() async {
-    final now = DateTime.now();
-    if (_lastCall != null) {
-      final elapsed = now.difference(_lastCall!);
-      if (elapsed < minInterval) {
-        await Future<void>.delayed(minInterval - elapsed);
-      }
-    }
-    _lastCall = DateTime.now();
+  /// Future that resolves when the *next* caller is allowed to proceed.
+  /// Each [throttle] gates on the previous value of this field, then
+  /// installs its own gate that opens [minInterval] later.
+  Future<void> _gate = Future<void>.value();
+
+  /// Waits until [minInterval] has elapsed since the previous caller
+  /// proceeded. The first call after construction always completes
+  /// immediately (modulo a microtask hop).
+  Future<void> throttle() {
+    final previous = _gate;
+    final readyForNext = Completer<void>();
+    _gate = readyForNext.future;
+
+    return previous.then((_) {
+      // We are now allowed to proceed. Open the gate for the next caller
+      // [minInterval] from now — not from when the previous caller
+      // returned, so a burst of N parallel calls fans out at the
+      // intended cadence rather than collapsing to a single window.
+      Timer(minInterval, () {
+        if (!readyForNext.isCompleted) readyForNext.complete();
+      });
+    });
   }
 }

--- a/lib/data/remote/api/igdb/igdb_token_manager.dart
+++ b/lib/data/remote/api/igdb/igdb_token_manager.dart
@@ -53,13 +53,21 @@ class IgdbTokenManager {
 
   Future<String> _exchange() async {
     try {
+      // Send client_id / client_secret in the form-encoded body, not the
+      // URL query string. Twitch accepts either, but the query-string
+      // form leaves the secret in upstream proxy logs and Twitch's edge
+      // access logs — out of our control. Body form is the canonical
+      // OAuth2 client-credentials shape.
       final response = await _authDio.post<Map<String, dynamic>>(
         '/oauth2/token',
-        queryParameters: {
+        data: {
           'client_id': clientId,
           'client_secret': clientSecret,
           'grant_type': 'client_credentials',
         },
+        options: Options(
+          contentType: Headers.formUrlEncodedContentType,
+        ),
       );
 
       final dto = TwitchTokenDto.fromJson(response.data ?? {});

--- a/lib/presentation/providers/connection_health_provider.dart
+++ b/lib/presentation/providers/connection_health_provider.dart
@@ -13,6 +13,14 @@ class ConnectionHealthNotifier extends Notifier<ConnectionHealth>
     with WidgetsBindingObserver {
   Timer? _timer;
 
+  /// True once we have registered ourselves as a [WidgetsBindingObserver].
+  /// `build()` re-runs whenever the watched config provider re-emits, but
+  /// the [Notifier] instance is preserved — so a naive
+  /// `addObserver(this)` in build() registers the same observer N times,
+  /// causing `didChangeAppLifecycleState` to fire N times per lifecycle
+  /// event. Guarding with this flag keeps it idempotent.
+  bool _observerRegistered = false;
+
   /// Ping interval in seconds (default 60).
   static const _pingIntervalSeconds = 60;
 
@@ -24,15 +32,20 @@ class ConnectionHealthNotifier extends Notifier<ConnectionHealth>
     // Start periodic pinging
     _startTimer();
 
-    // Register lifecycle observer
-    WidgetsBinding.instance.addObserver(this);
+    if (!_observerRegistered) {
+      WidgetsBinding.instance.addObserver(this);
+      _observerRegistered = true;
+    }
 
     // Trigger initial ping
     _ping();
 
     ref.onDispose(() {
       _timer?.cancel();
-      WidgetsBinding.instance.removeObserver(this);
+      if (_observerRegistered) {
+        WidgetsBinding.instance.removeObserver(this);
+        _observerRegistered = false;
+      }
     });
 
     return ConnectionHealth.unconfigured;
@@ -48,26 +61,21 @@ class ConnectionHealthNotifier extends Notifier<ConnectionHealth>
 
   Future<void> _ping() async {
     if (!ref.mounted) return;
-    final syncRepo = ref.read(syncRepositoryProvider);
-    if (syncRepo == null) {
+    // Reuse the long-lived client from `postgresSyncClientProvider` so
+    // we hit the cached connection. Building a fresh `PostgresSyncClient`
+    // per ping (and `close()`ing it in finally) used to pay a full TLS
+    // handshake every 60 s, which dwarfed the cost of the SELECT 1 that
+    // is the actual health check.
+    final client = ref.read(postgresSyncClientProvider);
+    if (client == null) {
       if (ref.mounted) state = ConnectionHealth.unconfigured;
       return;
     }
-
-    final config = ref.read(postgresConfigProvider).value;
-    if (config == null) {
-      if (ref.mounted) state = ConnectionHealth.unconfigured;
-      return;
-    }
-
-    final client = PostgresSyncClient(config: config);
     try {
       final health = await client.ping();
       if (ref.mounted) state = health;
     } on Exception {
       if (ref.mounted) state = ConnectionHealth.disconnected;
-    } finally {
-      await client.close();
     }
   }
 

--- a/lib/presentation/providers/repository_providers.dart
+++ b/lib/presentation/providers/repository_providers.dart
@@ -156,21 +156,33 @@ final ripLibraryRepositoryProvider = Provider<IRipLibraryRepository>((ref) {
   );
 });
 
-final syncRepositoryProvider = Provider<ISyncRepository?>((ref) {
+/// Single long-lived [PostgresSyncClient] per Postgres configuration.
+///
+/// Both [syncRepositoryProvider] and connection-health pings read this
+/// provider so they share one cached connection. Previously the health
+/// notifier minted a fresh client per ping and `await close()`d it
+/// immediately — defeating the connection cache and paying a TLS
+/// handshake every minute.
+final postgresSyncClientProvider =
+    Provider<PostgresSyncClient?>((ref) {
   final config = ref.watch(postgresConfigProvider).value;
   if (config == null) return null;
-
   final client = PostgresSyncClient(config: config);
+  ref.onDispose(() async => client.close());
+  return client;
+});
+
+final syncRepositoryProvider = Provider<ISyncRepository?>((ref) {
+  final client = ref.watch(postgresSyncClientProvider);
+  if (client == null) return null;
+
   final repo = SyncRepositoryImpl(
     mediaItemsDao: ref.watch(mediaItemsDaoProvider),
     syncLogDao: ref.watch(syncLogDaoProvider),
     syncClient: client,
   );
 
-  ref.onDispose(() async {
-    await repo.dispose();
-    await client.close();
-  });
+  ref.onDispose(() async => repo.dispose());
 
   return repo;
 });

--- a/lib/presentation/screens/metadata_confirm/widgets/editable_metadata_form.dart
+++ b/lib/presentation/screens/metadata_confirm/widgets/editable_metadata_form.dart
@@ -64,6 +64,15 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
   late List<String> _sourceApis;
   String? _resolution;
 
+  // Non-form metadata that an online lookup can refresh. Tracked as state
+  // so a user pressing "Search online" actually persists the fetched
+  // genres / critic data / IGDB extras on save — previously _buildEdited
+  // re-read these from widget.initial and discarded the lookup result.
+  late List<String> _genres;
+  double? _criticScore;
+  String? _criticSource;
+  late Map<String, dynamic> _extraMetadata;
+
   @override
   void initState() {
     super.initState();
@@ -86,7 +95,11 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
     _mediaType = widget.initial.mediaType ?? MediaType.unknown;
     _coverUrl = widget.initial.coverUrl;
     _sourceApis = List<String>.from(widget.initial.sourceApis);
-    final existingRes = widget.initial.extraMetadata['resolution'];
+    _genres = List<String>.from(widget.initial.genres);
+    _criticScore = widget.initial.criticScore;
+    _criticSource = widget.initial.criticSource;
+    _extraMetadata = Map<String, dynamic>.from(widget.initial.extraMetadata);
+    final existingRes = _extraMetadata['resolution'];
     _resolution = existingRes is String ? existingRes : null;
   }
 
@@ -165,8 +178,12 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
         _resolutionSuggestions(_mediaType, _formatController.text);
     final resolution =
         resSuggestions.contains(_resolution) ? _resolution : null;
-    final extra = Map<String, dynamic>.from(widget.initial.extraMetadata);
-    if (resolution != null) extra['resolution'] = resolution;
+    final extra = Map<String, dynamic>.from(_extraMetadata);
+    if (resolution != null) {
+      extra['resolution'] = resolution;
+    } else {
+      extra.remove('resolution');
+    }
     return widget.initial.copyWith(
       title: _titleController.text.isEmpty ? null : _titleController.text,
       subtitle: _subtitleController.text.isEmpty
@@ -183,6 +200,9 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
       mediaType: _mediaType,
       coverUrl: _coverUrl,
       sourceApis: _sourceApis,
+      genres: _genres,
+      criticScore: _criticScore,
+      criticSource: _criticSource,
       extraMetadata: extra,
     );
   }
@@ -283,19 +303,21 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
       return;
     }
 
-    final apiKeys = ref.read(apiKeysProvider).value ?? const {};
-    final missing = _missingApiMessage(_mediaType, apiKeys);
-    if (missing != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(missing)),
-      );
-      return;
-    }
-
+    // Wait for the secure-storage read to resolve before deciding which
+    // keys are missing — `.value` returns null while the AsyncNotifier is
+    // still loading, which previously caused a fresh-launch tap to show
+    // a misleading "TMDB API key required" even when keys were stored.
     final query = parts.join(' ');
     final messenger = ScaffoldMessenger.of(context);
     setState(() => _lookingUp = true);
     try {
+      final apiKeys = await ref.read(apiKeysProvider.future);
+      if (!mounted) return;
+      final missing = _missingApiMessage(_mediaType, apiKeys);
+      if (missing != null) {
+        messenger.showSnackBar(SnackBar(content: Text(missing)));
+        return;
+      }
       final repo = ref.read(metadataRepositoryProvider);
       final result = await repo.searchByTitle(
         query,
@@ -460,6 +482,21 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
       }
       if (found.sourceApis.isNotEmpty) {
         _sourceApis = found.sourceApis;
+      }
+      if (found.genres.isNotEmpty) {
+        _genres = List<String>.from(found.genres);
+      }
+      if (found.criticScore != null) {
+        _criticScore = found.criticScore;
+      }
+      if (found.criticSource != null && found.criticSource!.isNotEmpty) {
+        _criticSource = found.criticSource;
+      }
+      // Merge extras: prefer the lookup's keys (igdb_id, developer,
+      // platforms, …) but keep anything we already had that the lookup
+      // doesn't speak to (e.g. user-picked resolution).
+      if (found.extraMetadata.isNotEmpty) {
+        _extraMetadata = {..._extraMetadata, ...found.extraMetadata};
       }
     });
   }

--- a/lib/presentation/screens/rips/widgets/rip_album_detail_dialog.dart
+++ b/lib/presentation/screens/rips/widgets/rip_album_detail_dialog.dart
@@ -161,6 +161,15 @@ class _RipAlbumDetailDialogState extends ConsumerState<RipAlbumDetailDialog> {
   void _discard() {
     _artistController.text = widget.album.artist ?? '';
     _albumTitleController.text = widget.album.albumTitle ?? '';
+    // Dispose track-title controllers before clearing — `clear()` alone
+    // drops references and leaks the controllers, which still hold focus
+    // nodes and live `TextField` listeners. The State's own `dispose()`
+    // catches them on widget teardown but Discard is meant to be an
+    // in-place reset, so the leak persists for the lifetime of the
+    // dialog.
+    for (final c in _trackTitleControllers.values) {
+      c.dispose();
+    }
     _trackTitleControllers.clear();
     for (final c in _tagControllers.values) {
       c.dispose();

--- a/lib/presentation/screens/rips/widgets/rip_library_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_library_view.dart
@@ -718,6 +718,15 @@ class _RipAlbumDetailPanelState extends ConsumerState<_RipAlbumDetailPanel> {
   void _discard() {
     _artistController.text = widget.album.artist ?? '';
     _albumTitleController.text = widget.album.albumTitle ?? '';
+    // Dispose track-title controllers before clearing — `clear()` alone
+    // drops references and leaks the controllers, which still hold focus
+    // nodes and live `TextField` listeners. The State's own `dispose()`
+    // catches them on widget teardown but Discard is meant to be an
+    // in-place reset, so the leak persists for the lifetime of the
+    // screen.
+    for (final c in _trackTitleControllers.values) {
+      c.dispose();
+    }
     _trackTitleControllers.clear();
     for (final c in _tagControllers.values) {
       c.dispose();

--- a/lib/presentation/screens/scanner/desktop_scan_screen.dart
+++ b/lib/presentation/screens/scanner/desktop_scan_screen.dart
@@ -135,6 +135,20 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
     await _cameraService?.start();
   }
 
+  /// Fire-and-forget wrapper for [_resumeWebcamScanning] suitable for
+  /// the synchronous `ref.listen` callback. Surfaces any failure as a
+  /// SnackBar instead of letting it silently disappear into a dropped
+  /// future — the camera-restart path on Linux/Windows can throw if the
+  /// device is still releasing from the prior `stop()`.
+  void _resumeWebcamScanningSafely() {
+    unawaited(_resumeWebcamScanning().catchError((Object e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Could not restart webcam: $e')),
+      );
+    }));
+  }
+
   void _onSubmitted(String barcode) {
     if (barcode.trim().isEmpty) return;
     _controller.clear();
@@ -150,7 +164,7 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
         if (next.batchMode && next.result != null) {
           ref.read(scannerProvider.notifier).queueToBatch(next.result!);
           if (_webcamMode) {
-            _resumeWebcamScanning();
+            _resumeWebcamScanningSafely();
           } else {
             ref.read(scannerProvider.notifier).reset();
           }
@@ -162,7 +176,7 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
         if (next.batchMode && next.result != null) {
           ref.read(scannerProvider.notifier).queueToBatch(next.result!);
           if (_webcamMode) {
-            _resumeWebcamScanning();
+            _resumeWebcamScanningSafely();
           } else {
             ref.read(scannerProvider.notifier).reset();
           }
@@ -176,7 +190,7 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
         if (next.batchMode && next.result != null) {
           ref.read(scannerProvider.notifier).queueToBatch(next.result!);
           if (_webcamMode) {
-            _resumeWebcamScanning();
+            _resumeWebcamScanningSafely();
           } else {
             ref.read(scannerProvider.notifier).reset();
           }
@@ -194,7 +208,7 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
           );
         }
         if (_webcamMode) {
-          _resumeWebcamScanning();
+          _resumeWebcamScanningSafely();
         } else {
           ref.read(scannerProvider.notifier).reset();
         }
@@ -205,7 +219,7 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
           _focusNode.requestFocus();
         }
         if (_webcamMode && _hasScanned) {
-          _resumeWebcamScanning();
+          _resumeWebcamScanningSafely();
         }
       }
       if (next.state == ScanState.duplicate && _webcamMode) {
@@ -361,7 +375,7 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
           TextButton(
             onPressed: () {
               Navigator.of(dialogContext).pop();
-              _resumeWebcamScanning();
+              _resumeWebcamScanningSafely();
             },
             child: const Text('Scan again'),
           ),

--- a/test/unit/core/utils/rate_limiter_test.dart
+++ b/test/unit/core/utils/rate_limiter_test.dart
@@ -29,5 +29,37 @@ void main() {
       sw.stop();
       expect(sw.elapsedMilliseconds, lessThan(50));
     });
+
+    test(
+      'concurrent callers serialise — three parallel throttles fan out at minInterval',
+      () async {
+        // Regression test for the race where every concurrent caller
+        // observed the same _lastCall snapshot and all proceeded
+        // simultaneously, violating the upstream rate limit.
+        final limiter =
+            RateLimiter(minInterval: const Duration(milliseconds: 100));
+
+        // Prime the limiter so the first call's "always immediate"
+        // behaviour doesn't mask the test.
+        await limiter.throttle();
+
+        final sw = Stopwatch()..start();
+        final completionTimes = <int>[];
+
+        await Future.wait([
+          limiter.throttle().then((_) => completionTimes.add(sw.elapsedMilliseconds)),
+          limiter.throttle().then((_) => completionTimes.add(sw.elapsedMilliseconds)),
+          limiter.throttle().then((_) => completionTimes.add(sw.elapsedMilliseconds)),
+        ]);
+
+        completionTimes.sort();
+        // First fan-out call lands ~100 ms in (one minInterval after the
+        // priming call). Second ~200 ms. Third ~300 ms. Generous bounds
+        // to absorb scheduler jitter on CI runners.
+        expect(completionTimes[0], greaterThanOrEqualTo(80));
+        expect(completionTimes[1], greaterThanOrEqualTo(180));
+        expect(completionTimes[2], greaterThanOrEqualTo(280));
+      },
+    );
   });
 }

--- a/test/unit/data/remote/api/igdb/igdb_token_manager_test.dart
+++ b/test/unit/data/remote/api/igdb/igdb_token_manager_test.dart
@@ -22,6 +22,7 @@ Response<Map<String, dynamic>> _tokenResponse({
 void main() {
   setUpAll(() {
     registerFallbackValue(RequestOptions(path: ''));
+    registerFallbackValue(Options());
   });
 
   late _MockDio dio;
@@ -36,28 +37,41 @@ void main() {
     );
   });
 
-  test('exchanges Client ID + Secret for a bearer token', () async {
-    when(() => dio.post<Map<String, dynamic>>(
-          '/oauth2/token',
-          queryParameters: any(named: 'queryParameters'),
-        )).thenAnswer((_) async => _tokenResponse(token: 'fresh-token'));
+  test(
+    'exchanges Client ID + Secret for a bearer token (credentials in body, not query string)',
+    () async {
+      when(() => dio.post<Map<String, dynamic>>(
+            '/oauth2/token',
+            data: any<Map<String, dynamic>>(named: 'data'),
+            options: any(named: 'options'),
+          )).thenAnswer((_) async => _tokenResponse(token: 'fresh-token'));
 
-    final token = await manager.getToken();
+      final token = await manager.getToken();
 
-    expect(token, 'fresh-token');
-    final captured = verify(() => dio.post<Map<String, dynamic>>(
-          '/oauth2/token',
-          queryParameters: captureAny(named: 'queryParameters'),
-        )).captured.single as Map<String, dynamic>;
-    expect(captured['client_id'], 'cid');
-    expect(captured['client_secret'], 'secret');
-    expect(captured['grant_type'], 'client_credentials');
-  });
+      expect(token, 'fresh-token');
+      final invocation = verify(() => dio.post<Map<String, dynamic>>(
+            '/oauth2/token',
+            data: captureAny<Map<String, dynamic>>(named: 'data'),
+            options: captureAny(named: 'options'),
+          )).captured;
+
+      final body = invocation[0] as Map<String, dynamic>;
+      expect(body['client_id'], 'cid');
+      expect(body['client_secret'], 'secret');
+      expect(body['grant_type'], 'client_credentials');
+
+      // Secret must travel in the body so it never reaches Twitch's
+      // edge proxies as part of the URL line.
+      final options = invocation[1] as Options;
+      expect(options.contentType, Headers.formUrlEncodedContentType);
+    },
+  );
 
   test('caches the token so subsequent calls skip the exchange', () async {
     when(() => dio.post<Map<String, dynamic>>(
           '/oauth2/token',
-          queryParameters: any(named: 'queryParameters'),
+          data: any<Map<String, dynamic>>(named: 'data'),
+          options: any(named: 'options'),
         )).thenAnswer((_) async => _tokenResponse(token: 'once-only'));
 
     await manager.getToken();
@@ -65,7 +79,8 @@ void main() {
 
     verify(() => dio.post<Map<String, dynamic>>(
           '/oauth2/token',
-          queryParameters: any(named: 'queryParameters'),
+          data: any<Map<String, dynamic>>(named: 'data'),
+          options: any(named: 'options'),
         )).called(1);
   });
 
@@ -73,7 +88,8 @@ void main() {
     var call = 0;
     when(() => dio.post<Map<String, dynamic>>(
           '/oauth2/token',
-          queryParameters: any(named: 'queryParameters'),
+          data: any<Map<String, dynamic>>(named: 'data'),
+          options: any(named: 'options'),
         )).thenAnswer((_) async {
       call += 1;
       return _tokenResponse(token: 'token-$call');
@@ -90,7 +106,8 @@ void main() {
   test('throws when Twitch returns no access_token', () async {
     when(() => dio.post<Map<String, dynamic>>(
           '/oauth2/token',
-          queryParameters: any(named: 'queryParameters'),
+          data: any<Map<String, dynamic>>(named: 'data'),
+          options: any(named: 'options'),
         )).thenAnswer((_) async => Response<Map<String, dynamic>>(
           requestOptions: RequestOptions(path: '/oauth2/token'),
           data: const {},
@@ -104,7 +121,8 @@ void main() {
     var calls = 0;
     when(() => dio.post<Map<String, dynamic>>(
           '/oauth2/token',
-          queryParameters: any(named: 'queryParameters'),
+          data: any<Map<String, dynamic>>(named: 'data'),
+          options: any(named: 'options'),
         )).thenAnswer((_) async {
       calls += 1;
       await Future<void>.delayed(const Duration(milliseconds: 10));

--- a/test/widget/presentation/screens/manual_add/manual_add_screen_test.dart
+++ b/test/widget/presentation/screens/manual_add/manual_add_screen_test.dart
@@ -169,6 +169,10 @@ void main() {
       ProviderScope(
         overrides: [
           metadataRepositoryProvider.overrideWithValue(repo),
+          // _lookupOnline now awaits apiKeysProvider.future — without
+          // an override the real ApiKeysNotifier hits flutter_secure_storage,
+          // which never resolves under flutter_test.
+          apiKeysProvider.overrideWith(() => _EmptyApiKeysNotifier()),
         ],
         child: const MaterialApp(home: ManualAddScreen()),
       ),
@@ -208,6 +212,7 @@ void main() {
       ProviderScope(
         overrides: [
           metadataRepositoryProvider.overrideWithValue(repo),
+          apiKeysProvider.overrideWith(() => _EmptyApiKeysNotifier()),
         ],
         child: const MaterialApp(home: ManualAddScreen()),
       ),


### PR DESCRIPTION
## Summary

Seven correctness / security / lifecycle fixes from the post-merge code review. None are full data-loss like PR #61, but every one of them either silently drops user data or violates a contract.

### Editable metadata form
**#4** `_lookupOnline` now `await ref.read(apiKeysProvider.future)` before deciding which keys are missing. The previous `apiKeysProvider.value ?? const {}` raced the secure-storage read and could show a misleading "TMDB API key required" on a fresh launch.

**#C** `_buildEdited` now persists the **genres**, **criticScore**, **criticSource**, and **extraMetadata** that an online match returns (IGDB extras like `igdb_id`, `developer`, `platforms`, etc.). It used to re-read those from `widget.initial` and silently discarded everything the lookup brought back — the UI displayed "Metadata found" but saving lost most of it.

### Rate limiter (#5)
`RateLimiter.throttle` was racy: N concurrent callers all observed the same `_lastCall` snapshot and proceeded simultaneously. Replaced with a gate-chain pattern (each call awaits the previous gate, schedules its own gate `minInterval` after proceeding). Three parallel callers now fan out at `minInterval`, `2*minInterval`, `3*minInterval`. New regression test pins this. MusicBrainz's 1-req/s contract holds even when the parallel enrichment paths fire together.

### IGDB OAuth (#6)
Twitch token exchange sent `client_secret` as a URL query parameter. Twitch accepts either, but the query-string form leaves the secret in upstream proxy logs and Twitch edge access logs — out of our control. Now sent as a form-encoded request body. Existing tests rewritten and a new assertion verifies `Headers.formUrlEncodedContentType` is set.

### Rip controller leak (#7)
`_discard()` in both `rip_album_detail_dialog` and `rip_library_view` cleared the `_trackTitleControllers` map without disposing the controllers first. State's own `dispose()` catches them on widget teardown but Discard is meant to be an in-place reset, so the leak persisted for the lifetime of the screen. Fixed to mirror the existing `_tagControllers` discard loop.

### Desktop scan async (#8)
`ref.listen` is synchronous but called `_resumeWebcamScanning()` (an async method) without await/unawaited. Failures during the camera stop→start cycle on Linux/Windows silently vanished. Wrapped through a `_resumeWebcamScanningSafely()` helper that `unawaited(...)`s with a `.catchError` that surfaces failures as a SnackBar.

### Connection health (#9)
Two bugs: (a) `WidgetsBinding.instance.addObserver(this)` ran in every `build()`, and `build()` re-runs whenever `postgresConfigProvider` re-emits — so a config edit registered the same observer twice and `didChangeAppLifecycleState` fired twice per lifecycle event; (b) `_ping` constructed a fresh `PostgresSyncClient` per minute and `close()`d it in finally, defeating the connection cache and paying a TLS handshake every 60 s. Fixed (a) with an `_observerRegistered` guard. Fixed (b) by extracting a `postgresSyncClientProvider` that caches one client per Postgres config; both `syncRepositoryProvider` and the health notifier read it.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1277 tests pass (3 new — concurrent throttle, IGDB body shape; existing IGDB tests rewritten)
- [ ] Manual: cold-launch the app, immediately tap Search online in Manual Add for a film with TMDB key stored — confirm no spurious "TMDB API key required"
- [ ] Manual: search online, take a multi-match candidate, save — confirm `genres`, `criticScore`, IGDB extras land on the saved item
- [ ] Manual: edit two rip-album track titles, tap Discard, edit again — confirm no controller-after-dispose assertion in debug
- [ ] Manual: open the desktop scanner with a webcam, scan, click "Scan again" — confirm no orphaned futures (run with `--enable-asserts`)
- [ ] Manual: leave the connection health UI open for 5+ minutes — confirm one ping per minute and no second observer registered if you edit Postgres credentials mid-session

## Notes

`postgresSyncClientProvider` is a small refactor of PR #60's disposal wiring. The `ref.onDispose` for client `close()` moved from `syncRepositoryProvider` into the new dedicated provider, so the disposal contract is unchanged.