### PR TITLE
Fix code-review cluster 5: leaks, debounce, lifecycle (option A)

### DIFF
--- a/lib/data/local/dao/loans_dao.dart
+++ b/lib/data/local/dao/loans_dao.dart
@@ -88,7 +88,20 @@ class LoansDao extends DatabaseAccessor<AppDatabase> with _$LoansDaoMixin {
           latest = rows;
           emit();
         },
-        onError: controller.addError,
+        // Forward the error AND terminate the stream. Forwarding alone
+        // (the prior behaviour) left the controller open with the
+        // periodic timer still firing emit() on stale data — subscribers
+        // that didn't react to the error then sat indefinitely on a
+        // half-broken stream. Closing here gives them a clean
+        // "stream done" signal so they can rebuild.
+        onError: (Object error, StackTrace stack) async {
+          if (!controller.isClosed) {
+            controller.addError(error, stack);
+            timer?.cancel();
+            timer = null;
+            await controller.close();
+          }
+        },
       );
       timer = Timer.periodic(const Duration(seconds: 60), (_) => emit());
     };

--- a/lib/presentation/providers/split_ratio_provider.dart
+++ b/lib/presentation/providers/split_ratio_provider.dart
@@ -1,13 +1,28 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 const _prefKey = 'master_detail_split_ratio';
 const _defaultRatio = 0.45;
 
+/// Drag-debounce window. The master-detail divider can fire `setRatio`
+/// at frame rate during a drag; without debouncing each pixel queues a
+/// SharedPreferences write and saturates the platform-channel queue.
+/// State updates remain immediate so the UI is responsive — only the
+/// persistence is throttled.
+const _persistDebounce = Duration(milliseconds: 250);
+
 class SplitRatioNotifier extends Notifier<double> {
+  Timer? _persistTimer;
+
   @override
   double build() {
     _loadFromPrefs();
+    ref.onDispose(() {
+      _persistTimer?.cancel();
+      _persistTimer = null;
+    });
     return _defaultRatio;
   }
 
@@ -21,7 +36,15 @@ class SplitRatioNotifier extends Notifier<double> {
 
   void setRatio(double ratio) {
     state = ratio;
-    _persistToPrefs();
+    _schedulePersist();
+  }
+
+  /// Schedule a single prefs write [_persistDebounce] after the most
+  /// recent `setRatio` call. Repeated drag updates collapse to one
+  /// write at rest, instead of one per drag-update.
+  void _schedulePersist() {
+    _persistTimer?.cancel();
+    _persistTimer = Timer(_persistDebounce, _persistToPrefs);
   }
 
   Future<void> _persistToPrefs() async {

--- a/lib/presentation/screens/scanner/desktop_scan_screen.dart
+++ b/lib/presentation/screens/scanner/desktop_scan_screen.dart
@@ -35,6 +35,14 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
   bool _hasScanned = false;
   String? _cameraError;
 
+  /// Last keyboard-wedge submission timestamp + value. USB barcode
+  /// scanners are HID devices that can fire two Enter events in quick
+  /// succession; without this guard the same barcode is dispatched
+  /// twice before scannerProvider transitions to lookingUp.
+  DateTime? _lastKeyboardSubmitAt;
+  String? _lastKeyboardSubmitValue;
+  static const _keyboardSubmitDebounce = Duration(milliseconds: 300);
+
   @override
   void initState() {
     super.initState();
@@ -47,7 +55,17 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
     _focusNode.dispose();
     _keyboardFocusNode.dispose();
     _barcodeSubscription?.cancel();
-    _cameraService?.dispose();
+    // CameraService.dispose() is async (V4L2 / WMF / AVFoundation handle
+    // teardown) but State.dispose() must be sync. unawaited(...) marks
+    // the fire-and-forget intent; the catchError ensures a teardown
+    // failure on Linux/Windows surfaces in debug logs instead of going
+    // through the unhandled-async-error path.
+    final pendingCamera = _cameraService?.dispose();
+    if (pendingCamera != null) {
+      unawaited(pendingCamera.catchError((Object error, StackTrace stack) {
+        debugPrint('Camera dispose failed: $error');
+      }));
+    }
     super.dispose();
   }
 
@@ -150,9 +168,24 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
   }
 
   void _onSubmitted(String barcode) {
-    if (barcode.trim().isEmpty) return;
+    final trimmed = barcode.trim();
+    if (trimmed.isEmpty) return;
+    // Debounce keyboard-wedge bursts: a fast HID scanner can deliver two
+    // Enter events for the same scan before scannerProvider's state has
+    // transitioned to lookingUp, so the dedupe in the provider's `if
+    // (state.isLookingUp)` branch doesn't catch it. Drop the second
+    // submission of the same value within a 300 ms window.
+    final now = DateTime.now();
+    if (_lastKeyboardSubmitValue == trimmed &&
+        _lastKeyboardSubmitAt != null &&
+        now.difference(_lastKeyboardSubmitAt!) < _keyboardSubmitDebounce) {
+      _controller.clear();
+      return;
+    }
+    _lastKeyboardSubmitAt = now;
+    _lastKeyboardSubmitValue = trimmed;
     _controller.clear();
-    ref.read(scannerProvider.notifier).onBarcodeScanned(barcode.trim());
+    ref.read(scannerProvider.notifier).onBarcodeScanned(trimmed);
   }
 
   @override

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -251,10 +251,17 @@ class SettingsScreen extends ConsumerWidget {
               }
               try {
                 await repo.resetLocalDatabase();
+                // The reset can take seconds (full pull from Postgres).
+                // If the user navigated away from Settings during the
+                // await, the SnackBar must not fire on a torn-down
+                // context — `messenger` is captured pre-await but we
+                // still check `context.mounted` as the canonical guard.
+                if (!context.mounted) return;
                 messenger.showSnackBar(const SnackBar(
                   content: Text('Local data replaced with remote.'),
                 ));
               } on Exception catch (e) {
+                if (!context.mounted) return;
                 messenger.showSnackBar(SnackBar(
                   content: Text('Reset failed: $e'),
                 ));


### PR DESCRIPTION
## Summary

Five targeted fixes from the cluster-4 follow-up review (option A — small, no architecture changes). The wider items (Vision OCR cancellation, static-export path-traversal validator, batch-feedback fixes) and the original pull-broadening to non-media-item entities are deferred to cluster-6.

### HIGH-1 — `_confirmReset` SnackBar mounted guard

The reset button I wired up in cluster-4 ran `await repo.resetLocalDatabase()` (which can take seconds while the full pull from Postgres completes), then called `messenger.showSnackBar(...)` without re-checking the context. A user navigating away from Settings mid-reset would have the SnackBar fire on a dead context. `messenger` is still captured pre-await (the canonical pattern); the new `if (!context.mounted) return` is the extra defensive guard for both the success and the catch path.

### HIGH-2 — `watchOverdueLoans` closes on DB error

`LoansDao.watchOverdueLoans` forwarded internal stream errors via `onError: controller.addError` but never closed the controller. Subscribers that didn't react to the error sat indefinitely on a half-broken stream — the periodic 60s timer kept firing `emit()` against a stale `latest`. The handler now cancels the timer and closes the controller after forwarding the error so subscribers get a clean "stream done" signal and can rebuild.

### HIGH-3 — Keyboard-wedge scanner debounced

USB barcode scanners are HID devices and can deliver two Enter events per scan before `scannerProvider` transitions to `lookingUp`, so the provider's in-flight guard misses the second submission. Added a same-value 300 ms debounce to the keyboard `_onSubmitted` path. The webcam path (`_hasScanned`) is unchanged.

### HIGH-5 — Camera async dispose marked

`CameraService.dispose()` is `Future<void>` (V4L2 / WMF / AVFoundation handle teardown) but `State.dispose()` must be sync. The prior bare call lost any teardown error to the unhandled-async-error path. Now wrapped in `unawaited(...)` with a `catchError` that `debugPrint`s failures — explicit fire-and-forget intent and at least the error reaches debug logs.

### HIGH-7 — Split-ratio prefs writes debounced

`SplitRatioNotifier.setRatio` previously called `_persistToPrefs` per drag-update event, so dragging the master-detail divider queued one SharedPreferences write per pixel. State updates remain immediate (the UI is still responsive), but the prefs write is now collapsed to one call ~250 ms after the most recent drag, with the timer cancelled on disposal.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1303 tests pass
- [ ] Manual: configure Postgres, tap **Reset & Re-sync**, immediately back out of Settings before the pull finishes — confirm no SnackBar / context error in debug.
- [ ] Manual: trigger a DB error during overdue-loans watch (e.g. drop the loans table mid-session) — confirm the borrowers/dashboard rebuilds rather than freezing on a stale list.
- [ ] Manual: connect a USB barcode scanner with a known fast burst — scan once, confirm one (not two) lookups dispatched.
- [ ] Manual: pop the desktop scanner with the webcam still active on Linux/Windows, re-enter — camera initialises cleanly.
- [ ] Manual: drag the master-detail divider continuously for 3-5 seconds — confirm only one prefs write fires (e.g. via printf in `_persistToPrefs`).

## Notes

- Original cluster-5 pull-broadening (extending `pullChanges` over the allow-listed tables with per-entity DTO mappers + non-media conflict UI) is unchanged in scope and still queued for **cluster-6**.
- Wider option B items (Vision OCR cancellation, static-export path-traversal validator, `batch_metadata_edit` silent skip, `batch_tag_editor_dialog` per-track error handling) are still real and queued behind cluster-6 or in a parallel cluster-6b.