### PR TITLE
Fix code-review cluster 6: option B leftovers + medium-priority items

### DIFF
--- a/lib/core/utils/vision_ocr_channel.dart
+++ b/lib/core/utils/vision_ocr_channel.dart
@@ -1,11 +1,26 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 /// Method channel wrapper for macOS Vision framework text recognition.
 ///
 /// Only available on macOS. On other platforms, [recogniseText] returns null.
+///
+/// **Cancellation note:** Flutter's [MethodChannel] does not natively
+/// support per-call cancellation, so the platform invocation always
+/// runs to completion native-side. Both methods enforce a configurable
+/// timeout so a stalled or runaway recognition can't pin the Dart-side
+/// future indefinitely. Callers that may navigate away mid-OCR should
+/// still check their own `mounted`/disposed state before consuming the
+/// result.
 abstract final class VisionOcrChannel {
   static const _channel = MethodChannel('com.mymediascanner/vision_ocr');
+
+  /// Default per-call timeout. Vision OCR on a typical cover image
+  /// finishes in <1 s; 15 s is generous slack for large scans on
+  /// older Macs and bounds the worst case.
+  static const defaultTimeout = Duration(seconds: 15);
 
   /// Returns `true` if the Vision OCR channel is available on this platform.
   static bool get isAvailable =>
@@ -14,14 +29,22 @@ abstract final class VisionOcrChannel {
   /// Returns structured recognition results as a list of maps, each with
   /// 'text', 'confidence', and 'area' keys. Falls back to wrapping the
   /// plain text result if the native side doesn't support structured output.
+  ///
+  /// On [TimeoutException] returns `null` and lets the caller decide whether
+  /// to retry or surface a "took too long" message — the prior behaviour
+  /// would await the platform channel indefinitely if Vision deadlocked.
   static Future<List<Map<String, dynamic>>?> recogniseTextStructured(
-      String imagePath) async {
+    String imagePath, {
+    Duration timeout = defaultTimeout,
+  }) async {
     if (!isAvailable) return null;
     try {
-      final result = await _channel.invokeMethod<List<dynamic>>(
-        'recogniseTextStructured',
-        {'imagePath': imagePath},
-      );
+      final result = await _channel
+          .invokeMethod<List<dynamic>>(
+            'recogniseTextStructured',
+            {'imagePath': imagePath},
+          )
+          .timeout(timeout);
       if (result != null) {
         // Defensively coerce — a malformed native implementation returning
         // non-Map entries must not throw an uncaught TypeError.
@@ -39,10 +62,14 @@ abstract final class VisionOcrChannel {
       // Method not implemented on native side; fall through
     } on TypeError catch (e) {
       debugPrint('Vision OCR structured: malformed native response: $e');
+    } on TimeoutException {
+      debugPrint(
+          'Vision OCR structured: timed out after ${timeout.inSeconds}s');
+      return null;
     }
 
     // Fallback: wrap plain text result
-    final plain = await recogniseText(imagePath);
+    final plain = await recogniseText(imagePath, timeout: timeout);
     if (plain == null || plain.isEmpty) return null;
     return [
       {'text': plain, 'confidence': 1.0, 'area': 1.0},
@@ -51,17 +78,27 @@ abstract final class VisionOcrChannel {
 
   /// Recognises text from an image file at [imagePath] using the macOS
   /// Vision framework. Returns the most prominent text block, or `null`
-  /// if no text is detected or the platform is unsupported.
-  static Future<String?> recogniseText(String imagePath) async {
+  /// if no text is detected, the platform is unsupported, or the
+  /// platform invocation exceeds [timeout].
+  static Future<String?> recogniseText(
+    String imagePath, {
+    Duration timeout = defaultTimeout,
+  }) async {
     if (!isAvailable) return null;
     try {
-      final result = await _channel.invokeMethod<String>(
-        'recogniseText',
-        {'imagePath': imagePath},
-      );
+      final result = await _channel
+          .invokeMethod<String>(
+            'recogniseText',
+            {'imagePath': imagePath},
+          )
+          .timeout(timeout);
       return result;
     } on PlatformException catch (e) {
       debugPrint('Vision OCR channel error: ${e.message}');
+      return null;
+    } on TimeoutException {
+      debugPrint(
+          'Vision OCR: timed out after ${timeout.inSeconds}s on $imagePath');
       return null;
     }
   }

--- a/lib/data/local/dao/rip_library_dao.dart
+++ b/lib/data/local/dao/rip_library_dao.dart
@@ -74,6 +74,49 @@ class RipLibraryDao extends DatabaseAccessor<AppDatabase>
     });
   }
 
+  /// Atomically insert a brand-new album row together with its tracks.
+  /// Wrapping both writes in a single transaction prevents the
+  /// previously-possible orphan: a process crash between the
+  /// `insertAlbum` and `insertTracks` calls left an album visible in
+  /// the UI that fell over the moment the user pressed Play.
+  Future<void> insertAlbumWithTracks(
+    RipAlbumsTableCompanion album,
+    List<RipTracksTableCompanion> tracks,
+  ) {
+    return transaction(() async {
+      await into(ripAlbumsTable).insert(album);
+      if (tracks.isNotEmpty) {
+        await batch((b) {
+          b.insertAll(ripTracksTable, tracks);
+        });
+      }
+    });
+  }
+
+  /// Atomically update an existing album row and replace all of its
+  /// tracks with [tracks]. Used by re-scan: the old track set is wiped
+  /// and the freshly-discovered set is committed in the same
+  /// transaction so a crash mid-rescan can't leave the album with a
+  /// half-updated track list.
+  Future<void> updateAlbumAndReplaceTracks(
+    RipAlbumsTableCompanion album,
+    List<RipTracksTableCompanion> tracks,
+  ) {
+    return transaction(() async {
+      await (update(ripAlbumsTable)
+            ..where((t) => t.id.equals(album.id.value)))
+          .write(album);
+      await (delete(ripTracksTable)
+            ..where((t) => t.ripAlbumId.equals(album.id.value)))
+          .go();
+      if (tracks.isNotEmpty) {
+        await batch((b) {
+          b.insertAll(ripTracksTable, tracks);
+        });
+      }
+    });
+  }
+
   /// Hard-delete all tracks for a rip album (used on re-scan).
   Future<void> deleteTracksForAlbum(String ripAlbumId) {
     return (delete(ripTracksTable)

--- a/lib/data/repositories/rip_library_repository_impl.dart
+++ b/lib/data/repositories/rip_library_repository_impl.dart
@@ -118,6 +118,64 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
   }
 
   @override
+  Future<void> insertAlbumWithTracks(
+      RipAlbum album, List<RipTrack> tracks) async {
+    await _dao.insertAlbumWithTracks(
+      _albumCompanion(album),
+      tracks.map(_trackCompanion).toList(),
+    );
+  }
+
+  @override
+  Future<void> updateAlbumAndReplaceTracks(
+      RipAlbum album, List<RipTrack> tracks) async {
+    await _dao.updateAlbumAndReplaceTracks(
+      _albumCompanion(album),
+      tracks.map(_trackCompanion).toList(),
+    );
+  }
+
+  RipAlbumsTableCompanion _albumCompanion(RipAlbum album) =>
+      RipAlbumsTableCompanion(
+        id: Value(album.id),
+        libraryPath: Value(album.libraryPath),
+        artist: Value(album.artist),
+        albumTitle: Value(album.albumTitle),
+        barcode: Value(album.barcode),
+        trackCount: Value(album.trackCount),
+        discCount: Value(album.discCount),
+        totalSizeBytes: Value(album.totalSizeBytes),
+        mediaItemId: Value(album.mediaItemId),
+        cueFilePath: Value(album.cueFilePath),
+        gnudbDiscId: Value(album.gnudbDiscId),
+        lastScannedAt: Value(album.lastScannedAt),
+        updatedAt: Value(album.updatedAt),
+      );
+
+  RipTracksTableCompanion _trackCompanion(RipTrack t) =>
+      RipTracksTableCompanion(
+        id: Value(t.id),
+        ripAlbumId: Value(t.ripAlbumId),
+        discNumber: Value(t.discNumber),
+        trackNumber: Value(t.trackNumber),
+        title: Value(t.title),
+        filePath: Value(t.filePath),
+        durationMs: Value(t.durationMs),
+        fileSizeBytes: Value(t.fileSizeBytes),
+        updatedAt: Value(t.updatedAt),
+        accurateripStatus: Value(t.accurateRipStatus),
+        accurateripConfidence: Value(t.accurateRipConfidence),
+        accurateripCrcV1: Value(t.accurateRipCrcV1),
+        accurateripCrcV2: Value(t.accurateRipCrcV2),
+        peakLevel: Value(t.peakLevel),
+        trackQuality: Value(t.trackQuality),
+        copyCrc: Value(t.copyCrc),
+        clickCount: Value(t.clickCount),
+        ripLogSource: Value(t.ripLogSource),
+        qualityCheckedAt: Value(t.qualityCheckedAt),
+      );
+
+  @override
   Stream<Set<String>> watchRippedMediaItemIds() {
     return _dao.watchRippedMediaItemIds();
   }

--- a/lib/data/services/static_export_writer.dart
+++ b/lib/data/services/static_export_writer.dart
@@ -51,8 +51,31 @@ class StaticExportWriter {
     var done = 0;
     onProgress?.call(done, total);
 
+    final canonicalRoot = p.canonicalize(targetDir.path);
+
     for (final e in bundle.entries) {
-      final file = File(p.join(targetDir.path, e.key));
+      // Defence-in-depth: validate that the bundle key resolves to a
+      // path that stays inside [targetDir]. The keys come from
+      // [StaticExportService.build] which is in-tree, but a future
+      // change there could regress the contract — and a path-traversal
+      // bug in the writer is a much sharper failure than one in the
+      // service. Reject absolute paths, parent-traversal, and any
+      // resolved path that isn't a descendant of the target root.
+      final key = e.key;
+      if (p.isAbsolute(key) ||
+          key.split(p.separator).any((s) => s == '..') ||
+          key.split('/').any((s) => s == '..')) {
+        throw StateError(
+            'StaticExportWriter: refusing unsafe bundle key "$key"');
+      }
+      final resolved = p.canonicalize(p.join(targetDir.path, key));
+      if (!p.isWithin(canonicalRoot, resolved) &&
+          resolved != canonicalRoot) {
+        throw StateError(
+            'StaticExportWriter: bundle key "$key" resolves outside '
+            'target directory');
+      }
+      final file = File(resolved);
       await file.parent.create(recursive: true);
       await file.writeAsBytes(e.value);
       done++;

--- a/lib/domain/repositories/i_rip_library_repository.dart
+++ b/lib/domain/repositories/i_rip_library_repository.dart
@@ -11,6 +11,18 @@ abstract interface class IRipLibraryRepository {
   Future<List<RipTrack>> getTracksForAlbum(String ripAlbumId);
   Future<void> insertTracks(List<RipTrack> tracks);
   Future<void> deleteTracksForAlbum(String ripAlbumId);
+
+  /// Atomically insert a brand-new album with its tracks. Used by
+  /// scan-rip-library so a crash between the album-insert and the
+  /// track-insert can't leave a track-less orphan visible in the UI.
+  Future<void> insertAlbumWithTracks(
+      RipAlbum album, List<RipTrack> tracks);
+
+  /// Atomically update an existing album and replace all of its tracks.
+  /// Used by re-scan; the album row and the track set are committed
+  /// together so a crash mid-rescan can't leave them out of sync.
+  Future<void> updateAlbumAndReplaceTracks(
+      RipAlbum album, List<RipTrack> tracks);
   Stream<Set<String>> watchRippedMediaItemIds();
   Future<void> linkToMediaItem(String ripAlbumId, String mediaItemId);
   Future<void> unlinkFromMediaItem(String ripAlbumId);

--- a/lib/domain/usecases/scan_rip_library_usecase.dart
+++ b/lib/domain/usecases/scan_rip_library_usecase.dart
@@ -114,7 +114,10 @@ class ScanRipLibraryUseCase {
 
       final existing = existingByPath[result.directoryPath];
       if (existing != null) {
-        // Update existing album
+        // Update existing album. The album row update + delete-existing
+        // tracks + insert-new tracks are committed in a single
+        // transaction so a crash mid-rescan can't leave the album row
+        // pointing at a half-written track list.
         final updated = RipAlbum(
           id: existing.id,
           libraryPath: result.directoryPath,
@@ -129,13 +132,14 @@ class ScanRipLibraryUseCase {
           updatedAt: now,
           cueFilePath: result.cueFilePath,
         );
-        await _repo.updateAlbum(updated);
-
-        // Replace tracks
-        await _repo.deleteTracksForAlbum(existing.id);
-        await _repo.insertTracks(_buildTracks(existing.id, result.tracks, now));
+        await _repo.updateAlbumAndReplaceTracks(
+          updated,
+          _buildTracks(existing.id, result.tracks, now),
+        );
       } else {
-        // Insert new album
+        // Insert new album. Album row + tracks are committed atomically
+        // — the prior split inserts could leave a track-less orphan
+        // album visible in the UI that fell over on first play.
         final albumId = _uuid.v7();
         final album = RipAlbum(
           id: albumId,
@@ -150,8 +154,10 @@ class ScanRipLibraryUseCase {
           updatedAt: now,
           cueFilePath: result.cueFilePath,
         );
-        await _repo.insertAlbum(album);
-        await _repo.insertTracks(_buildTracks(albumId, result.tracks, now));
+        await _repo.insertAlbumWithTracks(
+          album,
+          _buildTracks(albumId, result.tracks, now),
+        );
       }
     }
 

--- a/lib/presentation/providers/batch_metadata_edit_provider.dart
+++ b/lib/presentation/providers/batch_metadata_edit_provider.dart
@@ -121,23 +121,31 @@ class BatchMetadataEditNotifier extends Notifier<BatchMetadataEditState> {
 
         try {
           final track = trackLookup[trackId];
-          if (track != null) {
-              // Apply TITLE separately if present, others via setTags.
-              final titleValue = tags['TITLE'];
-              final otherTags = Map<String, String>.from(tags)
-                ..remove('TITLE');
+          if (track == null) {
+            // Track was deleted (or its album invalidated) between
+            // batch-prep and apply. Surface this as an explicit error
+            // so the caller's "applied to N tracks" count is honest;
+            // silently skipping made the UI claim success while the
+            // mutation never reached the file.
+            errors.add(
+                '$trackId: track no longer exists in the rip library');
+            continue;
+          }
+          // Apply TITLE separately if present, others via setTags.
+          final titleValue = tags['TITLE'];
+          final otherTags = Map<String, String>.from(tags)
+            ..remove('TITLE');
 
-              if (titleValue != null) {
-                await useCase.editTrackTitle(
-                    track: track, title: titleValue);
-              }
+          if (titleValue != null) {
+            await useCase.editTrackTitle(
+                track: track, title: titleValue);
+          }
 
-              if (otherTags.isNotEmpty &&
-                  track.filePath.toLowerCase().endsWith('.flac')) {
-                await ref
-                    .read(metaflacWriterProvider)
-                    .setTags(track.filePath, otherTags);
-              }
+          if (otherTags.isNotEmpty &&
+              track.filePath.toLowerCase().endsWith('.flac')) {
+            await ref
+                .read(metaflacWriterProvider)
+                .setTags(track.filePath, otherTags);
           }
         } catch (e) {
           errors.add('$trackId: $e');

--- a/lib/presentation/providers/connection_health_provider.dart
+++ b/lib/presentation/providers/connection_health_provider.dart
@@ -29,24 +29,30 @@ class ConnectionHealthNotifier extends Notifier<ConnectionHealth>
     final config = ref.watch(postgresConfigProvider).value;
     if (config == null) return ConnectionHealth.unconfigured;
 
-    // Start periodic pinging
-    _startTimer();
-
     if (!_observerRegistered) {
+      // First-time setup: register the lifecycle observer, start the
+      // periodic ping timer, and wire disposal. `build()` re-runs every
+      // time `postgresConfigProvider` re-emits — calling `_startTimer`
+      // every time would cancel-and-restart the 60 s window so a
+      // burst of config edits (or even one unrelated re-emission) would
+      // postpone the next ping indefinitely. Guarding with the same
+      // flag we use for observer registration keeps both idempotent.
       WidgetsBinding.instance.addObserver(this);
       _observerRegistered = true;
+      _startTimer();
+      ref.onDispose(() {
+        _timer?.cancel();
+        _timer = null;
+        if (_observerRegistered) {
+          WidgetsBinding.instance.removeObserver(this);
+          _observerRegistered = false;
+        }
+      });
     }
 
-    // Trigger initial ping
+    // Always re-ping on rebuild — config may have changed and the new
+    // postgresSyncClientProvider value reflects that immediately.
     _ping();
-
-    ref.onDispose(() {
-      _timer?.cancel();
-      if (_observerRegistered) {
-        WidgetsBinding.instance.removeObserver(this);
-        _observerRegistered = false;
-      }
-    });
 
     return ConnectionHealth.unconfigured;
   }

--- a/lib/presentation/screens/rips/widgets/batch_tag_editor_dialog.dart
+++ b/lib/presentation/screens/rips/widgets/batch_tag_editor_dialog.dart
@@ -81,25 +81,46 @@ class _BatchTagEditorDialogState extends ConsumerState<BatchTagEditorDialog> {
     // Collect all track IDs and build pending changes map.
     final pendingChanges = <String, Map<String, String>>{};
     final originalValues = <String, Map<String, String>>{};
+    final readFailures = <String>[];
 
     for (final album in _selectedAlbums) {
       final tracks = ref.read(ripTracksProvider(album.id)).value ?? [];
       for (final track in tracks) {
-        pendingChanges[track.id] = Map<String, String>.from(tagChanges);
-        // Read current tag values for undo
-        final currentTags =
-            await ref.read(trackRawTagsProvider(track.filePath).future);
-        originalValues[track.id] = {
-          for (final key in tagChanges.keys)
-            if (currentTags.containsKey(key)) key: currentTags[key]!,
-        };
+        try {
+          // Read current tag values for undo. A bad FLAC, missing
+          // file, or vendor-tag parse error here used to bubble out and
+          // abort the entire batch with no per-track feedback. Now we
+          // collect the failure and continue with the rest.
+          final currentTags = await ref
+              .read(trackRawTagsProvider(track.filePath).future);
+          pendingChanges[track.id] = Map<String, String>.from(tagChanges);
+          originalValues[track.id] = {
+            for (final key in tagChanges.keys)
+              if (currentTags.containsKey(key)) key: currentTags[key]!,
+          };
+        } on Object catch (e) {
+          readFailures.add('${track.filePath}: $e');
+        }
       }
+    }
+
+    if (!mounted) return;
+    if (readFailures.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(
+          readFailures.length == 1
+              ? 'Could not read tags from 1 track — preview will skip it.'
+              : 'Could not read tags from ${readFailures.length} tracks — '
+                  'preview will skip them.',
+        ),
+        duration: const Duration(seconds: 4),
+      ));
     }
 
     ref.read(batchMetadataEditProvider.notifier).prepareBatchEdit(
           pendingChanges: pendingChanges,
           originalValues: originalValues,
-          affectedTrackCount: _totalTrackCount,
+          affectedTrackCount: pendingChanges.length,
           affectedAlbumCount: _selectedAlbums.length,
         );
 
@@ -123,24 +144,42 @@ class _BatchTagEditorDialogState extends ConsumerState<BatchTagEditorDialog> {
 
     final pendingChanges = <String, Map<String, String>>{};
     final originalValues = <String, Map<String, String>>{};
+    final readFailures = <String>[];
 
     for (final album in _selectedAlbums) {
       final tracks = ref.read(ripTracksProvider(album.id)).value ?? [];
       for (final track in tracks) {
-        pendingChanges[track.id] = Map<String, String>.from(tagChanges);
-        final currentTags =
-            await ref.read(trackRawTagsProvider(track.filePath).future);
-        originalValues[track.id] = {
-          for (final key in tagChanges.keys)
-            if (currentTags.containsKey(key)) key: currentTags[key]!,
-        };
+        try {
+          final currentTags = await ref
+              .read(trackRawTagsProvider(track.filePath).future);
+          pendingChanges[track.id] = Map<String, String>.from(tagChanges);
+          originalValues[track.id] = {
+            for (final key in tagChanges.keys)
+              if (currentTags.containsKey(key)) key: currentTags[key]!,
+          };
+        } on Object catch (e) {
+          readFailures.add('${track.filePath}: $e');
+        }
       }
+    }
+
+    if (!mounted) return;
+    if (readFailures.isNotEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(
+          readFailures.length == 1
+              ? 'Could not read tags from 1 track — it will be skipped.'
+              : 'Could not read tags from ${readFailures.length} tracks — '
+                  'they will be skipped.',
+        ),
+        duration: const Duration(seconds: 4),
+      ));
     }
 
     ref.read(batchMetadataEditProvider.notifier).prepareBatchEdit(
           pendingChanges: pendingChanges,
           originalValues: originalValues,
-          affectedTrackCount: _totalTrackCount,
+          affectedTrackCount: pendingChanges.length,
           affectedAlbumCount: _selectedAlbums.length,
         );
 

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -629,6 +629,14 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
   final _pathController = TextEditingController();
   final _flacBinaryController = TextEditingController();
 
+  /// One-shot seed flags — once we've written the stored value into a
+  /// controller, never overwrite it again. The earlier `text.isEmpty`
+  /// guard re-seeded the field if the user cleared it, clobbering an
+  /// in-progress edit on the next rebuild (e.g. when
+  /// `ripScanNotifierProvider` re-emits scan progress).
+  bool _pathSeeded = false;
+  bool _flacBinarySeeded = false;
+
   @override
   void dispose() {
     _pathController.dispose();
@@ -643,16 +651,24 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
     final flacBinaryAsync = ref.watch(flacBinaryPathOverrideProvider);
     final clickSensitivityAsync = ref.watch(clickDetectionSensitivityProvider);
 
-    // Initialise text field from stored path
+    // Initialise text fields from stored values exactly once.
     pathAsync.whenData((path) {
-      if (path != null && _pathController.text.isEmpty) {
+      if (!_pathSeeded && path != null) {
         _pathController.text = path;
+        _pathSeeded = true;
+      } else if (!_pathSeeded && path == null) {
+        // Mark seeded even when the stored value is null so a delayed
+        // user edit isn't overwritten by a later null re-emission.
+        _pathSeeded = true;
       }
     });
 
     flacBinaryAsync.whenData((path) {
-      if (path != null && _flacBinaryController.text.isEmpty) {
+      if (!_flacBinarySeeded && path != null) {
         _flacBinaryController.text = path;
+        _flacBinarySeeded = true;
+      } else if (!_flacBinarySeeded && path == null) {
+        _flacBinarySeeded = true;
       }
     });
 


### PR DESCRIPTION
## Summary

Seven post-cluster-5 fixes (two HIGH from Option B, five MEDIUM from the same review pass). No architecture changes; pull-broadening to non-media-item entities is still queued for a separate cluster.

### HIGH-4 — Vision OCR timeout

`VisionOcrChannel.recogniseText` / `recogniseTextStructured` now apply a 15 s timeout per invocation. Flutter's `MethodChannel` does not support per-call cancellation, so a hung Vision handler used to pin the Dart-side future indefinitely; the timeout caps the worst case and lets callers fall back instead of freezing the UI. The doc comment now states the cancellation contract so future callers know to also check their own `mounted` after the await.

### HIGH-6 — Static export path-traversal validator

`StaticExportWriter` validates every bundle key before writing. The keys come from the in-tree `StaticExportService` which is trusted, but a future regression there shouldn't translate to "arbitrary file write under the export root". Rejects absolute paths, `..` segments (both Posix and Windows separators), and any resolved path that isn't a descendant of the canonicalised target directory.

### MED-8 — Batch metadata edit surfaces missing tracks

`BatchMetadataEditNotifier.applyChanges` now records an explicit error when `trackLookup[id]` is null (track was deleted between batch-prep and apply), instead of silently skipping. The "applied to N tracks" success message used to count work that never reached the file.

### MED-9 — Batch tag editor per-track error handling

`BatchTagEditorDialog._openPreview` and `_applyDirectly` now wrap each per-track tag read in try/catch, collect the failed file paths, and show a snackbar summary. The prior implementation let the first exception abort the whole batch with no per-file feedback. The `affectedTrackCount` passed to `prepareBatchEdit` also now reflects the successfully-prepared count, so a partial failure is honest.

### MED-10 — Rip-library scan inserts atomic

Added `RipLibraryDao.insertAlbumWithTracks` (single transaction: `insertAlbum` + batch `insertTracks`) and `updateAlbumAndReplaceTracks` (single transaction: `updateAlbum` + `deleteTracksForAlbum` + batch `insertTracks`). Repository forwards via small companion-converter helpers, and `ScanRipLibraryUseCase` swaps from the prior split inserts. A crash mid-scan can no longer leave a track-less orphan album visible in the UI.

### MED-11 — FLAC library section rebuild guard

`_FlacLibrarySectionState` now seeds its `TextEditingController`s exactly once via `_pathSeeded` / `_flacBinarySeeded` flags. The earlier `text.isEmpty` guard re-seeded the field if the user cleared it, clobbering an in-progress edit on the next rebuild (e.g. when `ripScanNotifierProvider` re-emits scan progress). Mirrors the cluster-1 `ApiKeyForm` seed pattern.

### MED-12 — Connection health timer guard

`ConnectionHealthNotifier.build` only registers the lifecycle observer, starts the periodic ping timer, and wires `onDispose` on the **first** run, gated by the existing `_observerRegistered` flag. The prior unconditional `_startTimer` call in `build` cancelled-and-restarted the 60 s window every time `postgresConfigProvider` re-emitted, so a config edit (or unrelated re-emission) postponed the next ping indefinitely. The lifecycle handler still cancels on pause and restarts on resume — that's the only legitimate timer-restart path.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1303 tests pass
- [ ] Manual (macOS): open Cover OCR on a large or pathological cover image, navigate away mid-OCR — confirm no UI freeze; if Vision is slow, the 15 s timeout fires and falls back to plain-text or null.
- [ ] Manual: trigger a static export — confirm the bundle writes succeed and any future test that injects a key with `..` raises `StateError`.
- [ ] Manual: open the batch tag editor, select tracks where one file has been moved/deleted on disk — confirm the snackbar reports "Could not read tags from N tracks" and the rest of the batch still applies.
- [ ] Manual: rescan a rip library and kill the app mid-scan — re-launch, confirm no album row exists with zero tracks.
- [ ] Manual: open Settings → FLAC library, type a new path, then trigger a scan in another section — confirm the path field keeps your text instead of reverting.
- [ ] Manual: edit Postgres config rapidly, leave the app running for 60+ seconds with no further config changes — confirm the health-tile pings on schedule (was previously postponed indefinitely).

## Notes

- Pull-broadening (extending `pullChanges` over the allow-listed tables with per-entity DTO mappers + non-media conflict UI) is unchanged in scope and queued for the next cluster.
- The Vision OCR timeout is non-cancelling — the native handler still runs to completion. Adding true cancellation would require a paired native-side abort method, which is a bigger change for limited benefit.