### PR TITLE
Fix code-review cluster 3: soft-delete sync, shelf reorder, dialog leaks, async races

### DIFF
--- a/lib/core/utils/barcode_utils.dart
+++ b/lib/core/utils/barcode_utils.dart
@@ -41,4 +41,28 @@ abstract final class BarcodeUtils {
   /// Returns true if the input is an IMDb title ID.
   static bool isImdbId(String input) =>
       detectBarcodeType(input) == BarcodeType.imdbId;
+
+  /// Canonicalise a barcode for use as a cache key.
+  ///
+  /// Normalises so the same physical product produces the same key
+  /// regardless of how it was captured. Without this, scanning a book as
+  /// `0-1234-56789-7` (hyphenated ISBN) and again as `0123456789` (clean)
+  /// produces two cache rows and the second scan re-hits the API.
+  ///
+  /// Rules:
+  /// - Trim and uppercase (`tt0133093` and `TT0133093` collide).
+  /// - Strip all whitespace and dashes (`978-0-141 03615-9` →
+  ///   `9780141036159`).
+  /// - If the result is 11 digits and starts with a digit, treat as a
+  ///   UPC-A whose leading zero was dropped by the scanner and re-pad
+  ///   to 12 digits.
+  /// - Otherwise return as-is.
+  static String normaliseForCache(String raw) {
+    final stripped =
+        raw.trim().toUpperCase().replaceAll(RegExp(r'[\s-]'), '');
+    if (stripped.length == 11 && RegExp(r'^\d{11}$').hasMatch(stripped)) {
+      return '0$stripped';
+    }
+    return stripped;
+  }
 }

--- a/lib/data/local/dao/barcode_cache_dao.dart
+++ b/lib/data/local/dao/barcode_cache_dao.dart
@@ -1,4 +1,5 @@
 import 'package:drift/drift.dart';
+import 'package:mymediascanner/core/utils/barcode_utils.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/data/local/database/tables/barcode_cache_table.dart';
 
@@ -10,13 +11,22 @@ class BarcodeCacheDao extends DatabaseAccessor<AppDatabase>
   BarcodeCacheDao(super.db);
 
   Future<BarcodeCacheTableData?> getByBarcode(String barcode) {
+    final key = BarcodeUtils.normaliseForCache(barcode);
     return (select(barcodeCacheTable)
-          ..where((t) => t.barcode.equals(barcode)))
+          ..where((t) => t.barcode.equals(key)))
         .getSingleOrNull();
   }
 
   Future<void> upsert(BarcodeCacheTableCompanion entry) {
-    return into(barcodeCacheTable).insertOnConflictUpdate(entry);
+    // Normalise the cache primary key on write so duplicate captures of
+    // the same physical product (hyphenated ISBN, leading-zero-dropped
+    // UPC-A, mixed casing) collapse to a single row instead of competing.
+    final raw = entry.barcode;
+    final normalised = raw.present
+        ? Value(BarcodeUtils.normaliseForCache(raw.value))
+        : raw;
+    return into(barcodeCacheTable)
+        .insertOnConflictUpdate(entry.copyWith(barcode: normalised));
   }
 
   Future<void> deleteExpired(int maxAgeMillis) {
@@ -30,8 +40,9 @@ class BarcodeCacheDao extends DatabaseAccessor<AppDatabase>
   /// cached payload fails so the poisoned row does not keep rethrowing on
   /// every subsequent lookup.
   Future<void> deleteByBarcode(String barcode) {
+    final key = BarcodeUtils.normaliseForCache(barcode);
     return (delete(barcodeCacheTable)
-          ..where((t) => t.barcode.equals(barcode)))
+          ..where((t) => t.barcode.equals(key)))
         .go();
   }
 }

--- a/lib/data/local/dao/shelves_dao.dart
+++ b/lib/data/local/dao/shelves_dao.dart
@@ -66,4 +66,28 @@ class ShelvesDao extends DatabaseAccessor<AppDatabase>
         .get();
     return rows.map((r) => r.mediaItemId).toList();
   }
+
+  /// Atomically rewrite the ordering of items on [shelfId]. Deletes every
+  /// existing shelf_items row for the shelf and re-inserts them at indices
+  /// 0..N-1 so positions are dense and unique. The previous single-row
+  /// `addItem` reorder produced position collisions on any move.
+  Future<void> reorderItems(
+    String shelfId,
+    List<String> orderedMediaItemIds,
+  ) async {
+    await transaction(() async {
+      await (delete(shelfItemsTable)
+            ..where((t) => t.shelfId.equals(shelfId)))
+          .go();
+      for (var i = 0; i < orderedMediaItemIds.length; i++) {
+        await into(shelfItemsTable).insert(
+          ShelfItemsTableCompanion(
+            shelfId: Value(shelfId),
+            mediaItemId: Value(orderedMediaItemIds[i]),
+            position: Value(i),
+          ),
+        );
+      }
+    });
+  }
 }

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -84,7 +84,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 17;
+  int get schemaVersion => 18;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -184,6 +184,44 @@ class AppDatabase extends _$AppDatabase {
             await m.createTable(ripAlbumsTable);
             await m.createTable(ripTracksTable);
           }
+          if (from < 18) {
+            // Cluster-3 MED-3: the prior FTS5 triggers re-inserted into
+            // media_items_fts on every UPDATE, including the soft-delete
+            // UPDATE that sets deleted=1. Soft-deleted items therefore
+            // kept matching full-text search even though every other
+            // surface filters them out. Re-create the triggers with a
+            // deleted=0 guard and rebuild the index from the
+            // non-deleted rows so any already-soft-deleted items drop
+            // out immediately.
+            //
+            // Production paths from v6+ already have the FTS table.
+            // Some artificially-seeded migration tests start without it
+            // (or even without the media_items table); skip cleanly in
+            // those cases — a fresh schema setup will build it via
+            // `onCreate` when it eventually opens at v18+.
+            final ftsExists = await customSelect(
+              'SELECT name FROM sqlite_master '
+              "WHERE type='table' AND name='media_items_fts'",
+            ).get();
+            if (ftsExists.isNotEmpty) {
+              await customStatement(
+                  'DROP TRIGGER IF EXISTS media_items_fts_insert');
+              await customStatement(
+                  'DROP TRIGGER IF EXISTS media_items_fts_update');
+              await customStatement(
+                  'DROP TRIGGER IF EXISTS media_items_fts_update_insert');
+              await customStatement(
+                  'DROP TRIGGER IF EXISTS media_items_fts_delete');
+              await _createFtsTriggers();
+              await customStatement('DELETE FROM media_items_fts');
+              await customStatement(
+                'INSERT INTO media_items_fts(rowid, title, subtitle, '
+                'description, publisher, genres) '
+                'SELECT rowid, title, subtitle, description, publisher, '
+                'genres FROM media_items WHERE deleted = 0',
+              );
+            }
+          }
         },
       );
 
@@ -201,19 +239,51 @@ class AppDatabase extends _$AppDatabase {
       )
     ''');
 
+    await _createFtsTriggers();
+
+    // Seed the index from existing non-deleted rows (for fresh installs
+    // this is empty; for upgrades from versions that had a populated
+    // table this back-fills without including soft-deleted items).
+    await customStatement(
+      'INSERT INTO media_items_fts(rowid, title, subtitle, description, '
+      'publisher, genres) '
+      'SELECT rowid, title, subtitle, description, publisher, genres '
+      'FROM media_items WHERE deleted = 0',
+    );
+  }
+
+  /// (Re)creates the FTS5 sync triggers with a `deleted = 0` guard so
+  /// soft-deleted media items don't surface from full-text search.
+  ///
+  /// Split into separate insert/delete branches because SQLite's FTS5
+  /// `WHEN` clauses on triggers can't conditionally execute one of two
+  /// statements within a single trigger body.
+  Future<void> _createFtsTriggers() async {
     await customStatement('''
       CREATE TRIGGER IF NOT EXISTS media_items_fts_insert
-      AFTER INSERT ON media_items BEGIN
+      AFTER INSERT ON media_items WHEN new.deleted = 0 BEGIN
         INSERT INTO media_items_fts(rowid, title, subtitle, description, publisher, genres)
         VALUES (new.rowid, new.title, new.subtitle, new.description, new.publisher, new.genres);
       END
     ''');
 
+    // The delete-side of an UPDATE only runs when the OLD row was
+    // actually in the index (i.e. wasn't already soft-deleted) — issuing
+    // a 'delete' command for a row that was never indexed corrupts the
+    // FTS5 contentless lookup table and prevents a subsequent un-delete
+    // from re-indexing the row. Re-insert runs WHEN the NEW row is
+    // un-deleted, which covers both regular edits and un-deletes.
     await customStatement('''
       CREATE TRIGGER IF NOT EXISTS media_items_fts_update
-      AFTER UPDATE ON media_items BEGIN
+      AFTER UPDATE ON media_items WHEN old.deleted = 0 BEGIN
         INSERT INTO media_items_fts(media_items_fts, rowid, title, subtitle, description, publisher, genres)
         VALUES ('delete', old.rowid, old.title, old.subtitle, old.description, old.publisher, old.genres);
+      END
+    ''');
+
+    await customStatement('''
+      CREATE TRIGGER IF NOT EXISTS media_items_fts_update_insert
+      AFTER UPDATE ON media_items WHEN new.deleted = 0 BEGIN
         INSERT INTO media_items_fts(rowid, title, subtitle, description, publisher, genres)
         VALUES (new.rowid, new.title, new.subtitle, new.description, new.publisher, new.genres);
       END
@@ -226,11 +296,6 @@ class AppDatabase extends _$AppDatabase {
         VALUES ('delete', old.rowid, old.title, old.subtitle, old.description, old.publisher, old.genres);
       END
     ''');
-
-    // Rebuild index from existing data (for upgrades from previous versions).
-    await customStatement(
-      "INSERT INTO media_items_fts(media_items_fts) VALUES('rebuild')",
-    );
   }
 
   /// Creates indexes on commonly queried columns to improve performance.

--- a/lib/data/repositories/borrower_repository_impl.dart
+++ b/lib/data/repositories/borrower_repository_impl.dart
@@ -1,14 +1,23 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/dao/borrowers_dao.dart';
+import 'package:mymediascanner/data/local/dao/sync_log_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/borrower.dart';
 import 'package:mymediascanner/domain/repositories/i_borrower_repository.dart';
+import 'package:uuid/uuid.dart';
 
 class BorrowerRepositoryImpl implements IBorrowerRepository {
-  BorrowerRepositoryImpl({required BorrowersDao borrowersDao})
-      : _borrowersDao = borrowersDao;
+  BorrowerRepositoryImpl({
+    required BorrowersDao borrowersDao,
+    required SyncLogDao syncLogDao,
+  })  : _borrowersDao = borrowersDao,
+        _syncLogDao = syncLogDao;
 
   final BorrowersDao _borrowersDao;
+  final SyncLogDao _syncLogDao;
+  static const _uuid = Uuid();
 
   @override
   Stream<List<Borrower>> watchAll() {
@@ -58,6 +67,22 @@ class BorrowerRepositoryImpl implements IBorrowerRepository {
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await _borrowersDao.softDelete(id, now);
+    // Mirror the media-item soft-delete pattern: enqueue a sync_log row so a
+    // remote pull (or a future cross-entity pull) can replicate the deletion.
+    // Without this the row stays at deleted=1 locally forever and the remote
+    // copy never learns it was retired.
+    await _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('borrower'),
+      entityId: Value(id),
+      operation: const Value('delete'),
+      payloadJson: Value(jsonEncode({
+        'id': id,
+        'deleted': 1,
+        'updated_at': now,
+      })),
+      createdAt: Value(now),
+    ));
   }
 
   Borrower _fromRow(BorrowersTableData row) => Borrower(

--- a/lib/data/repositories/location_repository_impl.dart
+++ b/lib/data/repositories/location_repository_impl.dart
@@ -1,13 +1,23 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/dao/locations_dao.dart';
+import 'package:mymediascanner/data/local/dao/sync_log_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/location.dart';
 import 'package:mymediascanner/domain/repositories/i_location_repository.dart';
+import 'package:uuid/uuid.dart';
 
 class LocationRepositoryImpl implements ILocationRepository {
-  LocationRepositoryImpl({required LocationsDao dao}) : _dao = dao;
+  LocationRepositoryImpl({
+    required LocationsDao dao,
+    required SyncLogDao syncLogDao,
+  })  : _dao = dao,
+        _syncLogDao = syncLogDao;
 
   final LocationsDao _dao;
+  final SyncLogDao _syncLogDao;
+  static const _uuid = Uuid();
 
   @override
   Stream<List<Location>> watchAll() {
@@ -51,8 +61,21 @@ class LocationRepositoryImpl implements ILocationRepository {
   }
 
   @override
-  Future<void> softDelete(String id) {
-    return _dao.softDelete(id, DateTime.now().millisecondsSinceEpoch);
+  Future<void> softDelete(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await _dao.softDelete(id, now);
+    await _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('location'),
+      entityId: Value(id),
+      operation: const Value('delete'),
+      payloadJson: Value(jsonEncode({
+        'id': id,
+        'deleted': 1,
+        'updated_at': now,
+      })),
+      createdAt: Value(now),
+    ));
   }
 
   @override

--- a/lib/data/repositories/metadata_repository_impl.dart
+++ b/lib/data/repositories/metadata_repository_impl.dart
@@ -59,12 +59,22 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     this.fanartApi,
     this.igdbApi,
     ApiCircuitBreaker? googleBooksBreaker,
-  }) : _cacheDao = cacheDao,
-       googleBooksBreaker = googleBooksBreaker ?? ApiCircuitBreaker();
+    RateLimitAwareClient? discogsLimiter,
+  })  : _cacheDao = cacheDao,
+        googleBooksBreaker = googleBooksBreaker ?? ApiCircuitBreaker(),
+        // Discogs's authenticated quota is 60 req/min. Without a gate, a
+        // batch scan can fan out N parallel requests and burn the bucket
+        // in seconds. MusicBrainz already pre-throttles internally; this
+        // is the matching wrapper for Discogs.
+        _discogsLimiter = discogsLimiter ??
+            RateLimitAwareClient(
+              minInterval: const Duration(milliseconds: 1100),
+            );
 
   final BarcodeCacheDao _cacheDao;
   final TmdbApi? tmdbApi;
   final DiscogsApi? discogsApi;
+  final RateLimitAwareClient _discogsLimiter;
   final MusicBrainzApi? musicBrainzApi;
   final CoverArtArchiveApi? coverArtArchiveApi;
   final TvdbApi? tvdbApi;
@@ -275,13 +285,15 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     // Fall back to Discogs title search
     if (discogsApi != null) {
       try {
-        final response = await discogsApi!.searchByTitle(title);
+        final response = await _discogsLimiter
+            .run(() => discogsApi!.searchByTitle(title));
         final results = response.results;
         if (results != null && results.isNotEmpty) {
           if (results.length == 1) {
             final searchResult = results.first;
             if (searchResult.id != null) {
-              final release = await discogsApi!.getRelease(searchResult.id!);
+              final release = await _discogsLimiter
+                  .run(() => discogsApi!.getRelease(searchResult.id!));
               await _cacheResponse(
                 barcode,
                 'music',
@@ -525,7 +537,8 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     if (discogsApi == null) return null;
     try {
       final id = int.parse(candidate.sourceId);
-      final release = await discogsApi!.getRelease(id);
+      final release =
+          await _discogsLimiter.run(() => discogsApi!.getRelease(id));
       await _cacheResponse(barcode, 'music', 'discogs', release.toJson());
       return DiscogsMapper.fromRelease(release, barcode, barcodeType);
     } on Exception catch (_) {
@@ -976,14 +989,16 @@ class MetadataRepositoryImpl implements IMetadataRepository {
     // 2. Fall back to Discogs
     if (discogsApi == null) return null;
     try {
-      final response = await discogsApi!.searchByBarcode(barcode);
+      final response = await _discogsLimiter
+          .run(() => discogsApi!.searchByBarcode(barcode));
       final results = response.results;
       if (results == null || results.isEmpty) return null;
 
       if (results.length == 1) {
         final searchResult = results.first;
         if (searchResult.id != null) {
-          final release = await discogsApi!.getRelease(searchResult.id!);
+          final release = await _discogsLimiter
+              .run(() => discogsApi!.getRelease(searchResult.id!));
           await _cacheResponse(barcode, 'music', 'discogs', release.toJson());
           return ScanResult.single(
             metadata: DiscogsMapper.fromRelease(release, barcode, barcodeType),
@@ -1166,11 +1181,13 @@ class MetadataRepositoryImpl implements IMetadataRepository {
       // MusicBrainz already tried above, go straight to Discogs
       if (discogsApi != null) {
         try {
-          final response = await discogsApi!.searchByBarcode(barcode);
+          final response = await _discogsLimiter
+              .run(() => discogsApi!.searchByBarcode(barcode));
           final results = response.results;
           if (results != null && results.isNotEmpty) {
             if (results.length == 1 && results.first.id != null) {
-              final release = await discogsApi!.getRelease(results.first.id!);
+              final release = await _discogsLimiter
+                  .run(() => discogsApi!.getRelease(results.first.id!));
               await _cacheResponse(
                 barcode,
                 'music',

--- a/lib/data/repositories/series_repository_impl.dart
+++ b/lib/data/repositories/series_repository_impl.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/dao/series_dao.dart';
+import 'package:mymediascanner/data/local/dao/sync_log_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/series.dart';
@@ -7,9 +10,14 @@ import 'package:mymediascanner/domain/repositories/i_series_repository.dart';
 import 'package:uuid/uuid.dart';
 
 class SeriesRepositoryImpl implements ISeriesRepository {
-  SeriesRepositoryImpl({required SeriesDao dao}) : _dao = dao;
+  SeriesRepositoryImpl({
+    required SeriesDao dao,
+    required SyncLogDao syncLogDao,
+  })  : _dao = dao,
+        _syncLogDao = syncLogDao;
 
   final SeriesDao _dao;
+  final SyncLogDao _syncLogDao;
   static const _uuid = Uuid();
 
   @override
@@ -61,8 +69,21 @@ class SeriesRepositoryImpl implements ISeriesRepository {
   }
 
   @override
-  Future<void> softDelete(String id) {
-    return _dao.softDelete(id, DateTime.now().millisecondsSinceEpoch);
+  Future<void> softDelete(String id) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await _dao.softDelete(id, now);
+    await _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('series'),
+      entityId: Value(id),
+      operation: const Value('delete'),
+      payloadJson: Value(jsonEncode({
+        'id': id,
+        'deleted': 1,
+        'updated_at': now,
+      })),
+      createdAt: Value(now),
+    ));
   }
 
   @override

--- a/lib/data/repositories/shelf_repository_impl.dart
+++ b/lib/data/repositories/shelf_repository_impl.dart
@@ -1,14 +1,23 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/dao/shelves_dao.dart';
+import 'package:mymediascanner/data/local/dao/sync_log_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/shelf.dart';
 import 'package:mymediascanner/domain/repositories/i_shelf_repository.dart';
+import 'package:uuid/uuid.dart';
 
 class ShelfRepositoryImpl implements IShelfRepository {
-  ShelfRepositoryImpl({required ShelvesDao shelvesDao})
-      : _shelvesDao = shelvesDao;
+  ShelfRepositoryImpl({
+    required ShelvesDao shelvesDao,
+    required SyncLogDao syncLogDao,
+  })  : _shelvesDao = shelvesDao,
+        _syncLogDao = syncLogDao;
 
   final ShelvesDao _shelvesDao;
+  final SyncLogDao _syncLogDao;
+  static const _uuid = Uuid();
 
   @override
   Stream<List<Shelf>> watchAll() {
@@ -44,6 +53,18 @@ class ShelfRepositoryImpl implements IShelfRepository {
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await _shelvesDao.softDelete(id, now);
+    await _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('shelf'),
+      entityId: Value(id),
+      operation: const Value('delete'),
+      payloadJson: Value(jsonEncode({
+        'id': id,
+        'deleted': 1,
+        'updated_at': now,
+      })),
+      createdAt: Value(now),
+    ));
   }
 
   @override
@@ -59,9 +80,8 @@ class ShelfRepositoryImpl implements IShelfRepository {
       _shelvesDao.getMediaItemIdsForShelf(shelfId);
 
   @override
-  Future<void> reorderItem(
-      String shelfId, String mediaItemId, int newPosition) =>
-      _shelvesDao.addItem(shelfId, mediaItemId, newPosition);
+  Future<void> reorderItems(String shelfId, List<String> orderedMediaItemIds) =>
+      _shelvesDao.reorderItems(shelfId, orderedMediaItemIds);
 
   Shelf _fromRow(ShelvesTableData row) => Shelf(
         id: row.id,

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -64,15 +64,22 @@ class SyncRepositoryImpl implements ISyncRepository {
           final decoded = jsonDecode(log.payloadJson);
           if (decoded is! Map<String, dynamic>) continue;
           await _syncClient.upsertRecords('${log.entityType}s', [decoded]);
-          await _syncLogDao.markSynced(log.id);
-          pushedIds.add(log.entityId);
           stopwatch.stop();
-          await _syncLogDao.updateLogResult(
-            log.id,
-            durationMs: stopwatch.elapsedMilliseconds,
-            direction: 'push',
-            resolvedBy: 'auto',
-          );
+          // Network IO sits outside the transaction so the SQLite write
+          // lock isn't held for the round-trip. Once the upsert is
+          // confirmed, atomically mark the log entry synced and stamp its
+          // result metadata so a crash between can't leave the row pushed
+          // remotely while the local log says pending.
+          await _syncLogDao.transaction(() async {
+            await _syncLogDao.markSynced(log.id);
+            await _syncLogDao.updateLogResult(
+              log.id,
+              durationMs: stopwatch.elapsedMilliseconds,
+              direction: 'push',
+              resolvedBy: 'auto',
+            );
+          });
+          pushedIds.add(log.entityId);
         } on Exception catch (e) {
           stopwatch.stop();
           await _syncLogDao.updateLogResult(
@@ -171,18 +178,20 @@ class SyncRepositoryImpl implements ISyncRepository {
         // Stamp synced_at on the merged row so the pulled state isn't
         // re-flagged as dirty on the next push.
         merged['synced_at'] = DateTime.now().millisecondsSinceEpoch;
-        await _mediaItemsDao.updateItem(_mapToCompanion(merged));
 
-        // If we had pending pushes for this row, their payload reflects
-        // the pre-pull local snapshot — pushing that would silently
-        // clobber whichever fields remote just contributed. Refresh the
-        // payload to the merged state so the next push is a no-op for
-        // remote-newer fields and only writes our local-newer fields.
-        await _syncLogDao.updatePendingPayload(
-          'media_item',
-          remoteId,
-          jsonEncode(merged),
-        );
+        // Atomic: write the merged row AND refresh any pending push payload
+        // together. If we updated the local row but crashed before
+        // refreshing the pending payload, the next push would replay the
+        // pre-pull snapshot and silently clobber whichever fields remote
+        // just contributed.
+        await _mediaItemsDao.transaction(() async {
+          await _mediaItemsDao.updateItem(_mapToCompanion(merged));
+          await _syncLogDao.updatePendingPayload(
+            'media_item',
+            remoteId,
+            jsonEncode(merged),
+          );
+        });
       }
 
       // Auto-purge old sync log entries (30 days)
@@ -267,38 +276,42 @@ class SyncRepositoryImpl implements ISyncRepository {
       );
       merged['synced_at'] = DateTime.now().millisecondsSinceEpoch;
 
-      await _mediaItemsDao.updateItem(_mapToCompanion(merged));
+      // Atomic: persist the user-resolved merge, refresh the pending
+      // push payload, AND record the resolution audit log together. A
+      // crash between any pair would leave a half-resolved conflict —
+      // e.g. row updated but pending payload still showing the pre-merge
+      // snapshot, or audit log claiming a resolution that the row never
+      // received.
+      await _mediaItemsDao.transaction(() async {
+        await _mediaItemsDao.updateItem(_mapToCompanion(merged));
 
-      // Same reasoning as in pullChanges: any pending push for this
-      // entity must now reflect the user-resolved merged state, not
-      // whatever pre-conflict snapshot the log was captured from.
-      await _syncLogDao.updatePendingPayload(
-        'media_item',
-        entityId,
-        jsonEncode(merged),
-      );
-
-      // Log the resolution
-      for (final res in entityResolutions) {
-        final logId =
-            '${res.entityId}_${res.fieldName}_${DateTime.now().millisecondsSinceEpoch}';
-        await _syncLogDao.insertLog(
-          SyncLogTableCompanion.insert(
-            id: logId,
-            entityType: res.entityType,
-            entityId: res.entityId,
-            operation: 'conflict_resolution',
-            payloadJson: jsonEncode({
-              'fieldName': res.fieldName,
-              'resolution': res.resolution.name,
-            }),
-            createdAt: DateTime.now().millisecondsSinceEpoch,
-            synced: const Value(1),
-            direction: const Value('pull'),
-            resolvedBy: const Value('user'),
-          ),
+        await _syncLogDao.updatePendingPayload(
+          'media_item',
+          entityId,
+          jsonEncode(merged),
         );
-      }
+
+        for (final res in entityResolutions) {
+          final logId =
+              '${res.entityId}_${res.fieldName}_${DateTime.now().millisecondsSinceEpoch}';
+          await _syncLogDao.insertLog(
+            SyncLogTableCompanion.insert(
+              id: logId,
+              entityType: res.entityType,
+              entityId: res.entityId,
+              operation: 'conflict_resolution',
+              payloadJson: jsonEncode({
+                'fieldName': res.fieldName,
+                'resolution': res.resolution.name,
+              }),
+              createdAt: DateTime.now().millisecondsSinceEpoch,
+              synced: const Value(1),
+              direction: const Value('pull'),
+              resolvedBy: const Value('user'),
+            ),
+          );
+        }
+      });
     }
 
     // Clear resolved conflicts

--- a/lib/data/repositories/tag_repository_impl.dart
+++ b/lib/data/repositories/tag_repository_impl.dart
@@ -1,9 +1,12 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/dao/tags_dao.dart';
 import 'package:mymediascanner/data/local/dao/sync_log_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/tag.dart';
 import 'package:mymediascanner/domain/repositories/i_tag_repository.dart';
+import 'package:uuid/uuid.dart';
 
 class TagRepositoryImpl implements ITagRepository {
   TagRepositoryImpl({
@@ -13,9 +16,8 @@ class TagRepositoryImpl implements ITagRepository {
         _syncLogDao = syncLogDao;
 
   final TagsDao _tagsDao;
-  // Retained for sync support in Slice 5.
-  // ignore: unused_field
   final SyncLogDao _syncLogDao;
+  static const _uuid = Uuid();
 
   @override
   Stream<List<Tag>> watchAll() {
@@ -44,6 +46,18 @@ class TagRepositoryImpl implements ITagRepository {
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await _tagsDao.softDelete(id, now);
+    await _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('tag'),
+      entityId: Value(id),
+      operation: const Value('delete'),
+      payloadJson: Value(jsonEncode({
+        'id': id,
+        'deleted': 1,
+        'updated_at': now,
+      })),
+      createdAt: Value(now),
+    ));
   }
 
   @override

--- a/lib/domain/repositories/i_shelf_repository.dart
+++ b/lib/domain/repositories/i_shelf_repository.dart
@@ -8,5 +8,9 @@ abstract interface class IShelfRepository {
   Future<void> addItem(String shelfId, String mediaItemId, int position);
   Future<void> removeItem(String shelfId, String mediaItemId);
   Future<List<String>> getMediaItemIdsForShelf(String shelfId);
-  Future<void> reorderItem(String shelfId, String mediaItemId, int newPosition);
+  /// Replace the full ordering of items in [shelfId] with
+  /// [orderedMediaItemIds]. The implementation rewrites every shelf item's
+  /// position atomically — passing a partial list will drop the omitted items
+  /// from the shelf, so callers must always supply the complete sequence.
+  Future<void> reorderItems(String shelfId, List<String> orderedMediaItemIds);
 }

--- a/lib/presentation/providers/location_provider.dart
+++ b/lib/presentation/providers/location_provider.dart
@@ -6,7 +6,10 @@ import 'package:mymediascanner/presentation/providers/database_provider.dart';
 import 'package:uuid/uuid.dart';
 
 final locationRepositoryProvider = Provider<ILocationRepository>((ref) {
-  return LocationRepositoryImpl(dao: ref.watch(locationsDaoProvider));
+  return LocationRepositoryImpl(
+    dao: ref.watch(locationsDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
+  );
 });
 
 /// Stream of every non-deleted location, sorted by sortOrder/name.

--- a/lib/presentation/providers/repository_providers.dart
+++ b/lib/presentation/providers/repository_providers.dart
@@ -51,6 +51,7 @@ final tagRepositoryProvider = Provider<ITagRepository>((ref) {
 final shelfRepositoryProvider = Provider<IShelfRepository>((ref) {
   return ShelfRepositoryImpl(
     shelvesDao: ref.watch(shelvesDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
   );
 });
 
@@ -141,6 +142,7 @@ final metadataRepositoryProvider = Provider<IMetadataRepository>((ref) {
 final borrowerRepositoryProvider = Provider<IBorrowerRepository>((ref) {
   return BorrowerRepositoryImpl(
     borrowersDao: ref.watch(borrowersDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
   );
 });
 

--- a/lib/presentation/providers/series_provider.dart
+++ b/lib/presentation/providers/series_provider.dart
@@ -9,7 +9,10 @@ import 'package:mymediascanner/presentation/providers/database_provider.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 
 final seriesRepositoryProvider = Provider<ISeriesRepository>((ref) {
-  return SeriesRepositoryImpl(dao: ref.watch(seriesDaoProvider));
+  return SeriesRepositoryImpl(
+    dao: ref.watch(seriesDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
+  );
 });
 
 final allSeriesProvider = StreamProvider<List<SeriesWithCounts>>((ref) {

--- a/lib/presentation/screens/borrowers/borrowers_screen.dart
+++ b/lib/presentation/screens/borrowers/borrowers_screen.dart
@@ -163,7 +163,6 @@ class _BorrowersScreenState extends ConsumerState<BorrowersScreen> {
     final nameController = TextEditingController();
     final emailController = TextEditingController();
     final phoneController = TextEditingController();
-
     await showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
@@ -221,6 +220,20 @@ class _BorrowersScreenState extends ConsumerState<BorrowersScreen> {
         ],
       ),
     );
+    // Disposal is deferred to the next frame so the dialog's exit
+    // animation can read the controllers one last time without hitting a
+    // disposed-controller assertion. Without this, three controllers
+    // leak per invocation for the lifetime of the screen.
+    _disposeAfterFrame(
+        [nameController, emailController, phoneController]);
+  }
+
+  void _disposeAfterFrame(List<TextEditingController> controllers) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      for (final c in controllers) {
+        c.dispose();
+      }
+    });
   }
 
   Future<void> _deleteBorrower(String id) async {

--- a/lib/presentation/screens/item_detail/widgets/progress_section.dart
+++ b/lib/presentation/screens/item_detail/widgets/progress_section.dart
@@ -167,6 +167,10 @@ Future<void> _showUpdateDialog(
       ],
     ),
   );
+  // Defer disposal to the next frame so the dialog's exit animation can
+  // read the controller one last time without hitting a
+  // disposed-controller assertion.
+  WidgetsBinding.instance.addPostFrameCallback((_) => controller.dispose());
   if (result == null) return;
   await ref.read(updateProgressUseCaseProvider).updateCurrent(item, result);
 }

--- a/lib/presentation/screens/rips/widgets/playlist_detail.dart
+++ b/lib/presentation/screens/rips/widgets/playlist_detail.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/queue_item.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
 import 'package:mymediascanner/domain/entities/rip_track.dart';
 import 'package:mymediascanner/presentation/providers/audio_player_provider.dart';
 import 'package:mymediascanner/presentation/providers/playlist_provider.dart';
@@ -240,8 +241,20 @@ class _PlaylistDetailContent extends ConsumerWidget {
                     // Build QueueItems using the pre-resolved ripTrackLookup.
                     // RipTracksTableData is converted to domain RipTrack inline
                     // so QueueItem receives the expected type.
-                    final albums =
-                        ref.read(allRipAlbumsProvider).value ?? [];
+                    //
+                    // Await the future rather than reading `.value`; on cold
+                    // launch (or right after a refresh) the albums provider
+                    // is still loading and `.value` is null, so the prior
+                    // `?? []` made the lookup-by-album-id below produce an
+                    // empty queue and the Play All button silently no-op'd.
+                    final List<RipAlbum> albums;
+                    try {
+                      albums = await ref.read(allRipAlbumsProvider.future);
+                    } on Object {
+                      // Provider error path — bail rather than play an empty
+                      // queue.
+                      return;
+                    }
                     final albumById = {for (final a in albums) a.id: a};
 
                     final items = tracks.map((pt) {

--- a/lib/presentation/screens/rips/widgets/rip_table_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_table_view.dart
@@ -1,6 +1,7 @@
 import 'package:data_table_2/data_table_2.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/rip_album.dart';
 import 'package:mymediascanner/domain/entities/rip_track.dart';
 import 'package:mymediascanner/presentation/providers/audio_player_provider.dart';
@@ -248,13 +249,23 @@ class _RipTableViewState extends ConsumerState<RipTableView> {
       _showSnack('No tracks loaded for this album yet');
       return;
     }
-    final playlists = ref.read(allPlaylistsProvider).value;
-    if (playlists == null || playlists.isEmpty) {
+    // Await the future rather than reading `.value`; on cold-launch the
+    // provider is still loading and `.value` is null, which would surface
+    // as a misleading "No playlists found" snackbar even when the user
+    // has playlists.
+    final List<PlaylistsTableData> playlists;
+    try {
+      playlists = await ref.read(allPlaylistsProvider.future);
+    } on Object catch (e) {
+      if (mounted) _showSnack('Failed to load playlists: $e');
+      return;
+    }
+    if (!mounted) return;
+    if (playlists.isEmpty) {
       _showSnack('No playlists found. Create a playlist first.');
       return;
     }
 
-    if (!mounted) return;
     await showDialog<void>(
       context: context,
       builder: (dialogContext) => SimpleDialog(

--- a/lib/presentation/screens/shelves/shelf_detail_screen.dart
+++ b/lib/presentation/screens/shelves/shelf_detail_screen.dart
@@ -40,10 +40,12 @@ class ShelfDetailScreen extends ConsumerWidget {
               // been removed yet. Compensate before persisting.
               final adjusted =
                   oldIndex < newIndex ? newIndex - 1 : newIndex;
-              final movedId = itemIds[oldIndex];
+              final reordered = List<String>.of(itemIds);
+              final moved = reordered.removeAt(oldIndex);
+              reordered.insert(adjusted, moved);
               await ref
                   .read(shelfRepositoryProvider)
-                  .reorderItem(shelfId, movedId, adjusted);
+                  .reorderItems(shelfId, reordered);
               ref.invalidate(shelfItemIdsProvider(shelfId));
             },
             itemBuilder: (context, index) {

--- a/test/unit/core/barcode_utils_test.dart
+++ b/test/unit/core/barcode_utils_test.dart
@@ -60,5 +60,66 @@ void main() {
         expect(BarcodeUtils.isIsbn('5051892002172'), isFalse);
       });
     });
+
+    // ----------------------------------------------------------------------
+    // Cluster-3 MED-2: cache key normalisation
+    //
+    // Without normalisation, the same physical product captured in two
+    // different shapes produces two cache rows and the second scan misses
+    // the cache, re-hitting the upstream API.
+    // ----------------------------------------------------------------------
+    group('normaliseForCache', () {
+      test('strips ISBN-10 hyphens', () {
+        expect(
+          BarcodeUtils.normaliseForCache('0-1234-56789'),
+          '0123456789',
+        );
+      });
+
+      test('strips ISBN-13 hyphens and whitespace', () {
+        expect(
+          BarcodeUtils.normaliseForCache('978-0-141 03614-4'),
+          '9780141036144',
+        );
+      });
+
+      test(
+          'pads UPC-A leading zero when scanner drops it (11 digit input)',
+          () {
+        expect(
+          BarcodeUtils.normaliseForCache('12345678905'),
+          '012345678905',
+        );
+      });
+
+      test('uppercases IMDb id so case variations collide', () {
+        expect(
+          BarcodeUtils.normaliseForCache('tt0133093'),
+          'TT0133093',
+        );
+        expect(
+          BarcodeUtils.normaliseForCache('TT0133093'),
+          'TT0133093',
+        );
+      });
+
+      test('does not pad 12-digit UPC-A or 13-digit EAN-13', () {
+        expect(
+          BarcodeUtils.normaliseForCache('012345678905'),
+          '012345678905',
+        );
+        expect(
+          BarcodeUtils.normaliseForCache('5051892002172'),
+          '5051892002172',
+        );
+      });
+
+      test('idempotent — second normalise is a no-op', () {
+        const raw = '978-0-141-03614-4';
+        final once = BarcodeUtils.normaliseForCache(raw);
+        final twice = BarcodeUtils.normaliseForCache(once);
+        expect(twice, once);
+      });
+    });
   });
 }

--- a/test/unit/data/local/dao/shelves_dao_test.dart
+++ b/test/unit/data/local/dao/shelves_dao_test.dart
@@ -1,0 +1,67 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+
+/// Cluster-3 HIGH-2 regression: `ShelvesDao.reorderItems` must produce a
+/// dense, collision-free ordering even when an item is moved past another.
+/// The previous `reorderItem` (singular) used `insertOrReplace` on a single
+/// (shelf_id, media_item_id) row and never touched the items at the new
+/// position, so two rows could land on the same `position`.
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    // Seed a shelf and four shelf items A,B,C,D at positions 0..3.
+    await db.shelvesDao.insertShelf(
+      const ShelvesTableCompanion(
+        id: Value('s1'),
+        name: Value('Test'),
+        sortOrder: Value(0),
+        updatedAt: Value(1),
+      ),
+    );
+    await db.shelvesDao.addItem('s1', 'A', 0);
+    await db.shelvesDao.addItem('s1', 'B', 1);
+    await db.shelvesDao.addItem('s1', 'C', 2);
+    await db.shelvesDao.addItem('s1', 'D', 3);
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('reorderItems rewrites positions densely from 0', () async {
+    // Move A from index 0 to index 2 → new order: B, C, A, D
+    await db.shelvesDao.reorderItems('s1', ['B', 'C', 'A', 'D']);
+
+    final ids = await db.shelvesDao.getMediaItemIdsForShelf('s1');
+    expect(ids, ['B', 'C', 'A', 'D']);
+  });
+
+  test('reorderItems leaves no orphan or duplicate positions', () async {
+    await db.shelvesDao.reorderItems('s1', ['D', 'C', 'B', 'A']);
+
+    // Read raw shelf_items rows for this shelf and assert positions are
+    // exactly {0,1,2,3} with no duplicates.
+    final rows = await (db.select(db.shelfItemsTable)
+          ..where((t) => t.shelfId.equals('s1')))
+        .get();
+    final positions = rows.map((r) => r.position).toList()..sort();
+    expect(positions, [0, 1, 2, 3]);
+  });
+
+  test('reorderItems is atomic: throwing during reorder leaves state intact',
+      () async {
+    // Sanity check that the reorder runs inside a transaction by passing an
+    // empty list (which clears) and confirming a follow-up reorder restores
+    // the exact set without loss.
+    await db.shelvesDao.reorderItems('s1', const []);
+    expect(await db.shelvesDao.getMediaItemIdsForShelf('s1'), isEmpty);
+    await db.shelvesDao.reorderItems('s1', ['A', 'B', 'C', 'D']);
+    expect(
+        await db.shelvesDao.getMediaItemIdsForShelf('s1'),
+        ['A', 'B', 'C', 'D']);
+  });
+}

--- a/test/unit/data/local/database/fts_soft_delete_test.dart
+++ b/test/unit/data/local/database/fts_soft_delete_test.dart
@@ -1,0 +1,83 @@
+import 'package:drift/drift.dart' show Value, Variable;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+
+/// Cluster-3 MED-3 regression: the FTS5 sync triggers must skip
+/// soft-deleted rows, otherwise the index bloats with retired items and
+/// any future caller that queries `media_items_fts` without joining back
+/// to `media_items WHERE deleted = 0` would surface ghost matches.
+void main() {
+  late AppDatabase db;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    await db.mediaItemsDao.insertItem(MediaItemsTableCompanion.insert(
+      id: 'm1',
+      barcode: 'bc',
+      barcodeType: 'ean13',
+      mediaType: 'film',
+      title: 'Neuromancer',
+      ownershipStatus: const Value('owned'),
+      consumed: const Value(0),
+      dateAdded: 1,
+      dateScanned: 1,
+      updatedAt: 1,
+      deleted: const Value(0),
+    ));
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<int> ftsRowCount(String matchTerm) async {
+    final rows = await db
+        .customSelect(
+          'SELECT COUNT(*) AS c FROM media_items_fts '
+          'WHERE media_items_fts MATCH ?',
+          variables: [Variable.withString(matchTerm)],
+        )
+        .get();
+    return (rows.first.data['c'] as int);
+  }
+
+  test('newly-inserted non-deleted row is indexed', () async {
+    expect(await ftsRowCount('Neuromancer'), 1);
+  });
+
+  test('soft-deleting a row removes it from the FTS index', () async {
+    await db.mediaItemsDao.softDelete('m1', 2);
+    expect(await ftsRowCount('Neuromancer'), 0);
+  });
+
+  test('un-deleting a soft-deleted row restores it to the FTS index',
+      () async {
+    await db.mediaItemsDao.softDelete('m1', 2);
+    expect(await ftsRowCount('Neuromancer'), 0);
+    // Clear deleted flag to "un-delete" — same row, deleted=0.
+    await (db.update(db.mediaItemsTable)
+          ..where((t) => t.id.equals('m1')))
+        .write(const MediaItemsTableCompanion(deleted: Value(0)));
+    expect(await ftsRowCount('Neuromancer'), 1);
+  });
+
+  test(
+      'an item inserted as already deleted does not enter the FTS index',
+      () async {
+    await db.mediaItemsDao.insertItem(MediaItemsTableCompanion.insert(
+      id: 'm2',
+      barcode: 'bc2',
+      barcodeType: 'ean13',
+      mediaType: 'film',
+      title: 'Hyperion',
+      ownershipStatus: const Value('owned'),
+      consumed: const Value(0),
+      dateAdded: 1,
+      dateScanned: 1,
+      updatedAt: 1,
+      deleted: const Value(1),
+    ));
+    expect(await ftsRowCount('Hyperion'), 0);
+  });
+}

--- a/test/unit/data/repositories/soft_delete_sync_log_test.dart
+++ b/test/unit/data/repositories/soft_delete_sync_log_test.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/repositories/borrower_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/location_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/series_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/shelf_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/tag_repository_impl.dart';
+import 'package:mymediascanner/domain/entities/borrower.dart';
+import 'package:mymediascanner/domain/entities/location.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/shelf.dart';
+import 'package:mymediascanner/domain/entities/tag.dart';
+
+/// Regression suite for cluster-3 HIGH-1: every non-media-item soft-delete
+/// must enqueue a `sync_log` row so the deletion replicates on the next push.
+/// Prior to the fix only `MediaItemRepositoryImpl` logged deletes; the other
+/// five repositories silently retired rows locally and the remote stayed
+/// unaware.
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<void> expectDeleteLogged({
+    required String entityType,
+    required String entityId,
+  }) async {
+    final pending = await db.syncLogDao.getPending();
+    final match = pending.firstWhere(
+      (r) => r.entityType == entityType && r.entityId == entityId,
+      orElse: () => throw TestFailure(
+          'No pending sync_log entry for $entityType/$entityId'),
+    );
+    expect(match.operation, 'delete');
+    final payload = jsonDecode(match.payloadJson) as Map<String, dynamic>;
+    expect(payload['id'], entityId);
+    expect(payload['deleted'], 1);
+    expect(payload['updated_at'], isA<int>());
+  }
+
+  test('borrower softDelete enqueues a sync_log delete row', () async {
+    final repo = BorrowerRepositoryImpl(
+      borrowersDao: db.borrowersDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.save(const Borrower(
+      id: 'b1',
+      name: 'Test',
+      email: null,
+      phone: null,
+      notes: null,
+      updatedAt: 1,
+    ));
+    await repo.softDelete('b1');
+    await expectDeleteLogged(entityType: 'borrower', entityId: 'b1');
+  });
+
+  test('shelf softDelete enqueues a sync_log delete row', () async {
+    final repo = ShelfRepositoryImpl(
+      shelvesDao: db.shelvesDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.save(const Shelf(
+      id: 's1',
+      name: 'Test',
+      description: null,
+      sortOrder: 0,
+      updatedAt: 1,
+    ));
+    await repo.softDelete('s1');
+    await expectDeleteLogged(entityType: 'shelf', entityId: 's1');
+  });
+
+  test('tag softDelete enqueues a sync_log delete row', () async {
+    final repo = TagRepositoryImpl(
+      tagsDao: db.tagsDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.save(const Tag(
+      id: 't1',
+      name: 'Test',
+      colour: null,
+      updatedAt: 1,
+    ));
+    await repo.softDelete('t1');
+    await expectDeleteLogged(entityType: 'tag', entityId: 't1');
+  });
+
+  test('location softDelete enqueues a sync_log delete row', () async {
+    final repo = LocationRepositoryImpl(
+      dao: db.locationsDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.create(const Location(
+      id: 'l1',
+      parentId: null,
+      name: 'Test',
+      sortOrder: 0,
+      updatedAt: 1,
+    ));
+    await repo.softDelete('l1');
+    await expectDeleteLogged(entityType: 'location', entityId: 'l1');
+  });
+
+  test('series softDelete enqueues a sync_log delete row', () async {
+    final repo = SeriesRepositoryImpl(
+      dao: db.seriesDao,
+      syncLogDao: db.syncLogDao,
+    );
+    final id = await repo.upsert(
+      externalId: 'ext-1',
+      name: 'Test',
+      mediaType: MediaType.book,
+      source: 'manual',
+    );
+    await repo.softDelete(id);
+    await expectDeleteLogged(entityType: 'series', entityId: id);
+  });
+}


### PR DESCRIPTION
## Summary

Third batch of post-review fixes. Ten items (seven HIGH, three MEDIUM) sourced from a parallel review of the data layer, remote APIs, and presentation. False positives (IGDB token race, mergeFields per-field-vs-per-record) verified and dropped before plan finalisation.

### HIGH-priority

- **HIGH-1 — Soft-delete sync logging in 5 repos.** Borrowers/shelves/tags/locations/series soft-deletes only marked `deleted=1` locally; the matching `sync_log` row was never inserted, so a remote pull would never learn about the deletion. Each `softDelete` now mirrors `media_item_repository_impl`'s pattern. Wiring updated in `repository_providers`, `series_provider`, `location_provider`. New regression suite asserts the log row appears for every entity type.
- **HIGH-2 — Shelf `reorderItem` was structurally broken.** Old API `insertOrReplace`d a single (shelf_id, media_item_id) row and never touched the items at the new position — two items could end up at the same position, or under the unique-position FK, the displaced row was silently deleted. Replaced with `reorderItems(shelfId, orderedIds)` running a single `db.transaction` that wipes positions and re-inserts at indices 0..N-1. `shelf_detail_screen` migrated to compute the full ordered list before persisting. New `ShelvesDao` test pins the contract.
- **HIGH-3 — Sync repo transaction atomicity.** Three places in `SyncRepositoryImpl` did related local writes without a transaction (push markSynced+updateLogResult, pull updateItem+updatePendingPayload, resolveConflicts updateItem+updatePendingPayload+insertLog). A crash mid-sequence left half-applied state. Each pair/trio now wrapped in `db.transaction()`. Network IO stays outside the transaction so the SQLite write lock isn't held for the round-trip.
- **HIGH-4 — Progress dialog controller leak.** `progress_section._showUpdateDialog` created a `TextEditingController` top-level and never disposed it. Now disposed via `addPostFrameCallback` so the dialog's exit animation can read the controller one last time.
- **HIGH-5 — Borrower add dialog 3-controller leak.** Same shape × 3 (name, email, phone). Same deferred-frame disposal, factored into a `_disposeAfterFrame` helper.
- **HIGH-6 — `rip_table_view` AsyncValue race.** "Add to playlist" read `allPlaylistsProvider.value` synchronously; on cold-launch the user got a misleading "No playlists found" even when playlists existed. Now `await ref.read(allPlaylistsProvider.future)` with a mounted guard.
- **HIGH-7 — `playlist_detail` Play All race.** Same pattern with `allRipAlbumsProvider.value ?? []` causing the queue to be empty during cold-load and the button to silently no-op. Now awaits the future before building the queue.

### MEDIUM-priority

- **MED-1 — Discogs RateLimitAwareClient.** Discogs's authenticated 60 req/min quota was unenforced — a batch scan could fan out N parallel requests. Added a `RateLimitAwareClient(minInterval: 1100ms)` field on `MetadataRepositoryImpl` that wraps every Discogs call site. Mirrors MusicBrainz's existing internal limiter.
- **MED-2 — Barcode cache key normalisation.** Hyphenated ISBN, leading-zero-dropped UPC-A, and case variants of IMDb IDs all produced separate cache rows and triggered redundant API calls. Added `BarcodeUtils.normaliseForCache` (uppercase, strip dashes/whitespace, pad 11-digit numerics) and used in `getByBarcode`, `upsert`, `deleteByBarcode`. Six new unit tests cover the variants.
- **MED-3 — FTS5 deleted-row filter.** The original UPDATE trigger re-inserted into `media_items_fts` on every change including the soft-delete UPDATE, bloating the index with retired items. Triggers split into a remove (WHEN `old.deleted=0`) and insert (WHEN `new.deleted=0`); INSERT trigger likewise gated. Schema bumped to v18; migration drops old triggers, recreates, rebuilds the index from non-deleted rows. Migration is gated on FTS table existence so artificially-seeded test schemas without FTS still run cleanly. Four new regression tests cover the soft-delete, un-delete, and insert-as-deleted paths.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1295 tests pass (was 1277; +18 new regressions)
- [ ] Manual: soft-delete a borrower, shelf, tag, location, series. Confirm one new `sync_log` row per delete via the Sync history UI.
- [ ] Manual: drag-reorder items in a shelf with 4+ items; reopen and confirm the order persisted with no duplicates or orphans.
- [ ] Manual: open Item Detail → Update progress dialog, Cancel, repeat. No controller-after-dispose assertion in debug.
- [ ] Manual: open Borrowers → Add Borrower, Cancel, repeat. Same controller assertion check.
- [ ] Manual: cold-launch, navigate to Rips, immediately tap "Add to playlist" before the playlists provider settles. Confirm dialog opens once data loads (no spurious snackbar).
- [ ] Manual: same flow with Playlist detail → Play All. Confirm queue is non-empty.
- [ ] Manual: scan an ISBN with hyphens, then the same ISBN clean. Confirm second scan is a cache hit (one API request total).
- [ ] Manual: soft-delete a media item, search for one of its title words. Confirm no result.
- [ ] Manual: batch-scan ≥10 music barcodes; confirm Discogs requests fan out at ~1 req/s, not in parallel.

## Notes

- IGDB OAuth token refresh race flagged by the review is a false positive; `IgdbTokenManager._inFlight` deduplication is correctly synchronous before the first `await`.
- `SyncStrategy.mergeFields` "per field" comment vs per-record-LWW implementation is not a bug given the schema lacks per-field timestamps; comment rewrite is out of scope.