### PR TITLE
Fix code-review cluster 4: reset wiring, push coverage, status seed, clear-all

### DIFF
--- a/lib/data/local/dao/loans_dao.dart
+++ b/lib/data/local/dao/loans_dao.dart
@@ -110,6 +110,11 @@ class LoansDao extends DatabaseAccessor<AppDatabase> with _$LoansDaoMixin {
         .toList();
   }
 
+  Future<LoansTableData?> getById(String id) {
+    return (select(loansTable)..where((t) => t.id.equals(id)))
+        .getSingleOrNull();
+  }
+
   Future<void> insertLoan(LoansTableCompanion companion) {
     return into(loansTable).insert(companion);
   }

--- a/lib/data/local/dao/media_items_dao.dart
+++ b/lib/data/local/dao/media_items_dao.dart
@@ -126,6 +126,14 @@ class MediaItemsDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
+  /// Hard-delete every row in [mediaItemsTable]. Used by
+  /// `SyncRepositoryImpl.resetLocalDatabase` to honour the
+  /// "Replace local data with remote" affordance — soft-delete
+  /// would leave the rows visible to sync and defeat the reset.
+  Future<int> deleteAll() {
+    return delete(mediaItemsTable).go();
+  }
+
   Future<List<MediaItemsTableData>> getUnsynced() {
     return customSelect(
       'SELECT * FROM media_items WHERE synced_at IS NULL OR updated_at > synced_at',

--- a/lib/data/repositories/borrower_repository_impl.dart
+++ b/lib/data/repositories/borrower_repository_impl.dart
@@ -45,22 +45,28 @@ class BorrowerRepositoryImpl implements IBorrowerRepository {
     );
     if (existing != null) {
       await _borrowersDao.updateBorrower(companion);
+      await _logSync(borrower, 'update');
     } else {
       await _borrowersDao.insertBorrower(companion);
+      await _logSync(borrower, 'insert');
     }
   }
 
   @override
   Future<void> update(Borrower borrower) async {
+    final updated = borrower.copyWith(
+      updatedAt: DateTime.now().millisecondsSinceEpoch,
+    );
     final companion = BorrowersTableCompanion(
-      id: Value(borrower.id),
-      name: Value(borrower.name),
-      email: Value(borrower.email),
-      phone: Value(borrower.phone),
-      notes: Value(borrower.notes),
-      updatedAt: Value(DateTime.now().millisecondsSinceEpoch),
+      id: Value(updated.id),
+      name: Value(updated.name),
+      email: Value(updated.email),
+      phone: Value(updated.phone),
+      notes: Value(updated.notes),
+      updatedAt: Value(updated.updatedAt),
     );
     await _borrowersDao.updateBorrower(companion);
+    await _logSync(updated, 'update');
   }
 
   @override
@@ -82,6 +88,28 @@ class BorrowerRepositoryImpl implements IBorrowerRepository {
         'updated_at': now,
       })),
       createdAt: Value(now),
+    ));
+  }
+
+  /// Enqueue a `sync_log` row carrying a full snake_case snapshot of
+  /// [borrower]. Push uses the payload keys to derive the upsert column
+  /// list, so the snapshot must include every sync-relevant field.
+  Future<void> _logSync(Borrower borrower, String operation) {
+    return _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('borrower'),
+      entityId: Value(borrower.id),
+      operation: Value(operation),
+      payloadJson: Value(jsonEncode({
+        'id': borrower.id,
+        'name': borrower.name,
+        'email': borrower.email,
+        'phone': borrower.phone,
+        'notes': borrower.notes,
+        'updated_at': borrower.updatedAt,
+        'deleted': borrower.deleted ? 1 : 0,
+      })),
+      createdAt: Value(DateTime.now().millisecondsSinceEpoch),
     ));
   }
 

--- a/lib/data/repositories/loan_repository_impl.dart
+++ b/lib/data/repositories/loan_repository_impl.dart
@@ -1,13 +1,23 @@
+import 'dart:convert';
+
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/dao/loans_dao.dart';
+import 'package:mymediascanner/data/local/dao/sync_log_dao.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/domain/entities/loan.dart';
 import 'package:mymediascanner/domain/repositories/i_loan_repository.dart';
+import 'package:uuid/uuid.dart';
 
 class LoanRepositoryImpl implements ILoanRepository {
-  LoanRepositoryImpl({required LoansDao loansDao}) : _loansDao = loansDao;
+  LoanRepositoryImpl({
+    required LoansDao loansDao,
+    required SyncLogDao syncLogDao,
+  })  : _loansDao = loansDao,
+        _syncLogDao = syncLogDao;
 
   final LoansDao _loansDao;
+  final SyncLogDao _syncLogDao;
+  static const _uuid = Uuid();
 
   @override
   Stream<List<Loan>> watchAll() {
@@ -62,6 +72,7 @@ class LoanRepositoryImpl implements ILoanRepository {
       notes: Value(loan.notes),
       updatedAt: Value(loan.updatedAt),
     ));
+    await _logSync(loan, 'insert');
   }
 
   @override
@@ -75,18 +86,47 @@ class LoanRepositoryImpl implements ILoanRepository {
       notes: Value(loan.notes),
       updatedAt: Value(loan.updatedAt),
     ));
+    await _logSync(loan, 'update');
   }
 
   @override
   Future<void> updateDueDate(String loanId, int? dueAt) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await _loansDao.updateDueDate(loanId, dueAt, now);
+    final updated = await _loansDao.getById(loanId);
+    if (updated != null) await _logSync(_fromRow(updated), 'update');
   }
 
   @override
   Future<void> returnItem(String loanId) async {
     final now = DateTime.now().millisecondsSinceEpoch;
     await _loansDao.returnItem(loanId, now, now);
+    final updated = await _loansDao.getById(loanId);
+    if (updated != null) await _logSync(_fromRow(updated), 'update');
+  }
+
+  /// Enqueue a `sync_log` row carrying a full snake_case snapshot of
+  /// [loan]. Push uses the payload keys to derive the upsert column
+  /// list, so the snapshot must include every sync-relevant field.
+  Future<void> _logSync(Loan loan, String operation) {
+    return _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('loan'),
+      entityId: Value(loan.id),
+      operation: Value(operation),
+      payloadJson: Value(jsonEncode({
+        'id': loan.id,
+        'media_item_id': loan.mediaItemId,
+        'borrower_id': loan.borrowerId,
+        'lent_at': loan.lentAt,
+        'returned_at': loan.returnedAt,
+        'due_at': loan.dueAt,
+        'notes': loan.notes,
+        'updated_at': loan.updatedAt,
+        'deleted': loan.deleted ? 1 : 0,
+      })),
+      createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
   }
 
   Loan _fromRow(LoansTableData row) => Loan(

--- a/lib/data/repositories/location_repository_impl.dart
+++ b/lib/data/repositories/location_repository_impl.dart
@@ -43,8 +43,9 @@ class LocationRepositoryImpl implements ILocationRepository {
   }
 
   @override
-  Future<void> create(Location location) {
-    return _dao.insertLocation(_toCompanion(location));
+  Future<void> create(Location location) async {
+    await _dao.insertLocation(_toCompanion(location));
+    await _logSync(location, 'insert');
   }
 
   @override
@@ -58,6 +59,7 @@ class LocationRepositoryImpl implements ILocationRepository {
       }
     }
     await _dao.updateLocation(_toCompanion(location));
+    await _logSync(location, 'update');
   }
 
   @override
@@ -81,6 +83,27 @@ class LocationRepositoryImpl implements ILocationRepository {
   @override
   Future<bool> wouldCreateCycle(String movingId, String? newParentId) {
     return _dao.wouldCreateCycle(movingId, newParentId);
+  }
+
+  /// Enqueue a `sync_log` row carrying a full snake_case snapshot of
+  /// [location]. Push uses the payload keys to derive the upsert column
+  /// list, so the snapshot must include every sync-relevant field.
+  Future<void> _logSync(Location location, String operation) {
+    return _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('location'),
+      entityId: Value(location.id),
+      operation: Value(operation),
+      payloadJson: Value(jsonEncode({
+        'id': location.id,
+        'parent_id': location.parentId,
+        'name': location.name,
+        'sort_order': location.sortOrder,
+        'updated_at': location.updatedAt,
+        'deleted': location.deleted ? 1 : 0,
+      })),
+      createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
   }
 
   Location _fromRow(LocationsTableData row) => Location(

--- a/lib/data/repositories/series_repository_impl.dart
+++ b/lib/data/repositories/series_repository_impl.dart
@@ -55,15 +55,33 @@ class SeriesRepositoryImpl implements ISeriesRepository {
     final existing = await _dao.findByExternalId(externalId);
     final now = DateTime.now().millisecondsSinceEpoch;
     final id = existing?.id ?? _uuid.v7();
+    final resolvedTotalCount = totalCount ?? existing?.totalCount;
     await _dao.upsert(SeriesTableCompanion(
       id: Value(id),
       externalId: Value(externalId),
       name: Value(name),
       mediaType: Value(mediaType.name),
       source: Value(source),
-      totalCount: Value(totalCount ?? existing?.totalCount),
+      totalCount: Value(resolvedTotalCount),
       updatedAt: Value(now),
       deleted: const Value(0),
+    ));
+    await _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('series'),
+      entityId: Value(id),
+      operation: Value(existing == null ? 'insert' : 'update'),
+      payloadJson: Value(jsonEncode({
+        'id': id,
+        'external_id': externalId,
+        'name': name,
+        'media_type': mediaType.name,
+        'source': source,
+        'total_count': resolvedTotalCount,
+        'updated_at': now,
+        'deleted': 0,
+      })),
+      createdAt: Value(now),
     ));
     return id;
   }

--- a/lib/data/repositories/shelf_repository_impl.dart
+++ b/lib/data/repositories/shelf_repository_impl.dart
@@ -44,8 +44,10 @@ class ShelfRepositoryImpl implements IShelfRepository {
     final existing = await _shelvesDao.getById(shelf.id);
     if (existing != null) {
       await _shelvesDao.updateShelf(companion);
+      await _logSync(shelf, 'update');
     } else {
       await _shelvesDao.insertShelf(companion);
+      await _logSync(shelf, 'insert');
     }
   }
 
@@ -82,6 +84,27 @@ class ShelfRepositoryImpl implements IShelfRepository {
   @override
   Future<void> reorderItems(String shelfId, List<String> orderedMediaItemIds) =>
       _shelvesDao.reorderItems(shelfId, orderedMediaItemIds);
+
+  /// Enqueue a `sync_log` row carrying a full snake_case snapshot of
+  /// [shelf]. Push uses the payload keys to derive the upsert column
+  /// list, so the snapshot must include every sync-relevant field.
+  Future<void> _logSync(Shelf shelf, String operation) {
+    return _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('shelf'),
+      entityId: Value(shelf.id),
+      operation: Value(operation),
+      payloadJson: Value(jsonEncode({
+        'id': shelf.id,
+        'name': shelf.name,
+        'description': shelf.description,
+        'sort_order': shelf.sortOrder,
+        'updated_at': shelf.updatedAt,
+        'deleted': 0,
+      })),
+      createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
 
   Shelf _fromRow(ShelvesTableData row) => Shelf(
         id: row.id,

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -223,6 +223,22 @@ class SyncRepositoryImpl implements ISyncRepository {
   Future<void> resetLocalDatabase() async {
     await _emitStatus(isSyncing: true);
     try {
+      // Honour the dialog promise: "replace all local data with data
+      // from your PostgreSQL server". Wipe local media_items, drop
+      // every sync_log entry (any pending pushes for now-deleted rows
+      // would fail anyway), and clear the last-synced timestamp so the
+      // following pullChanges performs a full pull rather than an
+      // incremental one. The prior implementation was an incremental
+      // pull only — it kept stale local rows the remote no longer
+      // had, kept pending pushes that the user had just chosen to
+      // discard, and didn't refetch anything modified before
+      // lastSyncedAt.
+      await _mediaItemsDao.deleteAll();
+      await _syncLogDao.deleteAll();
+      _pendingConflicts.clear();
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_lastSyncedAtKey);
+
       await pullChanges();
       await _emitStatus(isSyncing: false);
     } on Exception catch (e) {
@@ -232,7 +248,18 @@ class SyncRepositoryImpl implements ISyncRepository {
   }
 
   @override
-  Stream<SyncStatus> watchSyncStatus() => _statusController.stream;
+  Stream<SyncStatus> watchSyncStatus() async* {
+    // Emit a current snapshot first so subscribers (most commonly the
+    // syncStatusProvider StreamProvider) leave the loading state
+    // immediately. The underlying controller is a non-replaying broadcast
+    // stream — without this seed, the UI sat on "Checking sync
+    // status..." until the first push/pull event, which on a fresh
+    // launch with no pending work would never arrive.
+    yield await _computeStatus(
+      conflictCount: _pendingConflicts.length,
+    );
+    yield* _statusController.stream;
+  }
 
   @override
   Stream<SyncProgress> watchSyncProgress() => _progressController.stream;
@@ -340,6 +367,12 @@ class SyncRepositoryImpl implements ISyncRepository {
     await _syncLogDao.purgeOlderThan(olderThanEpochMs);
   }
 
+  @override
+  Future<void> clearSyncHistory() async {
+    await _syncLogDao.deleteAll();
+    await _emitStatus();
+  }
+
   /// Closes the status/progress broadcast controllers so a subsequent
   /// repository rebuild (e.g. via Riverpod invalidation) doesn't leak
   /// listeners on the old instance.
@@ -353,15 +386,27 @@ class SyncRepositoryImpl implements ISyncRepository {
     String? error,
     int conflictCount = 0,
   }) async {
+    _statusController.add(await _computeStatus(
+      isSyncing: isSyncing,
+      error: error,
+      conflictCount: conflictCount,
+    ));
+  }
+
+  Future<SyncStatus> _computeStatus({
+    bool isSyncing = false,
+    String? error,
+    int conflictCount = 0,
+  }) async {
     final pendingLogs = await _syncLogDao.getPending();
     final lastSyncedAt = await _getLastSyncedAt();
-    _statusController.add(SyncStatus(
+    return SyncStatus(
       pendingCount: pendingLogs.length,
       lastSyncedAt: lastSyncedAt,
       isSyncing: isSyncing,
       error: error,
       conflictCount: conflictCount,
-    ));
+    );
   }
 
   Future<int?> _getLastSyncedAt() async {

--- a/lib/data/repositories/tag_repository_impl.dart
+++ b/lib/data/repositories/tag_repository_impl.dart
@@ -34,12 +34,14 @@ class TagRepositoryImpl implements ITagRepository {
 
   @override
   Future<void> save(Tag tag) async {
+    final existing = await _tagsDao.getById(tag.id);
     await _tagsDao.insertTag(TagsTableCompanion(
       id: Value(tag.id),
       name: Value(tag.name),
       colour: Value(tag.colour),
       updatedAt: Value(tag.updatedAt),
     ));
+    await _logSync(tag, existing == null ? 'insert' : 'update');
   }
 
   @override
@@ -71,6 +73,25 @@ class TagRepositoryImpl implements ITagRepository {
   @override
   Future<List<String>> getTagIdsForMediaItem(String mediaItemId) =>
       _tagsDao.getTagIdsForMediaItem(mediaItemId);
+
+  /// Enqueue a `sync_log` row carrying a full snake_case snapshot of
+  /// [tag]. Push uses the payload keys to derive the upsert column list.
+  Future<void> _logSync(Tag tag, String operation) {
+    return _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('tag'),
+      entityId: Value(tag.id),
+      operation: Value(operation),
+      payloadJson: Value(jsonEncode({
+        'id': tag.id,
+        'name': tag.name,
+        'colour': tag.colour,
+        'updated_at': tag.updatedAt,
+        'deleted': 0,
+      })),
+      createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
 
   Tag _fromRow(TagsTableData row) => Tag(
         id: row.id,

--- a/lib/domain/repositories/i_sync_repository.dart
+++ b/lib/domain/repositories/i_sync_repository.dart
@@ -20,7 +20,18 @@ abstract interface class ISyncRepository {
   Future<List<SyncLogEntry>> getSyncHistory({int limit = 50, int offset = 0});
 
   /// Purge sync log entries older than the given epoch timestamp.
+  ///
+  /// Only removes entries that have already been synced. Failed/pending
+  /// rows are preserved so the user can still inspect or retry them.
   Future<void> purgeSyncHistory(int olderThanEpochMs);
+
+  /// Remove every sync log entry, including pending and failed ones.
+  ///
+  /// Wires the "Clear sync history" affordance honestly — the prior
+  /// implementation routed through [purgeSyncHistory] which only deletes
+  /// successfully-synced rows, so pending/failed entries silently
+  /// survived a "Clear all" tap.
+  Future<void> clearSyncHistory();
 }
 
 class SyncStatus {

--- a/lib/presentation/providers/repository_providers.dart
+++ b/lib/presentation/providers/repository_providers.dart
@@ -149,6 +149,7 @@ final borrowerRepositoryProvider = Provider<IBorrowerRepository>((ref) {
 final loanRepositoryProvider = Provider<ILoanRepository>((ref) {
   return LoanRepositoryImpl(
     loansDao: ref.watch(loansDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
   );
 });
 

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mymediascanner/core/services/audio/replay_gain_service.dart';
 import 'package:mymediascanner/core/utils/platform_utils.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 import 'package:mymediascanner/presentation/providers/replay_gain_provider.dart';
 import 'package:mymediascanner/presentation/screens/settings/widgets/api_key_form.dart';
@@ -237,9 +238,27 @@ class SettingsScreen extends ConsumerWidget {
             style: FilledButton.styleFrom(
               backgroundColor: Theme.of(ctx).colorScheme.error,
             ),
-            onPressed: () {
+            onPressed: () async {
               Navigator.pop(ctx);
-              // Trigger full re-sync SYNC-09
+              final messenger = ScaffoldMessenger.of(context);
+              final repo = ref.read(syncRepositoryProvider);
+              if (repo == null) {
+                messenger.showSnackBar(const SnackBar(
+                  content:
+                      Text('Configure PostgreSQL first to reset.'),
+                ));
+                return;
+              }
+              try {
+                await repo.resetLocalDatabase();
+                messenger.showSnackBar(const SnackBar(
+                  content: Text('Local data replaced with remote.'),
+                ));
+              } on Exception catch (e) {
+                messenger.showSnackBar(SnackBar(
+                  content: Text('Reset failed: $e'),
+                ));
+              }
             },
             child: const Text('Reset'),
           ),

--- a/lib/presentation/screens/settings/widgets/sync_log_viewer.dart
+++ b/lib/presentation/screens/settings/widgets/sync_log_viewer.dart
@@ -148,9 +148,11 @@ class _SyncLogViewerState extends ConsumerState<SyncLogViewer> {
               Navigator.pop(ctx);
               final repo = ref.read(syncRepositoryProvider);
               if (repo != null) {
-                await repo.purgeSyncHistory(
-                  DateTime.now().millisecondsSinceEpoch,
-                );
+                // Use clearSyncHistory (true clear-all) rather than the
+                // older purgeSyncHistory(now), which only deleted synced
+                // rows — failed/pending entries were silently preserved
+                // despite the dialog promising "remove all".
+                await repo.clearSyncHistory();
                 ref.invalidate(syncHistoryProvider);
               }
             },

--- a/test/presentation/screens/settings/widgets/sync_status_tile_test.dart
+++ b/test/presentation/screens/settings/widgets/sync_status_tile_test.dart
@@ -217,4 +217,7 @@ class _FakeSyncRepository implements ISyncRepository {
 
   @override
   Future<void> purgeSyncHistory(int olderThanEpochMs) async {}
+
+  @override
+  Future<void> clearSyncHistory() async {}
 }

--- a/test/unit/data/repositories/save_update_sync_log_test.dart
+++ b/test/unit/data/repositories/save_update_sync_log_test.dart
@@ -1,0 +1,205 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/repositories/borrower_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/loan_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/location_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/series_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/shelf_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/tag_repository_impl.dart';
+import 'package:mymediascanner/domain/entities/borrower.dart';
+import 'package:mymediascanner/domain/entities/loan.dart';
+import 'package:mymediascanner/domain/entities/location.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/shelf.dart';
+import 'package:mymediascanner/domain/entities/tag.dart';
+
+/// Cluster-4 HIGH-2 regression: every save/create/update path on the six
+/// non-media-item repositories must enqueue a `sync_log` row so the
+/// mutation replicates on the next push. Cluster-3 added delete-logging
+/// only; insert/update were silent until this branch.
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<List<SyncLogTableData>> logsFor(String entityType, String id) async {
+    final rows = await db.syncLogDao.getPending();
+    return rows
+        .where((r) => r.entityType == entityType && r.entityId == id)
+        .toList();
+  }
+
+  test('borrower.save (insert) enqueues an insert sync_log row', () async {
+    final repo = BorrowerRepositoryImpl(
+      borrowersDao: db.borrowersDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.save(const Borrower(
+      id: 'b1',
+      name: 'Alice',
+      email: null,
+      phone: null,
+      notes: null,
+      updatedAt: 1,
+    ));
+    final logs = await logsFor('borrower', 'b1');
+    expect(logs, hasLength(1));
+    expect(logs.single.operation, 'insert');
+    final payload =
+        jsonDecode(logs.single.payloadJson) as Map<String, dynamic>;
+    expect(payload['name'], 'Alice');
+  });
+
+  test('borrower.update enqueues an update sync_log row', () async {
+    final repo = BorrowerRepositoryImpl(
+      borrowersDao: db.borrowersDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.save(const Borrower(
+      id: 'b1',
+      name: 'Alice',
+      email: null,
+      phone: null,
+      notes: null,
+      updatedAt: 1,
+    ));
+    await repo.update(const Borrower(
+      id: 'b1',
+      name: 'Alice Smith',
+      email: 'a@example.com',
+      phone: null,
+      notes: null,
+      updatedAt: 1,
+    ));
+    final logs = await logsFor('borrower', 'b1');
+    expect(logs, hasLength(2));
+    expect(logs.map((l) => l.operation).toList(), ['insert', 'update']);
+  });
+
+  test('shelf.save (insert) enqueues an insert sync_log row', () async {
+    final repo = ShelfRepositoryImpl(
+      shelvesDao: db.shelvesDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.save(const Shelf(
+      id: 's1',
+      name: 'Wishlist',
+      description: null,
+      sortOrder: 0,
+      updatedAt: 1,
+    ));
+    final logs = await logsFor('shelf', 's1');
+    expect(logs.single.operation, 'insert');
+  });
+
+  test('shelf.save (update) enqueues an update sync_log row', () async {
+    final repo = ShelfRepositoryImpl(
+      shelvesDao: db.shelvesDao,
+      syncLogDao: db.syncLogDao,
+    );
+    const initial = Shelf(
+      id: 's1',
+      name: 'Wishlist',
+      description: null,
+      sortOrder: 0,
+      updatedAt: 1,
+    );
+    await repo.save(initial);
+    await repo.save(initial.copyWith(name: 'Renamed'));
+    final logs = await logsFor('shelf', 's1');
+    expect(logs.map((l) => l.operation).toList(), ['insert', 'update']);
+  });
+
+  test('tag.save enqueues a sync_log row', () async {
+    final repo = TagRepositoryImpl(
+      tagsDao: db.tagsDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.save(const Tag(
+      id: 't1',
+      name: 'fav',
+      colour: '#ff0000',
+      updatedAt: 1,
+    ));
+    final logs = await logsFor('tag', 't1');
+    expect(logs.single.operation, 'insert');
+  });
+
+  test('location.create / update each enqueue a sync_log row', () async {
+    final repo = LocationRepositoryImpl(
+      dao: db.locationsDao,
+      syncLogDao: db.syncLogDao,
+    );
+    await repo.create(const Location(
+      id: 'l1',
+      parentId: null,
+      name: 'Lounge',
+      sortOrder: 0,
+      updatedAt: 1,
+    ));
+    await repo.update(const Location(
+      id: 'l1',
+      parentId: null,
+      name: 'Living Room',
+      sortOrder: 0,
+      updatedAt: 2,
+    ));
+    final logs = await logsFor('location', 'l1');
+    expect(logs.map((l) => l.operation).toList(), ['insert', 'update']);
+  });
+
+  test('series.upsert enqueues a sync_log row', () async {
+    final repo = SeriesRepositoryImpl(
+      dao: db.seriesDao,
+      syncLogDao: db.syncLogDao,
+    );
+    final id = await repo.upsert(
+      externalId: 'ext-1',
+      name: 'Foundation',
+      mediaType: MediaType.book,
+      source: 'manual',
+    );
+    final logs = await logsFor('series', id);
+    expect(logs.single.operation, 'insert');
+
+    // Second upsert with same externalId should record an update.
+    await repo.upsert(
+      externalId: 'ext-1',
+      name: 'Foundation (renamed)',
+      mediaType: MediaType.book,
+      source: 'manual',
+    );
+    final logs2 = await logsFor('series', id);
+    expect(logs2.map((l) => l.operation).toList(), ['insert', 'update']);
+  });
+
+  test('loan.createLoan / updateLoan / returnItem enqueue sync_log rows',
+      () async {
+    final repo = LoanRepositoryImpl(
+      loansDao: db.loansDao,
+      syncLogDao: db.syncLogDao,
+    );
+    const loan = Loan(
+      id: 'ln1',
+      mediaItemId: 'm1',
+      borrowerId: 'b1',
+      lentAt: 1,
+      updatedAt: 1,
+    );
+    await repo.createLoan(loan);
+    await repo.updateLoan(loan.copyWith(notes: 'update', updatedAt: 2));
+    await repo.returnItem('ln1');
+    final logs = await logsFor('loan', 'ln1');
+    expect(logs.map((l) => l.operation).toList(),
+        ['insert', 'update', 'update']);
+  });
+}

--- a/test/unit/data/repositories/soft_delete_sync_log_test.dart
+++ b/test/unit/data/repositories/soft_delete_sync_log_test.dart
@@ -35,12 +35,18 @@ void main() {
     required String entityId,
   }) async {
     final pending = await db.syncLogDao.getPending();
+    // Match the delete log specifically — cluster-4 added save/update
+    // logging, so a save-then-softDelete sequence yields multiple entries
+    // for the same (entityType, entityId) and the first one is the
+    // pre-delete insert.
     final match = pending.firstWhere(
-      (r) => r.entityType == entityType && r.entityId == entityId,
+      (r) =>
+          r.entityType == entityType &&
+          r.entityId == entityId &&
+          r.operation == 'delete',
       orElse: () => throw TestFailure(
-          'No pending sync_log entry for $entityType/$entityId'),
+          'No pending delete sync_log entry for $entityType/$entityId'),
     );
-    expect(match.operation, 'delete');
     final payload = jsonDecode(match.payloadJson) as Map<String, dynamic>;
     expect(payload['id'], entityId);
     expect(payload['deleted'], 1);

--- a/test/widget/presentation/sync_badge_test.dart
+++ b/test/widget/presentation/sync_badge_test.dart
@@ -187,4 +187,6 @@ class _FakeRepo implements ISyncRepository {
       [];
   @override
   Future<void> purgeSyncHistory(int olderThanEpochMs) async {}
+  @override
+  Future<void> clearSyncHistory() async {}
 }


### PR DESCRIPTION
## Summary

Four items from the post-cluster-3 review. Three of the four are real wiring/correctness misses surfaced in earlier review notes; the fourth is the visible follow-up to cluster-3's soft-delete-only push coverage. Pull-broadening to non-media-item entities is deferred to cluster-5 — it needs per-entity DTO mappers and conflict-UI changes that warrant their own design pass.

### HIGH-1 — Reset button wired end-to-end

The "Reset & Re-sync" dialog button at `settings_screen.dart:240` only ran `Navigator.pop(ctx)` and a `// Trigger full re-sync SYNC-09` comment. Users got nothing. Even the repo's `resetLocalDatabase()` just called `pullChanges()`, which uses `lastSyncedAt` for incremental pulls — nowhere near the dialog's "replace all local data with remote" promise.

- `settings_screen._confirmReset` now `await`s `resetLocalDatabase()` and surfaces success/error via `SnackBar`.
- `resetLocalDatabase()` hard-deletes every `media_items` row, drops every `sync_log` entry (any pending pushes for now-deleted rows would fail anyway), clears `_pendingConflicts`, and removes the `sync_last_synced_at` SharedPreference. The follow-up `pullChanges()` now sees `lastSyncedAt=null` and performs a full pull.
- `MediaItemsDao` gains `deleteAll()` — soft-delete would defeat the reset because soft-deleted rows still take part in sync.

### HIGH-2 — Push coverage on save/update for 6 repos

The sync infrastructure handles any `entity_type` generically (`PostgresSyncClient` allow-lists `shelves`, `tags`, `borrowers`, `loans`, `locations`, `series`; push derives upsert columns from payload keys). But cluster-3 only added `sync_log` on soft-delete. Create/update mutations on those six repos were silent — renaming a tag, editing a borrower, returning a loan never produced a push payload.

- Each of the six repos now emits an `insert`/`update` `sync_log` row on save/create/update with a snake_case payload mirroring the Postgres column shape.
- `LoanRepositoryImpl` was the only one without `SyncLogDao` injection — added, and `loanRepositoryProvider` wired through.
- `LoansDao` gains a `getById` helper used by `updateDueDate` / `returnItem` so they log the post-mutation state.
- New regression suite (`save_update_sync_log_test.dart`, 8 cases) pins the contract per repo.
- Cluster-3's `soft_delete_sync_log_test.dart` matcher now selects on `operation == 'delete'` since save+softDelete sequences yield two log entries for the same `(entityType, entityId)` pair.

### MED-3 — syncStatusProvider initial emission

`syncStatusProvider` stayed `AsyncLoading` until the first push/pull event because `watchSyncStatus()` returned a non-replaying broadcast stream with no initial emission. The Sync status tile sat on "Checking sync status..." indefinitely on cold launch when no work was pending.

- `watchSyncStatus()` is now an async generator that yields a freshly-computed `SyncStatus` snapshot first (via the new `_computeStatus` helper extracted from `_emitStatus`) and then forwards the controller stream.

### LOW-4 — Honest clear-all sync history

"Clear sync history" promised "remove all sync log entries" but routed through `purgeSyncHistory(now)` → `SyncLogDao.purgeOlderThan` — that filter explicitly preserves unsynced (failed/pending) rows so the user can retry them. Failed entries silently survived a "Clear all" tap.

- New `clearSyncHistory()` on `ISyncRepository` / `SyncRepositoryImpl` that delegates to `SyncLogDao.deleteAll()`.
- Dialog wired through to the new path.
- `purgeSyncHistory(epoch)` unchanged — still used by `pullChanges` for the 30-day auto-purge.
- Test stubs in `sync_status_tile_test.dart` and `sync_badge_test.dart` got the new `clearSyncHistory` override.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1303 tests pass (was 1295; +8 new, plus 5 cluster-3 tests adjusted)
- [ ] Manual: configure Postgres, soft-delete some rows, edit some others, then tap **Reset & Re-sync**. Confirm the SnackBar fires and the local data matches the remote (no stale soft-deletes, no pending pushes).
- [ ] Manual: rename a tag, edit a borrower, edit a loan due date, return a loan. Open Sync history and confirm one `update`/`insert` `sync_log` row per mutation.
- [ ] Manual: cold-launch with sync configured but no pending work. The Sync tile leaves "Checking..." within ~1s instead of staying stuck.
- [ ] Manual: trigger a push that produces a failed entry (offline / wrong creds), then tap **Clear sync history**. Confirm the failed entry is gone (was preserved before).

## Notes

- Pull-side broadening (extending `pullChanges` to iterate over the allow-listed tables and applying per-entity merges) is deferred to **cluster-5** because it requires per-entity DTO mappers in `SyncRepositoryImpl` and conflict-resolution UI changes for non-media types. Push-only coverage is still useful — it lets a multi-device user push from one client and resolve conflicts manually until cluster-5 lands.