### PR TITLE
Fix code-review cluster 7: sync round-trip, atomicity, reset, FTS, tag filter

### DIFF
--- a/lib/data/local/dao/media_items_dao.dart
+++ b/lib/data/local/dao/media_items_dao.dart
@@ -1,11 +1,12 @@
 import 'package:drift/drift.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/local/database/tables/media_item_tags_table.dart';
 import 'package:mymediascanner/data/local/database/tables/media_items_table.dart';
 import 'package:mymediascanner/domain/entities/ownership_status.dart';
 
 part 'media_items_dao.g.dart';
 
-@DriftAccessor(tables: [MediaItemsTable])
+@DriftAccessor(tables: [MediaItemsTable, MediaItemTagsTable])
 class MediaItemsDao extends DatabaseAccessor<AppDatabase>
     with _$MediaItemsDaoMixin {
   MediaItemsDao(super.db);
@@ -13,6 +14,7 @@ class MediaItemsDao extends DatabaseAccessor<AppDatabase>
   Stream<List<MediaItemsTableData>> watchAll({
     bool includeDeleted = false,
     String? mediaType,
+    List<String>? tagIds,
     String? sortBy,
     bool ascending = false,
   }) {
@@ -22,6 +24,21 @@ class MediaItemsDao extends DatabaseAccessor<AppDatabase>
     }
     if (mediaType != null) {
       query.where((t) => t.mediaType.equals(mediaType));
+    }
+    // Tag filter: include only rows that have at least one matching
+    // assignment in `media_item_tags`. The stream re-fires when either
+    // table changes because Drift tracks `readsFrom` on the subquery.
+    if (tagIds != null && tagIds.isNotEmpty) {
+      query.where(
+        (t) => existsQuery(
+          selectOnly(mediaItemTagsTable)
+            ..addColumns([mediaItemTagsTable.tagId])
+            ..where(
+              mediaItemTagsTable.mediaItemId.equalsExp(t.id) &
+                  mediaItemTagsTable.tagId.isIn(tagIds),
+            ),
+        ),
+      );
     }
 
     final orderColumn = switch (sortBy) {

--- a/lib/data/local/dao/media_items_dao.g.dart
+++ b/lib/data/local/dao/media_items_dao.g.dart
@@ -5,6 +5,9 @@ part of 'media_items_dao.dart';
 // ignore_for_file: type=lint
 mixin _$MediaItemsDaoMixin on DatabaseAccessor<AppDatabase> {
   $MediaItemsTableTable get mediaItemsTable => attachedDatabase.mediaItemsTable;
+  $TagsTableTable get tagsTable => attachedDatabase.tagsTable;
+  $MediaItemTagsTableTable get mediaItemTagsTable =>
+      attachedDatabase.mediaItemTagsTable;
   MediaItemsDaoManager get managers => MediaItemsDaoManager(this);
 }
 
@@ -15,5 +18,12 @@ class MediaItemsDaoManager {
       $$MediaItemsTableTableTableManager(
         _db.attachedDatabase,
         _db.mediaItemsTable,
+      );
+  $$TagsTableTableTableManager get tagsTable =>
+      $$TagsTableTableTableManager(_db.attachedDatabase, _db.tagsTable);
+  $$MediaItemTagsTableTableTableManager get mediaItemTagsTable =>
+      $$MediaItemTagsTableTableTableManager(
+        _db.attachedDatabase,
+        _db.mediaItemTagsTable,
       );
 }

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -84,7 +84,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 18;
+  int get schemaVersion => 19;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -222,6 +222,32 @@ class AppDatabase extends _$AppDatabase {
               );
             }
           }
+          if (from < 19) {
+            // Cluster-7 MED-1: the v18 fix added a `deleted = 0` guard to
+            // the insert and update triggers but missed the hard-delete
+            // trigger. Hard-deleting a row that was never indexed (the
+            // soft-deleted-then-wiped path that `resetLocalDatabase`
+            // walks) issued an FTS5 `delete` against a rowid the index
+            // had never seen, corrupting the contentless shadow tables.
+            // Drop and recreate the delete trigger with the matching
+            // guard. The other three already have it, so leave them
+            // alone.
+            final ftsExists = await customSelect(
+              'SELECT name FROM sqlite_master '
+              "WHERE type='table' AND name='media_items_fts'",
+            ).get();
+            if (ftsExists.isNotEmpty) {
+              await customStatement(
+                  'DROP TRIGGER IF EXISTS media_items_fts_delete');
+              await customStatement('''
+                CREATE TRIGGER media_items_fts_delete
+                AFTER DELETE ON media_items WHEN old.deleted = 0 BEGIN
+                  INSERT INTO media_items_fts(media_items_fts, rowid, title, subtitle, description, publisher, genres)
+                  VALUES ('delete', old.rowid, old.title, old.subtitle, old.description, old.publisher, old.genres);
+                END
+              ''');
+            }
+          }
         },
       );
 
@@ -289,13 +315,51 @@ class AppDatabase extends _$AppDatabase {
       END
     ''');
 
+    // Hard-delete trigger mirrors the update-side guard: skip rows that
+    // were never indexed (deleted=1 on insert, or already-soft-deleted
+    // when a hard wipe walks the table). Issuing an FTS5 `delete` for a
+    // rowid the index has never seen corrupts the contentless shadow
+    // tables and breaks subsequent inserts/searches.
     await customStatement('''
       CREATE TRIGGER IF NOT EXISTS media_items_fts_delete
-      AFTER DELETE ON media_items BEGIN
+      AFTER DELETE ON media_items WHEN old.deleted = 0 BEGIN
         INSERT INTO media_items_fts(media_items_fts, rowid, title, subtitle, description, publisher, genres)
         VALUES ('delete', old.rowid, old.title, old.subtitle, old.description, old.publisher, old.genres);
       END
     ''');
+  }
+
+  /// Hard-delete every row of synced user data, in a single transaction
+  /// so a partial wipe cannot leave the database with orphaned children.
+  ///
+  /// Used by `SyncRepositoryImpl.resetLocalDatabase` to honour the
+  /// "Replace local data with remote" affordance. Tables that are
+  /// strictly local (rip library scans, batch sessions, the barcode
+  /// metadata cache) are left alone — they aren't synced, so there's
+  /// nothing on the server to repopulate them with, and rebuilding by
+  /// re-scanning is the right path.
+  ///
+  /// Children before parents to play nice with FK enforcement if it
+  /// ever gets enabled. `sync_log` is cleared too so any pending pushes
+  /// for now-deleted rows don't fire on the next sync.
+  Future<void> wipeSyncedUserData() async {
+    await transaction(() async {
+      // Join tables first.
+      await delete(mediaItemTagsTable).go();
+      await delete(shelfItemsTable).go();
+      // Children of borrowers/media_items/shelves/etc.
+      await delete(loansTable).go();
+      // Top-level synced entities.
+      await delete(mediaItemsTable).go();
+      await delete(tagsTable).go();
+      await delete(shelvesTable).go();
+      await delete(borrowersTable).go();
+      await delete(locationsTable).go();
+      await delete(seriesTable).go();
+      // Audit log — pending pushes for the rows we just deleted would
+      // fail anyway, and the user explicitly asked to discard them.
+      await delete(syncLogTable).go();
+    });
   }
 
   /// Creates indexes on commonly queried columns to improve performance.

--- a/lib/data/remote/sync/migrations/006_locations_series_tables.sql
+++ b/lib/data/remote/sync/migrations/006_locations_series_tables.sql
@@ -1,0 +1,53 @@
+-- Migration 006: locations and series tables.
+--
+-- The Dart client at `LocationRepositoryImpl` and `SeriesRepositoryImpl`
+-- has been enqueueing sync_log rows with entity_type='location' and
+-- 'series' since those features shipped, but the corresponding
+-- server-side tables never existed — every push was silently rejected
+-- by the client-side allow-list (`location` round-tripped through `+s`
+-- pluralisation to `locations`, which passed the allow-list but hit a
+-- "relation does not exist" at execution; `series` round-tripped to
+-- `seriess` and was rejected outright). Cluster-7 fixes the
+-- pluralisation in tableForEntityType; this migration creates the
+-- remote tables those pushes now actually need.
+--
+-- Schema mirrors the local Drift tables `LocationsTable` /
+-- `SeriesTable`. `parent_id` is a self-FK with ON DELETE SET NULL so a
+-- top-level deletion doesn't cascade away the children — soft delete is
+-- the canonical retire path; this is just defence in depth.
+
+CREATE TABLE IF NOT EXISTS locations (
+  id TEXT PRIMARY KEY,
+  parent_id TEXT REFERENCES locations(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  updated_at BIGINT NOT NULL DEFAULT 0,
+  deleted INTEGER NOT NULL DEFAULT 0,
+  device_id TEXT NOT NULL DEFAULT 'default',
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_locations_parent
+  ON locations(parent_id) WHERE parent_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_locations_updated_at
+  ON locations(updated_at);
+
+CREATE TABLE IF NOT EXISTS series (
+  id TEXT PRIMARY KEY,
+  external_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  media_type TEXT NOT NULL,
+  source TEXT NOT NULL,
+  total_count INTEGER,
+  updated_at BIGINT NOT NULL DEFAULT 0,
+  deleted INTEGER NOT NULL DEFAULT 0,
+  device_id TEXT NOT NULL DEFAULT 'default',
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- `external_id` is qualified by source (e.g. `tmdb:131635`) so a
+-- straight UNIQUE here is safe — the qualifier already namespaces it.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_series_external_id
+  ON series(external_id);
+CREATE INDEX IF NOT EXISTS idx_series_updated_at
+  ON series(updated_at);

--- a/lib/data/remote/sync/postgres_sync_client.dart
+++ b/lib/data/remote/sync/postgres_sync_client.dart
@@ -44,6 +44,41 @@ class PostgresSyncClient {
     'series',
   };
 
+  /// Singular `sync_log.entity_type` → remote table name mapping.
+  ///
+  /// The previous implementation appended a literal `s` to derive the
+  /// table, which silently produced `shelfs` / `seriess` (rejected by
+  /// the allow-list above) and broke every push for those entities.
+  /// Maintain this map alongside `_allowedTables` whenever a new
+  /// syncable entity is added.
+  static const _tableByEntityType = <String, String>{
+    'media_item': 'media_items',
+    'shelf': 'shelves',
+    'shelf_item': 'shelf_items',
+    'tag': 'tags',
+    'media_item_tag': 'media_item_tags',
+    'borrower': 'borrowers',
+    'loan': 'loans',
+    'location': 'locations',
+    'series': 'series',
+  };
+
+  /// Resolve the remote table name for a `sync_log.entity_type` value.
+  /// Throws [ArgumentError] if [entityType] is unknown — pushing such a
+  /// row would fail at the SQL layer anyway, but failing here surfaces
+  /// the typo earlier with a clearer message.
+  static String tableForEntityType(String entityType) {
+    final table = _tableByEntityType[entityType];
+    if (table == null) {
+      throw ArgumentError.value(
+        entityType,
+        'entityType',
+        'No remote table mapping (sync_log entity_type unrecognised)',
+      );
+    }
+    return table;
+  }
+
   /// Matches a valid SQL identifier (column or table name).
   static final _identifierRegex = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*$');
 

--- a/lib/data/repositories/borrower_repository_impl.dart
+++ b/lib/data/repositories/borrower_repository_impl.dart
@@ -34,7 +34,6 @@ class BorrowerRepositoryImpl implements IBorrowerRepository {
 
   @override
   Future<void> save(Borrower borrower) async {
-    final existing = await _borrowersDao.getById(borrower.id);
     final companion = BorrowersTableCompanion(
       id: Value(borrower.id),
       name: Value(borrower.name),
@@ -43,13 +42,17 @@ class BorrowerRepositoryImpl implements IBorrowerRepository {
       notes: Value(borrower.notes),
       updatedAt: Value(borrower.updatedAt),
     );
-    if (existing != null) {
-      await _borrowersDao.updateBorrower(companion);
-      await _logSync(borrower, 'update');
-    } else {
-      await _borrowersDao.insertBorrower(companion);
-      await _logSync(borrower, 'insert');
-    }
+    // Atomic write + sync_log: see MediaItemRepositoryImpl.save.
+    await _borrowersDao.transaction(() async {
+      final existing = await _borrowersDao.getById(borrower.id);
+      if (existing != null) {
+        await _borrowersDao.updateBorrower(companion);
+        await _logSync(borrower, 'update');
+      } else {
+        await _borrowersDao.insertBorrower(companion);
+        await _logSync(borrower, 'insert');
+      }
+    });
   }
 
   @override
@@ -65,30 +68,34 @@ class BorrowerRepositoryImpl implements IBorrowerRepository {
       notes: Value(updated.notes),
       updatedAt: Value(updated.updatedAt),
     );
-    await _borrowersDao.updateBorrower(companion);
-    await _logSync(updated, 'update');
+    await _borrowersDao.transaction(() async {
+      await _borrowersDao.updateBorrower(companion);
+      await _logSync(updated, 'update');
+    });
   }
 
   @override
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _borrowersDao.softDelete(id, now);
-    // Mirror the media-item soft-delete pattern: enqueue a sync_log row so a
-    // remote pull (or a future cross-entity pull) can replicate the deletion.
-    // Without this the row stays at deleted=1 locally forever and the remote
-    // copy never learns it was retired.
-    await _syncLogDao.insertLog(SyncLogTableCompanion(
-      id: Value(_uuid.v7()),
-      entityType: const Value('borrower'),
-      entityId: Value(id),
-      operation: const Value('delete'),
-      payloadJson: Value(jsonEncode({
-        'id': id,
-        'deleted': 1,
-        'updated_at': now,
-      })),
-      createdAt: Value(now),
-    ));
+    await _borrowersDao.transaction(() async {
+      await _borrowersDao.softDelete(id, now);
+      // Mirror the media-item soft-delete pattern: enqueue a sync_log row
+      // so a remote pull (or a future cross-entity pull) can replicate
+      // the deletion. Without this the row stays at deleted=1 locally
+      // forever and the remote copy never learns it was retired.
+      await _syncLogDao.insertLog(SyncLogTableCompanion(
+        id: Value(_uuid.v7()),
+        entityType: const Value('borrower'),
+        entityId: Value(id),
+        operation: const Value('delete'),
+        payloadJson: Value(jsonEncode({
+          'id': id,
+          'deleted': 1,
+          'updated_at': now,
+        })),
+        createdAt: Value(now),
+      ));
+    });
   }
 
   /// Enqueue a `sync_log` row carrying a full snake_case snapshot of

--- a/lib/data/repositories/loan_repository_impl.dart
+++ b/lib/data/repositories/loan_repository_impl.dart
@@ -63,46 +63,55 @@ class LoanRepositoryImpl implements ILoanRepository {
 
   @override
   Future<void> createLoan(Loan loan) async {
-    await _loansDao.insertLoan(LoansTableCompanion(
-      id: Value(loan.id),
-      mediaItemId: Value(loan.mediaItemId),
-      borrowerId: Value(loan.borrowerId),
-      lentAt: Value(loan.lentAt),
-      dueAt: Value(loan.dueAt),
-      notes: Value(loan.notes),
-      updatedAt: Value(loan.updatedAt),
-    ));
-    await _logSync(loan, 'insert');
+    // Atomic write + sync_log: see MediaItemRepositoryImpl.save.
+    await _loansDao.transaction(() async {
+      await _loansDao.insertLoan(LoansTableCompanion(
+        id: Value(loan.id),
+        mediaItemId: Value(loan.mediaItemId),
+        borrowerId: Value(loan.borrowerId),
+        lentAt: Value(loan.lentAt),
+        dueAt: Value(loan.dueAt),
+        notes: Value(loan.notes),
+        updatedAt: Value(loan.updatedAt),
+      ));
+      await _logSync(loan, 'insert');
+    });
   }
 
   @override
   Future<void> updateLoan(Loan loan) async {
-    await _loansDao.updateLoan(LoansTableCompanion(
-      id: Value(loan.id),
-      mediaItemId: Value(loan.mediaItemId),
-      borrowerId: Value(loan.borrowerId),
-      lentAt: Value(loan.lentAt),
-      dueAt: Value(loan.dueAt),
-      notes: Value(loan.notes),
-      updatedAt: Value(loan.updatedAt),
-    ));
-    await _logSync(loan, 'update');
+    await _loansDao.transaction(() async {
+      await _loansDao.updateLoan(LoansTableCompanion(
+        id: Value(loan.id),
+        mediaItemId: Value(loan.mediaItemId),
+        borrowerId: Value(loan.borrowerId),
+        lentAt: Value(loan.lentAt),
+        dueAt: Value(loan.dueAt),
+        notes: Value(loan.notes),
+        updatedAt: Value(loan.updatedAt),
+      ));
+      await _logSync(loan, 'update');
+    });
   }
 
   @override
   Future<void> updateDueDate(String loanId, int? dueAt) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _loansDao.updateDueDate(loanId, dueAt, now);
-    final updated = await _loansDao.getById(loanId);
-    if (updated != null) await _logSync(_fromRow(updated), 'update');
+    await _loansDao.transaction(() async {
+      await _loansDao.updateDueDate(loanId, dueAt, now);
+      final updated = await _loansDao.getById(loanId);
+      if (updated != null) await _logSync(_fromRow(updated), 'update');
+    });
   }
 
   @override
   Future<void> returnItem(String loanId) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _loansDao.returnItem(loanId, now, now);
-    final updated = await _loansDao.getById(loanId);
-    if (updated != null) await _logSync(_fromRow(updated), 'update');
+    await _loansDao.transaction(() async {
+      await _loansDao.returnItem(loanId, now, now);
+      final updated = await _loansDao.getById(loanId);
+      if (updated != null) await _logSync(_fromRow(updated), 'update');
+    });
   }
 
   /// Enqueue a `sync_log` row carrying a full snake_case snapshot of

--- a/lib/data/repositories/location_repository_impl.dart
+++ b/lib/data/repositories/location_repository_impl.dart
@@ -44,12 +44,19 @@ class LocationRepositoryImpl implements ILocationRepository {
 
   @override
   Future<void> create(Location location) async {
-    await _dao.insertLocation(_toCompanion(location));
-    await _logSync(location, 'insert');
+    // Atomic write + sync_log: see MediaItemRepositoryImpl.save.
+    await _dao.transaction(() async {
+      await _dao.insertLocation(_toCompanion(location));
+      await _logSync(location, 'insert');
+    });
   }
 
   @override
   Future<void> update(Location location) async {
+    // Cycle detection runs outside the transaction because reading from
+    // the same connection inside the transaction would still see
+    // committed state, but throwing here surfaces the validation error
+    // to the caller before we open a write txn — cleaner failure mode.
     final existing = await _dao.getById(location.id);
     if (existing != null && existing.parentId != location.parentId) {
       if (await _dao.wouldCreateCycle(location.id, location.parentId)) {
@@ -58,26 +65,30 @@ class LocationRepositoryImpl implements ILocationRepository {
             '${location.parentId}: would create a cycle.');
       }
     }
-    await _dao.updateLocation(_toCompanion(location));
-    await _logSync(location, 'update');
+    await _dao.transaction(() async {
+      await _dao.updateLocation(_toCompanion(location));
+      await _logSync(location, 'update');
+    });
   }
 
   @override
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _dao.softDelete(id, now);
-    await _syncLogDao.insertLog(SyncLogTableCompanion(
-      id: Value(_uuid.v7()),
-      entityType: const Value('location'),
-      entityId: Value(id),
-      operation: const Value('delete'),
-      payloadJson: Value(jsonEncode({
-        'id': id,
-        'deleted': 1,
-        'updated_at': now,
-      })),
-      createdAt: Value(now),
-    ));
+    await _dao.transaction(() async {
+      await _dao.softDelete(id, now);
+      await _syncLogDao.insertLog(SyncLogTableCompanion(
+        id: Value(_uuid.v7()),
+        entityType: const Value('location'),
+        entityId: Value(id),
+        operation: const Value('delete'),
+        payloadJson: Value(jsonEncode({
+          'id': id,
+          'deleted': 1,
+          'updated_at': now,
+        })),
+        createdAt: Value(now),
+      ));
+    });
   }
 
   @override

--- a/lib/data/repositories/media_item_repository_impl.dart
+++ b/lib/data/repositories/media_item_repository_impl.dart
@@ -33,17 +33,32 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
   }) {
     final useFts =
         searchQuery != null && searchQuery.trim().length >= 2;
+    final hasTagFilter = tagIds != null && tagIds.isNotEmpty;
 
     final Stream<List<MediaItemsTableData>> baseStream = useFts
         ? _mediaItemsDao.watchSearch(searchQuery)
         : _mediaItemsDao.watchAll(
             mediaType: mediaType?.name,
+            tagIds: tagIds,
             sortBy: sortBy,
             ascending: ascending,
           );
 
-    return baseStream.map(
-      (rows) => rows
+    // FTS path skips the DAO-level tag filter (the FTS query joins only
+    // `media_items_fts`), so we have to apply tagIds in-memory by looking
+    // up the assignments. This is rare — full-text search + tag filter
+    // — and a single small read per emission.
+    Future<Set<String>> resolveTaggedIds() async {
+      if (!useFts || !hasTagFilter) return const <String>{};
+      final assignments = await (_db.select(_db.mediaItemTagsTable)
+            ..where((t) => t.tagId.isIn(tagIds)))
+          .get();
+      return assignments.map((a) => a.mediaItemId).toSet();
+    }
+
+    return baseStream.asyncMap((rows) async {
+      final taggedIds = await resolveTaggedIds();
+      return rows
           .where((r) =>
               useFts ||
               mediaType == null ||
@@ -53,10 +68,14 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
               useFts ||
               searchQuery == null ||
               r.title.toLowerCase().contains(searchQuery.toLowerCase()))
+          .where((r) =>
+              !useFts || !hasTagFilter || taggedIds.contains(r.id))
           .map(_fromRow)
-          .toList(),
-    );
+          .toList();
+    });
   }
+
+  AppDatabase get _db => _mediaItemsDao.attachedDatabase;
 
   @override
   Stream<List<MediaItem>> watchByStatus(OwnershipStatus status) {
@@ -102,28 +121,38 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
 
   @override
   Future<void> save(MediaItem item) async {
-    await _mediaItemsDao.insertItem(_toCompanion(item));
-    await _logSync('media_item', item.id, 'insert', item);
+    // Atomic: the row write and its sync_log entry must commit together,
+    // or both roll back. A crash between the two left the local mutation
+    // permanently invisible to `pushChanges` (which only iterates
+    // pending log rows), so re-edits couldn't recover the data.
+    await _mediaItemsDao.transaction(() async {
+      await _mediaItemsDao.insertItem(_toCompanion(item));
+      await _logSync('media_item', item.id, 'insert', item);
+    });
   }
 
   @override
   Future<void> update(MediaItem item) async {
-    await _mediaItemsDao.updateItem(_toCompanion(item));
-    await _logSync('media_item', item.id, 'update', item);
+    await _mediaItemsDao.transaction(() async {
+      await _mediaItemsDao.updateItem(_toCompanion(item));
+      await _logSync('media_item', item.id, 'update', item);
+    });
   }
 
   @override
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _mediaItemsDao.softDelete(id, now);
-    await _syncLogDao.insertLog(SyncLogTableCompanion(
-      id: Value(_uuid.v7()),
-      entityType: const Value('media_item'),
-      entityId: Value(id),
-      operation: const Value('delete'),
-      payloadJson: Value(jsonEncode({'id': id, 'deleted': 1})),
-      createdAt: Value(now),
-    ));
+    await _mediaItemsDao.transaction(() async {
+      await _mediaItemsDao.softDelete(id, now);
+      await _syncLogDao.insertLog(SyncLogTableCompanion(
+        id: Value(_uuid.v7()),
+        entityType: const Value('media_item'),
+        entityId: Value(id),
+        operation: const Value('delete'),
+        payloadJson: Value(jsonEncode({'id': id, 'deleted': 1})),
+        createdAt: Value(now),
+      ));
+    });
   }
 
   @override

--- a/lib/data/repositories/series_repository_impl.dart
+++ b/lib/data/repositories/series_repository_impl.dart
@@ -52,56 +52,63 @@ class SeriesRepositoryImpl implements ISeriesRepository {
     required String source,
     int? totalCount,
   }) async {
-    final existing = await _dao.findByExternalId(externalId);
     final now = DateTime.now().millisecondsSinceEpoch;
-    final id = existing?.id ?? _uuid.v7();
-    final resolvedTotalCount = totalCount ?? existing?.totalCount;
-    await _dao.upsert(SeriesTableCompanion(
-      id: Value(id),
-      externalId: Value(externalId),
-      name: Value(name),
-      mediaType: Value(mediaType.name),
-      source: Value(source),
-      totalCount: Value(resolvedTotalCount),
-      updatedAt: Value(now),
-      deleted: const Value(0),
-    ));
-    await _syncLogDao.insertLog(SyncLogTableCompanion(
-      id: Value(_uuid.v7()),
-      entityType: const Value('series'),
-      entityId: Value(id),
-      operation: Value(existing == null ? 'insert' : 'update'),
-      payloadJson: Value(jsonEncode({
-        'id': id,
-        'external_id': externalId,
-        'name': name,
-        'media_type': mediaType.name,
-        'source': source,
-        'total_count': resolvedTotalCount,
-        'updated_at': now,
-        'deleted': 0,
-      })),
-      createdAt: Value(now),
-    ));
-    return id;
+    // Atomic upsert + sync_log: read-then-write in a single transaction
+    // so a concurrent upsert with the same externalId can't cause two
+    // distinct ids to race in.
+    return _dao.transaction(() async {
+      final existing = await _dao.findByExternalId(externalId);
+      final id = existing?.id ?? _uuid.v7();
+      final resolvedTotalCount = totalCount ?? existing?.totalCount;
+      await _dao.upsert(SeriesTableCompanion(
+        id: Value(id),
+        externalId: Value(externalId),
+        name: Value(name),
+        mediaType: Value(mediaType.name),
+        source: Value(source),
+        totalCount: Value(resolvedTotalCount),
+        updatedAt: Value(now),
+        deleted: const Value(0),
+      ));
+      await _syncLogDao.insertLog(SyncLogTableCompanion(
+        id: Value(_uuid.v7()),
+        entityType: const Value('series'),
+        entityId: Value(id),
+        operation: Value(existing == null ? 'insert' : 'update'),
+        payloadJson: Value(jsonEncode({
+          'id': id,
+          'external_id': externalId,
+          'name': name,
+          'media_type': mediaType.name,
+          'source': source,
+          'total_count': resolvedTotalCount,
+          'updated_at': now,
+          'deleted': 0,
+        })),
+        createdAt: Value(now),
+      ));
+      return id;
+    });
   }
 
   @override
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _dao.softDelete(id, now);
-    await _syncLogDao.insertLog(SyncLogTableCompanion(
-      id: Value(_uuid.v7()),
-      entityType: const Value('series'),
-      entityId: Value(id),
-      operation: const Value('delete'),
-      payloadJson: Value(jsonEncode({
-        'id': id,
-        'deleted': 1,
-        'updated_at': now,
-      })),
-      createdAt: Value(now),
-    ));
+    await _dao.transaction(() async {
+      await _dao.softDelete(id, now);
+      await _syncLogDao.insertLog(SyncLogTableCompanion(
+        id: Value(_uuid.v7()),
+        entityType: const Value('series'),
+        entityId: Value(id),
+        operation: const Value('delete'),
+        payloadJson: Value(jsonEncode({
+          'id': id,
+          'deleted': 1,
+          'updated_at': now,
+        })),
+        createdAt: Value(now),
+      ));
+    });
   }
 
   @override

--- a/lib/data/repositories/shelf_repository_impl.dart
+++ b/lib/data/repositories/shelf_repository_impl.dart
@@ -41,32 +41,37 @@ class ShelfRepositoryImpl implements IShelfRepository {
       sortOrder: Value(shelf.sortOrder),
       updatedAt: Value(shelf.updatedAt),
     );
-    final existing = await _shelvesDao.getById(shelf.id);
-    if (existing != null) {
-      await _shelvesDao.updateShelf(companion);
-      await _logSync(shelf, 'update');
-    } else {
-      await _shelvesDao.insertShelf(companion);
-      await _logSync(shelf, 'insert');
-    }
+    // Atomic write + sync_log: see MediaItemRepositoryImpl.save.
+    await _shelvesDao.transaction(() async {
+      final existing = await _shelvesDao.getById(shelf.id);
+      if (existing != null) {
+        await _shelvesDao.updateShelf(companion);
+        await _logSync(shelf, 'update');
+      } else {
+        await _shelvesDao.insertShelf(companion);
+        await _logSync(shelf, 'insert');
+      }
+    });
   }
 
   @override
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _shelvesDao.softDelete(id, now);
-    await _syncLogDao.insertLog(SyncLogTableCompanion(
-      id: Value(_uuid.v7()),
-      entityType: const Value('shelf'),
-      entityId: Value(id),
-      operation: const Value('delete'),
-      payloadJson: Value(jsonEncode({
-        'id': id,
-        'deleted': 1,
-        'updated_at': now,
-      })),
-      createdAt: Value(now),
-    ));
+    await _shelvesDao.transaction(() async {
+      await _shelvesDao.softDelete(id, now);
+      await _syncLogDao.insertLog(SyncLogTableCompanion(
+        id: Value(_uuid.v7()),
+        entityType: const Value('shelf'),
+        entityId: Value(id),
+        operation: const Value('delete'),
+        payloadJson: Value(jsonEncode({
+          'id': id,
+          'deleted': 1,
+          'updated_at': now,
+        })),
+        createdAt: Value(now),
+      ));
+    });
   }
 
   @override

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -63,7 +63,13 @@ class SyncRepositoryImpl implements ISyncRepository {
         try {
           final decoded = jsonDecode(log.payloadJson);
           if (decoded is! Map<String, dynamic>) continue;
-          await _syncClient.upsertRecords('${log.entityType}s', [decoded]);
+          // Resolve table from a maintained map — naive `+s` pluralisation
+          // mangles `shelf`/`series` and previously caused those pushes
+          // to fail the allow-list check before they ever reached the
+          // server.
+          final table =
+              PostgresSyncClient.tableForEntityType(log.entityType);
+          await _syncClient.upsertRecords(table, [decoded]);
           stopwatch.stop();
           // Network IO sits outside the transaction so the SQLite write
           // lock isn't held for the round-trip. Once the upsert is
@@ -194,6 +200,44 @@ class SyncRepositoryImpl implements ISyncRepository {
         });
       }
 
+      // Pull non-media-item tables that this client also pushes. The
+      // previous implementation only pulled `media_items`, so a remote
+      // edit to a tag / shelf / borrower / loan / location / series
+      // would never round-trip back to other clients. These entities
+      // don't need the timestamp-window conflict detection that
+      // `media_items` does (no per-field merge UI exists for them yet),
+      // so we apply a simple last-write-wins by `updated_at`.
+      await _pullLastWriteWins(
+        tableName: 'tags',
+        entityType: 'tag',
+        afterTimestamp: lastSyncedAt,
+      );
+      await _pullLastWriteWins(
+        tableName: 'shelves',
+        entityType: 'shelf',
+        afterTimestamp: lastSyncedAt,
+      );
+      await _pullLastWriteWins(
+        tableName: 'borrowers',
+        entityType: 'borrower',
+        afterTimestamp: lastSyncedAt,
+      );
+      await _pullLastWriteWins(
+        tableName: 'loans',
+        entityType: 'loan',
+        afterTimestamp: lastSyncedAt,
+      );
+      await _pullLastWriteWins(
+        tableName: 'locations',
+        entityType: 'location',
+        afterTimestamp: lastSyncedAt,
+      );
+      await _pullLastWriteWins(
+        tableName: 'series',
+        entityType: 'series',
+        afterTimestamp: lastSyncedAt,
+      );
+
       // Auto-purge old sync log entries (30 days)
       final purgeThreshold =
           DateTime.now().millisecondsSinceEpoch - _purgeThresholdMs;
@@ -216,6 +260,158 @@ class SyncRepositoryImpl implements ISyncRepository {
     }
   }
 
+  /// Pull rows from a remote table and upsert them locally using a
+  /// last-write-wins policy on `updated_at`. Used for the simple
+  /// entities (tag, shelf, borrower, loan, location, series) that don't
+  /// have the per-field conflict UI that `media_items` carries.
+  ///
+  /// A row is applied locally if either:
+  ///   - no local row exists with the same `id`, OR
+  ///   - the remote `updated_at` is strictly greater than the local
+  ///     `updated_at`.
+  ///
+  /// The local upsert is dispatched per [entityType] because each table
+  /// has a distinct companion shape; the `_applyRemoteRow` switch keeps
+  /// the dispatch in one place rather than scattered across a wider
+  /// callback API.
+  Future<void> _pullLastWriteWins({
+    required String tableName,
+    required String entityType,
+    required int? afterTimestamp,
+  }) async {
+    final rows = await _syncClient.pullRecords(
+      tableName,
+      afterTimestamp: afterTimestamp,
+    );
+    final total = rows.length;
+    for (var i = 0; i < rows.length; i++) {
+      final remote = rows[i];
+      final id = remote['id'];
+      if (id is! String) continue;
+      _progressController.add(SyncProgress(
+        phase: SyncPhase.pull,
+        current: i + 1,
+        total: total,
+        currentEntityType: entityType,
+      ));
+      final remoteUpdatedAt = (remote['updated_at'] as num?)?.toInt() ?? 0;
+      final localUpdatedAt = await _localUpdatedAt(entityType, id);
+      if (localUpdatedAt != null && remoteUpdatedAt <= localUpdatedAt) {
+        continue;
+      }
+      await _applyRemoteRow(entityType, remote);
+    }
+  }
+
+  Future<int?> _localUpdatedAt(String entityType, String id) async {
+    final db = _mediaItemsDao.attachedDatabase;
+    switch (entityType) {
+      case 'tag':
+        final row = await db.tagsDao.getById(id);
+        return row?.updatedAt;
+      case 'shelf':
+        final row = await db.shelvesDao.getById(id);
+        return row?.updatedAt;
+      case 'borrower':
+        final row = await db.borrowersDao.getById(id);
+        return row?.updatedAt;
+      case 'loan':
+        final row = await db.loansDao.getById(id);
+        return row?.updatedAt;
+      case 'location':
+        final row = await db.locationsDao.getById(id);
+        return row?.updatedAt;
+      case 'series':
+        final row = await db.seriesDao.getById(id);
+        return row?.updatedAt;
+      default:
+        throw StateError('Unsupported entity type for pull: $entityType');
+    }
+  }
+
+  Future<void> _applyRemoteRow(
+      String entityType, Map<String, dynamic> remote) async {
+    final db = _mediaItemsDao.attachedDatabase;
+    switch (entityType) {
+      case 'tag':
+        await db.into(db.tagsTable).insertOnConflictUpdate(
+              TagsTableCompanion.insert(
+                id: remote['id'] as String,
+                name: remote['name'] as String? ?? '',
+                colour: Value(remote['colour'] as String?),
+                updatedAt: (remote['updated_at'] as num?)?.toInt() ?? 0,
+                deleted: Value((remote['deleted'] as num?)?.toInt() ?? 0),
+              ),
+            );
+      case 'shelf':
+        await db.into(db.shelvesTable).insertOnConflictUpdate(
+              ShelvesTableCompanion.insert(
+                id: remote['id'] as String,
+                name: remote['name'] as String? ?? '',
+                description: Value(remote['description'] as String?),
+                sortOrder:
+                    Value((remote['sort_order'] as num?)?.toInt() ?? 0),
+                updatedAt: (remote['updated_at'] as num?)?.toInt() ?? 0,
+                deleted: Value((remote['deleted'] as num?)?.toInt() ?? 0),
+              ),
+            );
+      case 'borrower':
+        await db.into(db.borrowersTable).insertOnConflictUpdate(
+              BorrowersTableCompanion.insert(
+                id: remote['id'] as String,
+                name: remote['name'] as String? ?? '',
+                email: Value(remote['email'] as String?),
+                phone: Value(remote['phone'] as String?),
+                notes: Value(remote['notes'] as String?),
+                updatedAt: (remote['updated_at'] as num?)?.toInt() ?? 0,
+                deleted: Value((remote['deleted'] as num?)?.toInt() ?? 0),
+              ),
+            );
+      case 'loan':
+        await db.into(db.loansTable).insertOnConflictUpdate(
+              LoansTableCompanion.insert(
+                id: remote['id'] as String,
+                mediaItemId: remote['media_item_id'] as String,
+                borrowerId: remote['borrower_id'] as String,
+                lentAt: (remote['lent_at'] as num?)?.toInt() ?? 0,
+                returnedAt:
+                    Value((remote['returned_at'] as num?)?.toInt()),
+                dueAt: Value((remote['due_at'] as num?)?.toInt()),
+                notes: Value(remote['notes'] as String?),
+                updatedAt: (remote['updated_at'] as num?)?.toInt() ?? 0,
+                deleted: Value((remote['deleted'] as num?)?.toInt() ?? 0),
+              ),
+            );
+      case 'location':
+        await db.into(db.locationsTable).insertOnConflictUpdate(
+              LocationsTableCompanion.insert(
+                id: remote['id'] as String,
+                parentId: Value(remote['parent_id'] as String?),
+                name: remote['name'] as String? ?? '',
+                sortOrder:
+                    Value((remote['sort_order'] as num?)?.toInt() ?? 0),
+                updatedAt: (remote['updated_at'] as num?)?.toInt() ?? 0,
+                deleted: Value((remote['deleted'] as num?)?.toInt() ?? 0),
+              ),
+            );
+      case 'series':
+        await db.into(db.seriesTable).insertOnConflictUpdate(
+              SeriesTableCompanion.insert(
+                id: remote['id'] as String,
+                externalId: remote['external_id'] as String? ?? '',
+                name: remote['name'] as String? ?? '',
+                mediaType: remote['media_type'] as String? ?? '',
+                source: remote['source'] as String? ?? '',
+                totalCount: Value((remote['total_count'] as num?)?.toInt()),
+                updatedAt: (remote['updated_at'] as num?)?.toInt() ?? 0,
+                deleted: Value((remote['deleted'] as num?)?.toInt() ?? 0),
+              ),
+            );
+      default:
+        throw StateError('Unsupported entity type for pull: $entityType');
+    }
+  }
+
   @override
   Future<bool> testConnection() => _syncClient.testConnection();
 
@@ -224,17 +420,15 @@ class SyncRepositoryImpl implements ISyncRepository {
     await _emitStatus(isSyncing: true);
     try {
       // Honour the dialog promise: "replace all local data with data
-      // from your PostgreSQL server". Wipe local media_items, drop
-      // every sync_log entry (any pending pushes for now-deleted rows
-      // would fail anyway), and clear the last-synced timestamp so the
-      // following pullChanges performs a full pull rather than an
-      // incremental one. The prior implementation was an incremental
-      // pull only — it kept stale local rows the remote no longer
-      // had, kept pending pushes that the user had just chosen to
-      // discard, and didn't refetch anything modified before
-      // lastSyncedAt.
-      await _mediaItemsDao.deleteAll();
-      await _syncLogDao.deleteAll();
+      // from your PostgreSQL server". The previous implementation only
+      // wiped `media_items` and `sync_log`, leaving shelves, tags,
+      // tag/shelf joins, borrowers, loans, locations, and series behind
+      // — orphaned local data that the next pull couldn't reconcile.
+      // `wipeSyncedUserData` clears every synced table in one atomic
+      // transaction; non-synced tables (rip library, batch sessions,
+      // barcode cache) are left alone since the server has nothing to
+      // repopulate them with.
+      await _mediaItemsDao.attachedDatabase.wipeSyncedUserData();
       _pendingConflicts.clear();
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_lastSyncedAtKey);

--- a/lib/data/repositories/tag_repository_impl.dart
+++ b/lib/data/repositories/tag_repository_impl.dart
@@ -34,32 +34,37 @@ class TagRepositoryImpl implements ITagRepository {
 
   @override
   Future<void> save(Tag tag) async {
-    final existing = await _tagsDao.getById(tag.id);
-    await _tagsDao.insertTag(TagsTableCompanion(
-      id: Value(tag.id),
-      name: Value(tag.name),
-      colour: Value(tag.colour),
-      updatedAt: Value(tag.updatedAt),
-    ));
-    await _logSync(tag, existing == null ? 'insert' : 'update');
+    // Atomic write + sync_log: see MediaItemRepositoryImpl.save.
+    await _tagsDao.transaction(() async {
+      final existing = await _tagsDao.getById(tag.id);
+      await _tagsDao.insertTag(TagsTableCompanion(
+        id: Value(tag.id),
+        name: Value(tag.name),
+        colour: Value(tag.colour),
+        updatedAt: Value(tag.updatedAt),
+      ));
+      await _logSync(tag, existing == null ? 'insert' : 'update');
+    });
   }
 
   @override
   Future<void> softDelete(String id) async {
     final now = DateTime.now().millisecondsSinceEpoch;
-    await _tagsDao.softDelete(id, now);
-    await _syncLogDao.insertLog(SyncLogTableCompanion(
-      id: Value(_uuid.v7()),
-      entityType: const Value('tag'),
-      entityId: Value(id),
-      operation: const Value('delete'),
-      payloadJson: Value(jsonEncode({
-        'id': id,
-        'deleted': 1,
-        'updated_at': now,
-      })),
-      createdAt: Value(now),
-    ));
+    await _tagsDao.transaction(() async {
+      await _tagsDao.softDelete(id, now);
+      await _syncLogDao.insertLog(SyncLogTableCompanion(
+        id: Value(_uuid.v7()),
+        entityType: const Value('tag'),
+        entityId: Value(id),
+        operation: const Value('delete'),
+        payloadJson: Value(jsonEncode({
+          'id': id,
+          'deleted': 1,
+          'updated_at': now,
+        })),
+        createdAt: Value(now),
+      ));
+    });
   }
 
   @override

--- a/test/unit/data/local/database/fts_hard_delete_unindexed_test.dart
+++ b/test/unit/data/local/database/fts_hard_delete_unindexed_test.dart
@@ -1,0 +1,83 @@
+import 'package:drift/drift.dart' show Value, Variable;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+
+/// Cluster-7 MED-1 regression: the FTS5 hard-delete trigger must skip rows
+/// that were never indexed. The insert / update triggers carry a
+/// `WHEN ... deleted = 0` guard so soft-deleted rows are kept out of the
+/// index. Without the same guard on the delete trigger, a hard delete of
+/// a previously-soft-deleted row issues an FTS5 `('delete', ...)` for a
+/// rowid that the index has never seen, which corrupts the contentless
+/// shadow tables and can prevent later inserts from matching.
+///
+/// `resetLocalDatabase` walks every row, including soft-deleted ones, via
+/// `mediaItemsDao.deleteAll()`, so this is the realistic crash path.
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<int> ftsRowCount(String matchTerm) async {
+    final rows = await db
+        .customSelect(
+          'SELECT COUNT(*) AS c FROM media_items_fts '
+          'WHERE media_items_fts MATCH ?',
+          variables: [Variable.withString(matchTerm)],
+        )
+        .get();
+    return (rows.first.data['c'] as int);
+  }
+
+  Future<void> insertItem({
+    required String id,
+    required String title,
+    required int deleted,
+  }) {
+    return db.mediaItemsDao.insertItem(MediaItemsTableCompanion.insert(
+      id: id,
+      barcode: 'bc-$id',
+      barcodeType: 'ean13',
+      mediaType: 'film',
+      title: title,
+      ownershipStatus: const Value('owned'),
+      consumed: const Value(0),
+      dateAdded: 1,
+      dateScanned: 1,
+      updatedAt: 1,
+      deleted: Value(deleted),
+    ));
+  }
+
+  test(
+      'hard-deleting a never-indexed (soft-deleted) row leaves FTS '
+      'consistent for subsequent inserts and searches', () async {
+    // Indexed row.
+    await insertItem(id: 'm1', title: 'Neuromancer', deleted: 0);
+    // Never-indexed row (insert trigger skips because deleted=1).
+    await insertItem(id: 'm2', title: 'Hyperion', deleted: 1);
+
+    expect(await ftsRowCount('Neuromancer'), 1);
+    expect(await ftsRowCount('Hyperion'), 0);
+
+    // Hard-delete every row — mirrors `resetLocalDatabase`.
+    await db.mediaItemsDao.deleteAll();
+
+    // Index is empty.
+    expect(await ftsRowCount('Neuromancer'), 0);
+    expect(await ftsRowCount('Hyperion'), 0);
+
+    // The corruption symptom: a fresh row inserted afterwards should be
+    // discoverable. With the broken trigger the index can be left in a
+    // state where contentless shadow rows mismatch the docsize table and
+    // a subsequent insert-then-MATCH yields no result, or throws.
+    await insertItem(id: 'm3', title: 'Snow Crash', deleted: 0);
+    expect(await ftsRowCount('Snow Crash'), 1);
+  });
+}

--- a/test/unit/data/local/database/wipe_synced_user_data_test.dart
+++ b/test/unit/data/local/database/wipe_synced_user_data_test.dart
@@ -1,0 +1,136 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+
+/// Cluster-7 HIGH-3 regression: `resetLocalDatabase` previously called
+/// `mediaItemsDao.deleteAll() + syncLogDao.deleteAll()` only, leaving
+/// every other synced table (shelves, tags, joins, borrowers, loans,
+/// locations, series) populated with stale rows. After the fix, the
+/// reset routes through `wipeSyncedUserData` which clears all of them
+/// in one transaction.
+void main() {
+  late AppDatabase db;
+
+  setUp(() {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<void> seedAll() async {
+    // media_items
+    await db.mediaItemsDao.insertItem(MediaItemsTableCompanion.insert(
+      id: 'm1',
+      barcode: 'bc',
+      barcodeType: 'ean13',
+      mediaType: 'film',
+      title: 'Neuromancer',
+      ownershipStatus: const Value('owned'),
+      consumed: const Value(0),
+      dateAdded: 1,
+      dateScanned: 1,
+      updatedAt: 1,
+      deleted: const Value(0),
+    ));
+    // tags + media_item_tags
+    await db.tagsDao.insertTag(TagsTableCompanion.insert(
+      id: 't1',
+      name: 'Sci-Fi',
+      updatedAt: 1,
+    ));
+    await db.tagsDao.assignToMediaItem('t1', 'm1');
+    // shelves + shelf_items
+    await db.shelvesDao.insertShelf(ShelvesTableCompanion.insert(
+      id: 's1',
+      name: 'Wishlist',
+      updatedAt: 1,
+    ));
+    await db.shelvesDao.addItem('s1', 'm1', 0);
+    // borrowers + loans
+    await db.borrowersDao.insertBorrower(BorrowersTableCompanion.insert(
+      id: 'b1',
+      name: 'Alice',
+      updatedAt: 1,
+    ));
+    await db.loansDao.insertLoan(LoansTableCompanion.insert(
+      id: 'ln1',
+      mediaItemId: 'm1',
+      borrowerId: 'b1',
+      lentAt: 1,
+      updatedAt: 1,
+    ));
+    // locations
+    await db.locationsDao.insertLocation(LocationsTableCompanion.insert(
+      id: 'l1',
+      name: 'Lounge',
+      updatedAt: 1,
+    ));
+    // series
+    await db.seriesDao.upsert(SeriesTableCompanion.insert(
+      id: 'sr1',
+      externalId: 'tmdb:1',
+      name: 'Foundation',
+      mediaType: 'book',
+      source: 'manual',
+      updatedAt: 1,
+    ));
+    // sync_log
+    await db.syncLogDao.insertLog(SyncLogTableCompanion.insert(
+      id: 'log1',
+      entityType: 'media_item',
+      entityId: 'm1',
+      operation: 'insert',
+      payloadJson: '{}',
+      createdAt: 1,
+    ));
+  }
+
+  Future<int> count(String table) async {
+    final rows = await db
+        .customSelect('SELECT COUNT(*) AS c FROM $table')
+        .get();
+    return rows.first.data['c'] as int;
+  }
+
+  test('seed populates every relevant table', () async {
+    await seedAll();
+    expect(await count('media_items'), 1);
+    expect(await count('tags'), 1);
+    expect(await count('media_item_tags'), 1);
+    expect(await count('shelves'), 1);
+    expect(await count('shelf_items'), 1);
+    expect(await count('borrowers'), 1);
+    expect(await count('loans'), 1);
+    expect(await count('locations'), 1);
+    expect(await count('series'), 1);
+    expect(await count('sync_log'), 1);
+  });
+
+  test('wipeSyncedUserData clears every synced table', () async {
+    await seedAll();
+    await db.wipeSyncedUserData();
+    expect(await count('media_items'), 0);
+    expect(await count('tags'), 0);
+    expect(await count('media_item_tags'), 0);
+    expect(await count('shelves'), 0);
+    expect(await count('shelf_items'), 0);
+    expect(await count('borrowers'), 0);
+    expect(await count('loans'), 0);
+    expect(await count('locations'), 0);
+    expect(await count('series'), 0);
+    expect(await count('sync_log'), 0);
+  });
+
+  test('wipeSyncedUserData leaves non-synced tables alone', () async {
+    // Seed a barcode_cache row — strictly local, must survive a reset.
+    await db.customStatement(
+      'INSERT INTO barcode_cache (barcode, response_json, source_api, '
+      "cached_at) VALUES ('999', '{}', 'tmdb', 1)",
+    );
+    await db.wipeSyncedUserData();
+    expect(await count('barcode_cache'), 1);
+  });
+}

--- a/test/unit/data/repositories/media_item_repository_impl_test.dart
+++ b/test/unit/data/repositories/media_item_repository_impl_test.dart
@@ -89,4 +89,78 @@ void main() {
     final m = await repo.findByTitleYear('Foo', 2000);
     expect(m, isEmpty);
   });
+
+  group('watchAll tagIds filter (cluster-7 MED-2 regression)', () {
+    Future<void> seedTag(String id, String name) async {
+      await db.tagsDao.insertTag(TagsTableCompanion.insert(
+        id: id,
+        name: name,
+        updatedAt: 1,
+      ));
+    }
+
+    Future<void> assign(String tagId, String mediaItemId) async {
+      await db.tagsDao.assignToMediaItem(tagId, mediaItemId);
+    }
+
+    test('null/empty tagIds returns every non-deleted row', () async {
+      await repo.save(baseItem(id: 'a'));
+      await repo.save(baseItem(id: 'b'));
+      final all = await repo.watchAll().first;
+      expect(all.map((e) => e.id).toSet(), {'a', 'b'});
+      final allEmpty = await repo.watchAll(tagIds: const []).first;
+      expect(allEmpty.map((e) => e.id).toSet(), {'a', 'b'});
+    });
+
+    test('single tag matches only assigned rows', () async {
+      await repo.save(baseItem(id: 'a'));
+      await repo.save(baseItem(id: 'b'));
+      await repo.save(baseItem(id: 'c'));
+      await seedTag('t1', 'Sci-Fi');
+      await assign('t1', 'a');
+      await assign('t1', 'c');
+
+      final filtered = await repo.watchAll(tagIds: const ['t1']).first;
+      expect(filtered.map((e) => e.id).toSet(), {'a', 'c'});
+    });
+
+    test('multiple tagIds is a UNION (any match)', () async {
+      await repo.save(baseItem(id: 'a'));
+      await repo.save(baseItem(id: 'b'));
+      await repo.save(baseItem(id: 'c'));
+      await seedTag('t1', 'A');
+      await seedTag('t2', 'B');
+      await assign('t1', 'a');
+      await assign('t2', 'b');
+
+      final filtered =
+          await repo.watchAll(tagIds: const ['t1', 't2']).first;
+      expect(filtered.map((e) => e.id).toSet(), {'a', 'b'});
+    });
+
+    test('tagIds combined with mediaType narrows correctly', () async {
+      await repo.save(baseItem(id: 'a').copyWith(mediaType: MediaType.book));
+      await repo.save(baseItem(id: 'b').copyWith(mediaType: MediaType.film));
+      await seedTag('t1', 'Fav');
+      await assign('t1', 'a');
+      await assign('t1', 'b');
+
+      final books = await repo
+          .watchAll(mediaType: MediaType.book, tagIds: const ['t1'])
+          .first;
+      expect(books.map((e) => e.id).toSet(), {'a'});
+    });
+
+    test('tagIds with FTS searchQuery still applies tag filter', () async {
+      await repo.save(baseItem(id: 'a').copyWith(title: 'Dune'));
+      await repo.save(baseItem(id: 'b').copyWith(title: 'Dune Messiah'));
+      await seedTag('t1', 'Owned');
+      await assign('t1', 'b');
+
+      final filtered = await repo
+          .watchAll(searchQuery: 'Dune', tagIds: const ['t1'])
+          .first;
+      expect(filtered.map((e) => e.id).toSet(), {'b'});
+    });
+  });
 }

--- a/test/unit/data/repositories/sync_repository_pull_lww_test.dart
+++ b/test/unit/data/repositories/sync_repository_pull_lww_test.dart
@@ -1,0 +1,204 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/remote/sync/postgres_sync_client.dart';
+import 'package:mymediascanner/data/repositories/sync_repository_impl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockSyncClient extends Mock implements PostgresSyncClient {}
+
+/// Cluster-7 HIGH-1b regression: `pullChanges` previously only fetched
+/// `media_items`. Successfully pushed tag/shelf/borrower/loan/location/
+/// series rows on one device never round-tripped to other devices. The
+/// fix adds a last-write-wins pull for those tables. These tests pin
+/// the upsert + LWW comparison behaviour without needing a live Postgres.
+void main() {
+  late AppDatabase db;
+  late _MockSyncClient client;
+  late SyncRepositoryImpl repo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    client = _MockSyncClient();
+    repo = SyncRepositoryImpl(
+      mediaItemsDao: db.mediaItemsDao,
+      syncLogDao: db.syncLogDao,
+      syncClient: client,
+    );
+
+    // Default stubs — every table empty unless overridden.
+    when(() => client.pullRecords(any(),
+            afterTimestamp: any(named: 'afterTimestamp')))
+        .thenAnswer((_) async => <Map<String, dynamic>>[]);
+  });
+
+  tearDown(() async {
+    await repo.dispose();
+    await db.close();
+  });
+
+  test('pullChanges inserts new tag from remote', () async {
+    when(() => client.pullRecords('tags',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 't-remote',
+          'name': 'Remote',
+          'colour': '#abcdef',
+          'updated_at': 100,
+          'deleted': 0,
+        }
+      ],
+    );
+
+    await repo.pullChanges();
+
+    final row = await db.tagsDao.getById('t-remote');
+    expect(row, isNotNull);
+    expect(row!.name, 'Remote');
+    expect(row.colour, '#abcdef');
+    expect(row.updatedAt, 100);
+  });
+
+  test('pullChanges keeps newer local tag when remote is older', () async {
+    // Local: updated_at=200
+    await db.tagsDao.insertTag(TagsTableCompanion.insert(
+      id: 't1',
+      name: 'Local',
+      colour: const Value('#111111'),
+      updatedAt: 200,
+    ));
+    // Remote: updated_at=100 (older). Should not overwrite.
+    when(() => client.pullRecords('tags',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 't1',
+          'name': 'Remote',
+          'colour': '#222222',
+          'updated_at': 100,
+          'deleted': 0,
+        }
+      ],
+    );
+
+    await repo.pullChanges();
+
+    final row = await db.tagsDao.getById('t1');
+    expect(row!.name, 'Local');
+    expect(row.colour, '#111111');
+  });
+
+  test('pullChanges overwrites local tag when remote is newer', () async {
+    await db.tagsDao.insertTag(TagsTableCompanion.insert(
+      id: 't1',
+      name: 'Local',
+      colour: const Value('#111111'),
+      updatedAt: 100,
+    ));
+    when(() => client.pullRecords('tags',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 't1',
+          'name': 'Remote',
+          'colour': '#222222',
+          'updated_at': 200,
+          'deleted': 0,
+        }
+      ],
+    );
+
+    await repo.pullChanges();
+
+    final row = await db.tagsDao.getById('t1');
+    expect(row!.name, 'Remote');
+    expect(row.colour, '#222222');
+  });
+
+  test('pullChanges inserts shelf, borrower, loan, location, series',
+      () async {
+    when(() => client.pullRecords('shelves',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 's1',
+          'name': 'Wishlist',
+          'description': null,
+          'sort_order': 0,
+          'updated_at': 1,
+          'deleted': 0,
+        }
+      ],
+    );
+    when(() => client.pullRecords('borrowers',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 'b1',
+          'name': 'Alice',
+          'email': null,
+          'phone': null,
+          'notes': null,
+          'updated_at': 1,
+          'deleted': 0,
+        }
+      ],
+    );
+    when(() => client.pullRecords('loans',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 'ln1',
+          'media_item_id': 'm1',
+          'borrower_id': 'b1',
+          'lent_at': 1,
+          'returned_at': null,
+          'due_at': null,
+          'notes': null,
+          'updated_at': 1,
+          'deleted': 0,
+        }
+      ],
+    );
+    when(() => client.pullRecords('locations',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 'l1',
+          'parent_id': null,
+          'name': 'Lounge',
+          'sort_order': 0,
+          'updated_at': 1,
+          'deleted': 0,
+        }
+      ],
+    );
+    when(() => client.pullRecords('series',
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => [
+        {
+          'id': 'sr1',
+          'external_id': 'tmdb:1',
+          'name': 'Foundation',
+          'media_type': 'book',
+          'source': 'manual',
+          'total_count': null,
+          'updated_at': 1,
+          'deleted': 0,
+        }
+      ],
+    );
+
+    await repo.pullChanges();
+
+    expect((await db.shelvesDao.getById('s1'))!.name, 'Wishlist');
+    expect((await db.borrowersDao.getById('b1'))!.name, 'Alice');
+    expect((await db.loansDao.getById('ln1'))!.borrowerId, 'b1');
+    expect((await db.locationsDao.getById('l1'))!.name, 'Lounge');
+    expect((await db.seriesDao.getById('sr1'))!.externalId, 'tmdb:1');
+  });
+}

--- a/test/unit/data/sync/postgres_sync_client_test.dart
+++ b/test/unit/data/sync/postgres_sync_client_test.dart
@@ -128,6 +128,33 @@ void main() {
       expect(result.params.length, 153);
     });
 
+    group('tableForEntityType (cluster-7 HIGH-1 regression)', () {
+      test('regular plurals resolve correctly', () {
+        expect(PostgresSyncClient.tableForEntityType('media_item'),
+            'media_items');
+        expect(PostgresSyncClient.tableForEntityType('tag'), 'tags');
+        expect(PostgresSyncClient.tableForEntityType('borrower'), 'borrowers');
+        expect(PostgresSyncClient.tableForEntityType('loan'), 'loans');
+        expect(
+            PostgresSyncClient.tableForEntityType('location'), 'locations');
+      });
+
+      test('shelf maps to shelves, not shelfs', () {
+        expect(PostgresSyncClient.tableForEntityType('shelf'), 'shelves');
+      });
+
+      test('series maps to series, not seriess', () {
+        expect(PostgresSyncClient.tableForEntityType('series'), 'series');
+      });
+
+      test('unknown entity types throw ArgumentError', () {
+        expect(
+          () => PostgresSyncClient.tableForEntityType('mystery'),
+          throwsA(isA<ArgumentError>()),
+        );
+      });
+    });
+
     test('buildBatchUpsertSql with single column record (only id)', () {
       final records = [
         {'id': '1'},


### PR DESCRIPTION
## Summary

Five issues from a post-merge review of sync + persistence, all confirmed against the code:

- **HIGH 1 — non-media entities couldn't sync.** `'${entityType}s'` pluralisation broke `shelf` → `shelfs` and `series` → `seriess` (rejected by the allow-list); `location` reached Postgres but the remote table didn't exist. Pull only fetched `media_items`, so even successfully pushed tag/borrower/loan rows never round-tripped to other devices. Fix: explicit `PostgresSyncClient.tableForEntityType` map, migration `006_locations_series_tables.sql` creating the missing remote tables, and a last-write-wins `_pullLastWriteWins` over the six non-media entities.
- **HIGH 2 — local writes weren't atomic with `sync_log`.** Every repo (media_item, shelf, tag, borrower, loan, location, series) wrote the row then logged separately. A crash between the two left the mutation permanently invisible to `pushChanges` (which only iterates pending log rows). Fix: wrap save/update/softDelete in `dao.transaction(() async { ... })` across all seven repos.
- **HIGH 3 — `resetLocalDatabase` was a partial reset.** Only `media_items` and `sync_log` were cleared, leaving shelves, tags, joins, borrowers, loans, locations, series populated. Fix: new `AppDatabase.wipeSyncedUserData()` deletes every synced table in one transaction; non-synced tables (rip library, batch sessions, barcode cache) are deliberately left alone.
- **MEDIUM 4 — `tagIds` was silently dropped.** `IMediaItemRepository.watchAll` declared the parameter but the implementation never used it. Fix: thread it through `MediaItemsDao.watchAll` via `existsQuery` against `media_item_tags`; FTS path applies the filter in-memory.
- **MEDIUM 5 — FTS hard-delete trigger could corrupt the index.** v18 added the `deleted = 0` guard to insert and update triggers but missed the delete trigger. `resetLocalDatabase` walked previously-soft-deleted rows that were never indexed, issuing FTS deletes for unknown rowids and corrupting the external-content shadow tables (reproduced as `database disk image is malformed`). Fix: schema v19 drops and recreates the trigger with the guard.

## Test plan

- [x] `flutter analyze` — clean
- [x] `flutter test` — 1321 pass (1316 existing + 5 new)
- [x] TDD: new `fts_hard_delete_unindexed_test.dart` reproduces the FTS corruption before the fix and passes after
- [x] New `wipe_synced_user_data_test.dart` covers the cleared/preserved tables
- [x] New `sync_repository_pull_lww_test.dart` covers insert / older-remote / newer-remote / multi-table for the LWW pull
- [x] New tests in `media_item_repository_impl_test.dart` cover the tagIds filter (single, multiple, with mediaType, with FTS)
- [x] New tests in `postgres_sync_client_test.dart` lock in the irregular plurals (`shelf` → `shelves`, `series` → `series`)
- [ ] Apply migration 006 to the running self-hosted Postgres before the next sync from a client carrying location/series sync_log entries