### PR TITLE
feat(tmdb): TMDB account sync — slice 3b (mobile UI)

### DIFF
--- a/docs/superpowers/plans/2026-04-28-tmdb-account-sync-slice-3b-mobile.md
+++ b/docs/superpowers/plans/2026-04-28-tmdb-account-sync-slice-3b-mobile.md
@@ -1,0 +1,486 @@
+# TMDB Account Sync — Slice 3b (Mobile UI) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the TMDB Account Sync feature usable from Android and iOS by un-gating the settings card and adding a Settings-screen tile group that routes to the existing bucket views and the resolve-conflicts screen.
+
+**Architecture:** Reuse all existing widgets (TmdbAccountSyncSection, TmdbConnectDialog, TmdbImportDialog, TmdbDisconnectWarningDialog, TmdbBucketScreen, TmdbResolveConflictsScreen) by removing the desktop early-return on the settings card and adding a new `TmdbListsSection` widget that exposes the bucket-view routes via `ListTile` entries. No new providers, no platform code, no new packages.
+
+**Tech Stack:** Flutter, Riverpod 3 (existing providers), GoRouter (existing routes).
+
+**Source spec:** `docs/superpowers/specs/2026-04-28-tmdb-account-sync-slice-3b-mobile-design.md`
+
+---
+
+## File Layout
+
+### Create
+
+| Path | Responsibility |
+|---|---|
+| `lib/presentation/screens/settings/widgets/tmdb_lists_section.dart` | Section with three bucket-view tiles + conditional Resolve-Conflicts tile, gated on `isConnected`. |
+| `test/widget/screens/settings/widgets/tmdb_lists_section_test.dart` | Widget tests for the four states (disconnected / connected / conflicts-with-ask-user / conflicts-without-ask-user). |
+
+### Modify
+
+| Path | Change |
+|---|---|
+| `lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart` | Remove the `if (!PlatformCapability.isDesktop) return SizedBox.shrink()` early-return at the top of `build`. The API-key gate stays. |
+| `lib/presentation/screens/settings/settings_screen.dart` | Append `TmdbListsSection()` to the API Integrations group children list, after `TmdbAccountSyncSection()`. |
+| `test/widget/screens/settings/widgets/tmdb_account_sync_section_test.dart` (if exists) | Remove any test setup that forced desktop-mode for rendering — render now happens cross-platform. If no such test exists, no change. |
+
+---
+
+## Convention notes
+
+- Widget tests use `ProviderScope(overrides: [...])` to inject mock providers, following the slice-A `TmdbConnectDialog` test pattern.
+- Routes are `/tmdb/watchlist`, `/tmdb/rated`, `/tmdb/favourites`, `/tmdb/conflicts` — registered in slice A and slice 2.
+- Tile labels use British English (`Favourites`, `TMDB Favourites`).
+
+---
+
+## Task 1: Create `TmdbListsSection` with widget test
+
+**Files:**
+- Create: `lib/presentation/screens/settings/widgets/tmdb_lists_section.dart`
+- Create: `test/widget/screens/settings/widgets/tmdb_lists_section_test.dart`
+
+- [ ] **Step 1: Write the failing widget test**
+
+Create `test/widget/screens/settings/widgets/tmdb_lists_section_test.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/domain/entities/tmdb_bridge_item.dart';
+import 'package:mymediascanner/domain/entities/tmdb_conflict_policy.dart';
+import 'package:mymediascanner/domain/entities/tmdb_connection_state.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+import 'package:mymediascanner/presentation/providers/tmdb_account_sync_provider.dart';
+import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_lists_section.dart';
+
+void main() {
+  Widget _harness({
+    required TmdbConnectionState connection,
+    required TmdbAccountSyncSettings settings,
+    List<TmdbBridgeItem> conflicts = const [],
+  }) {
+    return ProviderScope(
+      overrides: [
+        tmdbAccountConnectionProvider.overrideWith(
+            () => _StubConnectionNotifier(connection)),
+        tmdbAccountSyncSettingsProvider.overrideWith(
+            () => _StubSettingsNotifier(settings)),
+        tmdbConflictedRowsProvider.overrideWith((ref) =>
+            Stream<List<TmdbBridgeItem>>.value(conflicts)),
+      ],
+      child: MaterialApp.router(
+        routerConfig: GoRouter(
+          initialLocation: '/',
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) => const Scaffold(
+                  body: SafeArea(child: TmdbListsSection())),
+            ),
+            GoRoute(
+                path: '/tmdb/watchlist',
+                builder: (_, _) => const Scaffold(body: Text('Watchlist'))),
+            GoRoute(
+                path: '/tmdb/rated',
+                builder: (_, _) => const Scaffold(body: Text('Rated'))),
+            GoRoute(
+                path: '/tmdb/favourites',
+                builder: (_, _) => const Scaffold(body: Text('Favourites'))),
+            GoRoute(
+                path: '/tmdb/conflicts',
+                builder: (_, _) => const Scaffold(body: Text('Conflicts'))),
+          ],
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders nothing when disconnected', (tester) async {
+    await tester.pumpWidget(_harness(
+      connection: const TmdbDisconnected(),
+      settings: const TmdbAccountSyncSettings(),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('TMDB Watchlist'), findsNothing);
+    expect(find.text('TMDB Rated'), findsNothing);
+    expect(find.text('TMDB Favourites'), findsNothing);
+  });
+
+  testWidgets('renders three tiles when connected', (tester) async {
+    await tester.pumpWidget(_harness(
+      connection: const TmdbConnected(accountId: 1, username: 'p'),
+      settings: const TmdbAccountSyncSettings(),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('TMDB Watchlist'), findsOneWidget);
+    expect(find.text('TMDB Rated'), findsOneWidget);
+    expect(find.text('TMDB Favourites'), findsOneWidget);
+    expect(find.textContaining('Resolve Conflicts'), findsNothing);
+  });
+
+  testWidgets('shows Resolve Conflicts tile under ask-user policy with conflicts',
+      (tester) async {
+    final conflict = TmdbBridgeItem(
+      id: 'br-1',
+      tmdbId: 100,
+      mediaType: 'movie',
+    );
+    await tester.pumpWidget(_harness(
+      connection: const TmdbConnected(accountId: 1, username: 'p'),
+      settings: const TmdbAccountSyncSettings(
+        conflictPolicy: TmdbConflictPolicy.askUser,
+      ),
+      conflicts: [conflict],
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Resolve Conflicts (1)'), findsOneWidget);
+  });
+
+  testWidgets(
+      'hides Resolve Conflicts tile when policy is not askUser even if conflicts exist',
+      (tester) async {
+    final conflict = TmdbBridgeItem(
+      id: 'br-1',
+      tmdbId: 100,
+      mediaType: 'movie',
+    );
+    await tester.pumpWidget(_harness(
+      connection: const TmdbConnected(accountId: 1, username: 'p'),
+      settings: const TmdbAccountSyncSettings(
+        conflictPolicy: TmdbConflictPolicy.preferLatestTimestamp,
+      ),
+      conflicts: [conflict],
+    ));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Resolve Conflicts'), findsNothing);
+  });
+}
+
+class _StubConnectionNotifier extends TmdbAccountConnectionNotifier {
+  _StubConnectionNotifier(this._initial);
+  final TmdbConnectionState _initial;
+  @override
+  Future<TmdbConnectionState> build() async => _initial;
+}
+
+class _StubSettingsNotifier extends TmdbAccountSyncSettingsNotifier {
+  _StubSettingsNotifier(this._initial);
+  final TmdbAccountSyncSettings _initial;
+  @override
+  TmdbAccountSyncSettings build() => _initial;
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `flutter test test/widget/screens/settings/widgets/tmdb_lists_section_test.dart`
+Expected: FAIL — `TmdbListsSection` does not exist.
+
+- [ ] **Step 3: Implement `TmdbListsSection`**
+
+Create `lib/presentation/screens/settings/widgets/tmdb_lists_section.dart`:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/domain/entities/tmdb_conflict_policy.dart';
+import 'package:mymediascanner/domain/entities/tmdb_connection_state.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+import 'package:mymediascanner/presentation/providers/tmdb_account_sync_provider.dart';
+
+/// TMDB-account list entries surfaced in the Settings screen.
+///
+/// Renders three route tiles (Watchlist / Rated / Favourites) when
+/// connected, plus a fourth Resolve-Conflicts tile when the user has
+/// chosen the ask-user conflict policy and there are conflicts pending.
+///
+/// Cross-platform: this is the mobile entry point for the bucket views,
+/// and on desktop it complements the existing sidebar entries.
+class TmdbListsSection extends ConsumerWidget {
+  const TmdbListsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connectionAsync = ref.watch(tmdbAccountConnectionProvider);
+    final isConnected = connectionAsync.value is TmdbConnected;
+    if (!isConnected) return const SizedBox.shrink();
+
+    final settings = ref.watch(tmdbAccountSyncSettingsProvider);
+    final conflictsCount = ref.watch(tmdbConflictedRowsProvider).maybeWhen(
+          data: (rows) => rows.length,
+          orElse: () => 0,
+        );
+    final showConflicts =
+        settings.conflictPolicy == TmdbConflictPolicy.askUser &&
+            conflictsCount > 0;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text('TMDB Lists',
+                  style: Theme.of(context).textTheme.titleMedium),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.bookmark_border),
+            title: const Text('TMDB Watchlist'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () =>
+                GoRouter.of(context).go('/tmdb/watchlist'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.star_border),
+            title: const Text('TMDB Rated'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () =>
+                GoRouter.of(context).go('/tmdb/rated'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.favorite_border),
+            title: const Text('TMDB Favourites'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () =>
+                GoRouter.of(context).go('/tmdb/favourites'),
+          ),
+          if (showConflicts)
+            ListTile(
+              leading: Icon(Icons.warning_amber,
+                  color: Theme.of(context).colorScheme.error),
+              title: Text('Resolve Conflicts ($conflictsCount)'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () =>
+                  GoRouter.of(context).go('/tmdb/conflicts'),
+            ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `flutter test test/widget/screens/settings/widgets/tmdb_lists_section_test.dart`
+Expected: 4/4 pass.
+
+- [ ] **Step 5: Run analyzer**
+
+Run: `flutter analyze lib/presentation/screens/settings/widgets/tmdb_lists_section.dart test/widget/screens/settings/widgets/tmdb_lists_section_test.dart`
+Expected: zero issues.
+
+- [ ] **Step 6: Commit**
+
+Verify branch is `feat/tmdb-account-sync-slice-3b-mobile` via `git branch --show-current`.
+
+```bash
+git add lib/presentation/screens/settings/widgets/tmdb_lists_section.dart \
+        test/widget/screens/settings/widgets/tmdb_lists_section_test.dart
+git commit -m "feat(tmdb-sync): add TmdbListsSection with route tiles for buckets and conflicts"
+```
+
+Verify `git rev-parse feat/tmdb-account-sync-slice-3b-mobile` == `git rev-parse HEAD`.
+
+---
+
+## Task 2: Remove desktop early-return from TmdbAccountSyncSection
+
+**Files:**
+- Modify: `lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart`
+- Modify (if exists): existing widget test for `TmdbAccountSyncSection`
+
+- [ ] **Step 1: Investigate the existing card**
+
+Read `lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart`. The first lines of `TmdbAccountSyncSection.build` should look like:
+
+```dart
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  if (!PlatformCapability.isDesktop) return const SizedBox.shrink();
+
+  final tmdbKey = (ref.watch(apiKeysProvider).value ?? {})['tmdb'] ?? '';
+  if (tmdbKey.trim().isEmpty) return const SizedBox.shrink();
+  // ...
+```
+
+The first guard is the desktop early-return. The second is the API-key gate (we keep this).
+
+Also check whether `PlatformCapability` is still used elsewhere in the file. If the only use site is the line we're removing, remove the import too.
+
+- [ ] **Step 2: Remove the desktop early-return**
+
+Edit `lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart`:
+
+Find:
+```dart
+if (!PlatformCapability.isDesktop) return const SizedBox.shrink();
+```
+
+Delete this line (and any trailing blank line that becomes orphaned).
+
+If `PlatformCapability` is no longer referenced anywhere in the file, also delete its import:
+
+```dart
+import 'package:mymediascanner/core/utils/platform_utils.dart';
+```
+
+If `PlatformCapability` is still used elsewhere in the file (e.g., to gate something else), keep the import.
+
+- [ ] **Step 3: Check for an existing widget test that assumes desktop-only rendering**
+
+Run: `find test/widget -name "tmdb_account_sync_section*" -print`
+
+If no such test exists, no further test-file changes are needed.
+
+If a test exists, read it. If it forces desktop mode (e.g., via a `PlatformCapability` override or by skipping non-desktop runs), either:
+- Remove the platform override so the test exercises the now-cross-platform behaviour, OR
+- Replace the desktop-specific assertion with a generic one.
+
+Apply whichever change keeps the test meaningful. If the existing test is hostile to the removal (e.g. tightly coupled to `SizedBox.shrink()` on mobile), update the assertion to verify the card now renders on mobile too:
+
+```dart
+testWidgets('renders the card regardless of platform', (tester) async {
+  // ... existing harness setup with provider overrides ...
+  await tester.pumpWidget(harness);
+  await tester.pumpAndSettle();
+  expect(find.text('TMDB Account Sync'), findsOneWidget);
+});
+```
+
+- [ ] **Step 4: Run analyzer**
+
+Run: `flutter analyze lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart`
+Expected: zero issues.
+
+If the analyzer flags `unused_import` for `platform_utils.dart`, delete the import (this means `PlatformCapability` was only used in the line we removed).
+
+- [ ] **Step 5: Run the section's tests (if any)**
+
+Run: `flutter test test/widget/screens/settings/widgets/tmdb_account_sync_section_test.dart`
+Expected: PASS (if such a test exists). If the file doesn't exist, skip.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart
+# Only add the test file if it was modified.
+git commit -m "feat(tmdb-sync): un-gate TmdbAccountSyncSection for mobile"
+```
+
+Verify branch + HEAD match.
+
+---
+
+## Task 3: Embed TmdbListsSection in the settings screen
+
+**Files:**
+- Modify: `lib/presentation/screens/settings/settings_screen.dart`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `lib/presentation/screens/settings/settings_screen.dart`, alongside the existing `tmdb_account_sync_section.dart` import, add:
+
+```dart
+import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_lists_section.dart';
+```
+
+- [ ] **Step 2: Add the section to the API Integrations children list**
+
+Find the API Integrations group's `children:` list. Slice A landed it as:
+
+```dart
+children: const [ApiKeyForm(), TmdbAccountSyncSection()],
+```
+
+Change to:
+
+```dart
+children: const [
+  ApiKeyForm(),
+  TmdbAccountSyncSection(),
+  TmdbListsSection(),
+],
+```
+
+The `const` qualifier may need to drop if any of the children become non-const through future edits — for now they're all const-constructible so the literal stays.
+
+- [ ] **Step 3: Run analyzer**
+
+Run: `flutter analyze lib/presentation/screens/settings/settings_screen.dart`
+Expected: zero issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/presentation/screens/settings/settings_screen.dart
+git commit -m "feat(tmdb-sync): embed TmdbListsSection in settings screen"
+```
+
+Verify branch + HEAD match.
+
+---
+
+## Task 4: Final verification
+
+**Files:** none
+
+- [ ] **Step 1: Run analyzer on the entire codebase**
+
+Run: `flutter analyze`
+Expected: zero issues.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `flutter test`
+Expected: 1368+ tests pass (slice 2 baseline + 4 new from `TmdbListsSection`).
+
+- [ ] **Step 3: Linux build**
+
+Run: `flutter build linux --debug`
+Expected: build succeeds.
+
+- [ ] **Step 4: Android build**
+
+Run: `flutter build apk --debug --flavor dev`
+Expected: build succeeds.
+
+- [ ] **Step 5: iOS / macOS** (skip on Linux host with a note)
+
+- [ ] **Step 6: Manual inspection**
+
+1. `lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart` no longer has the `if (!PlatformCapability.isDesktop) return ...` line.
+2. `lib/presentation/screens/settings/widgets/tmdb_lists_section.dart` exists with three route tiles + conditional fourth.
+3. `lib/presentation/screens/settings/settings_screen.dart` includes `TmdbListsSection()` after `TmdbAccountSyncSection()` in the API Integrations children list.
+4. The desktop sidebar TMDB group from slice A still renders (sanity — `app_scaffold.dart` unchanged in this slice).
+
+- [ ] **Step 7: Final report**
+
+Branch: `feat/tmdb-account-sync-slice-3b-mobile`
+HEAD: `<SHA>`
+Total commits since main: `<git rev-list --count main..HEAD>`
+Test results: `<count> passing`
+Linux build: `<PASS/FAIL>`
+Android build: `<PASS/FAIL>`
+Manual inspection: `<PASS/FAIL>`
+
+---
+
+## Self-review
+
+- **Spec coverage:** Each in-scope item from the spec maps to a task. Card un-gating (Task 2), `TmdbListsSection` (Task 1), settings embedding (Task 3), final verification (Task 4). The dialog-rendering verification in the spec is covered by Task 4's manual inspection step (the dialogs don't change code-wise; they just inherit from Material 3's adaptive rendering once the card is reachable).
+- **Placeholder scan:** No "TBD"/"TODO" markers. Task 2 has a conditional path for the existing widget test depending on whether one exists — this is intentional; the implementer needs to inspect first. The instructions are concrete in both branches.
+- **Type consistency:** `TmdbConnectionState`, `TmdbAccountSyncSettings`, `TmdbConflictPolicy`, `TmdbBridgeItem`, `tmdbAccountConnectionProvider`, `tmdbAccountSyncSettingsProvider`, `tmdbConflictedRowsProvider` are all used consistently with the names established in slices A and 2.
+- **Routing:** `/tmdb/watchlist`, `/tmdb/rated`, `/tmdb/favourites`, `/tmdb/conflicts` — all four routes are registered (slice A added the first three, slice 2 added the fourth). No router changes needed in slice 3b.

--- a/docs/superpowers/specs/2026-04-28-tmdb-account-sync-slice-3b-mobile-design.md
+++ b/docs/superpowers/specs/2026-04-28-tmdb-account-sync-slice-3b-mobile-design.md
@@ -1,0 +1,216 @@
+# Design: TMDB Account Sync — Slice 3b (mobile UI)
+
+**Status:** Approved (brainstorm 2026-04-28)
+**Author:** Paul Snow
+**Created:** 2026-04-28
+**Implements:** Mobile UI surfaces for the TMDB Account Sync feature originally scoped in `docs/superpowers/plans/2026-04-28-tmdb-account-sync.md`. Builds on slice A (PR #70) and slice 2 (PR #71).
+**Target platforms:** Android, iOS — same widget code as desktop, with new mobile entry points.
+
+---
+
+## Scope
+
+Most TMDB account-sync UI surfaces are already cross-platform: `TmdbBridgeBadge` on collection grid covers, `TmdbBridgeBadge` strip on item-detail, `TmdbAccountControlsSection` on item-detail, and `TmdbAccountPanel` on metadata-confirm all render on iOS/Android because they're gated only on `accountSyncEnabled`, never on `PlatformCapability.isDesktop`.
+
+The remaining gap is **how a mobile user reaches the connection-management UI and the bucket views**. Slice A/2 routed those through:
+- `TmdbAccountSyncSection` (settings card) — desktop early-returned via `if (!PlatformCapability.isDesktop) return SizedBox.shrink()`.
+- Three bucket views accessed via desktop sidebar entries.
+- Resolve-conflicts screen accessed via conditional desktop sidebar entry.
+
+Slice 3b ungates the settings card and adds Settings-screen entry points for the bucket views and resolve-conflicts screen. Sidebar entries on desktop remain — they coexist with the settings tiles.
+
+### In scope
+
+1. Remove the desktop-only early-return from `TmdbAccountSyncSection`. The card now renders on all platforms when a TMDB API key is configured (the existing API-key gate stays).
+2. New `TmdbListsSection` widget — three tiles routing to existing bucket screens (`/tmdb/watchlist`, `/tmdb/rated`, `/tmdb/favourites`) + a conditional fourth tile for the resolve-conflicts route when `policy == askUser && conflicts > 0`.
+3. Embed `TmdbListsSection` in `settings_screen.dart`'s API Integrations group, immediately below the existing `TmdbAccountSyncSection`.
+4. Verify the existing `TmdbConnectDialog`, `TmdbImportDialog`, and `TmdbDisconnectWarningDialog` (all `AlertDialog` widgets) render correctly on small mobile screens. Material 3 dialogs are responsive — no widget changes expected.
+5. Update any widget tests that previously assumed desktop-only rendering of `TmdbAccountSyncSection`.
+6. Add a widget test for `TmdbListsSection` covering: empty (not connected), connected (three tiles), and conflicts-with-ask-user (four tiles).
+
+### Out of scope (deferred)
+
+- Custom URL scheme / Universal Links / App Links for post-approval auto-return on mobile. The slice-A/2 manual continue button still works.
+- Mobile-specific reskins of the dialogs.
+- Reorganising the bottom navigation bar.
+- Mobile-specific TMDB account icon set or branding.
+
+---
+
+## Architecture
+
+No new platform code, no new packages, no new providers. The full set of changes:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                     Settings screen                              │
+│                                                                  │
+│   API Integrations                                               │
+│   ├─ ApiKeyForm (existing)                                       │
+│   ├─ TmdbAccountSyncSection (existing — desktop gate REMOVED)    │
+│   └─ TmdbListsSection (NEW) — bucket entry tiles                 │
+└──────────────────────────────────────────────────────────────────┘
+            │                                          │
+            ▼                                          ▼
+┌────────────────────────┐                  ┌────────────────────────┐
+│ TmdbConnectDialog      │                  │ TmdbBucketScreen       │
+│ TmdbImportDialog       │                  │ TmdbResolveConflicts   │
+│ TmdbDisconnectWarning  │                  │   Screen               │
+│ (existing AlertDialog) │                  │ (existing — already    │
+│ — render on mobile     │                  │   mobile-aware via     │
+│ via Material 3)        │                  │   conditional AppBar)  │
+└────────────────────────┘                  └────────────────────────┘
+```
+
+The existing slice-A `TmdbBucketScreen` already conditionally renders `ScreenHeader` on desktop and `AppBar` on mobile (slice-A Task 16 fix). The slice-2 `TmdbResolveConflictsScreen` does the same. Both work on mobile out of the box once a mobile entry point exists.
+
+### TmdbListsSection layout
+
+Visible only when `connectionAsync.value is TmdbConnected`. Title row "TMDB Lists" + three `ListTile`s (icon + label + arrow), each tapping to `GoRouter.of(context).go(...)`:
+
+| Tile | Icon | Route |
+|---|---|---|
+| TMDB Watchlist | `Icons.bookmark_border` | `/tmdb/watchlist` |
+| TMDB Rated | `Icons.star_border` | `/tmdb/rated` |
+| TMDB Favourites | `Icons.favorite_border` | `/tmdb/favourites` |
+| Resolve Conflicts (N) | `Icons.warning_amber` | `/tmdb/conflicts` |
+
+The fourth tile renders only when:
+- `settings.conflictPolicy == TmdbConflictPolicy.askUser`
+- AND `tmdbConflictedRowsProvider` data list is non-empty
+
+The label includes the count parenthetical, mirroring the desktop sidebar pattern.
+
+### Settings card un-gate
+
+In `TmdbAccountSyncSection.build`, the first line is currently:
+
+```dart
+if (!PlatformCapability.isDesktop) return const SizedBox.shrink();
+```
+
+Remove this. The card now renders on any platform where the next gate (API key configured) is satisfied:
+
+```dart
+final tmdbKey = (ref.watch(apiKeysProvider).value ?? {})['tmdb'] ?? '';
+if (tmdbKey.trim().isEmpty) return const SizedBox.shrink();
+```
+
+The remainder of the build method is platform-agnostic Material widgets — no further changes needed.
+
+### Desktop coexistence
+
+On desktop, the Settings card AND the desktop sidebar TMDB group both surface the bucket views. Tapping either route reaches the same `TmdbBucketScreen` instance via the shell branch. The sidebar gives quick top-level navigation; the settings tiles give a self-contained entry point that doesn't depend on the sidebar being expanded. Both useful on desktop; only the settings tiles work on mobile.
+
+### Mobile UX flow
+
+```
+Open app on mobile (e.g. Android)
+  ↓
+Bottom-nav: Library / Scan / Insights / etc.
+  ↓
+(Settings is reached via Library → AppBar overflow → "Settings", or via the existing settings route — same as today)
+  ↓
+Settings screen
+  ↓
+Scroll to "API Integrations" section
+  ↓
+TMDB Account Sync card (now renders on mobile)
+  ├─ Status: Disconnected → Connect button
+  ├─ Connect dialog opens (AlertDialog), user approves in browser, taps Continue
+  ├─ Status: Connected as @user
+  ├─ Toggles, conflict-policy radio, last-sync, etc.
+  ├─ Buttons: Import account contents, Sync TMDB now
+  ↓
+TMDB Lists section
+  ├─ TMDB Watchlist → tap → /tmdb/watchlist (TmdbBucketScreen with mobile AppBar)
+  ├─ TMDB Rated → tap → /tmdb/rated
+  ├─ TMDB Favourites → tap → /tmdb/favourites
+  └─ Resolve Conflicts (3) → tap → /tmdb/conflicts (only when ask-user policy + conflicts)
+```
+
+---
+
+## Test changes
+
+### Updated tests
+
+- Any existing widget test for `TmdbAccountSyncSection` that wrapped the test in a desktop-mode override now needs to be replaced with a generic test (no platform override needed) OR have the override kept for the desktop-specific behaviour.
+- Search the test tree for `TmdbAccountSyncSection` to find any.
+
+### New widget test
+
+`test/widget/screens/settings/widgets/tmdb_lists_section_test.dart` covering:
+
+- **Disconnected state** — section renders nothing (or a minimal "Connect TMDB to see lists" hint, matching the empty-state pattern of other settings sub-sections).
+- **Connected state** — three tiles visible (Watchlist / Rated / Favourites). Tapping each invokes router with the right route.
+- **Conflicts-with-ask-user** — fourth tile visible with the count.
+- **Conflicts-but-no-ask-user-policy** — fourth tile NOT visible.
+
+---
+
+## Files
+
+### Create (2)
+
+- `lib/presentation/screens/settings/widgets/tmdb_lists_section.dart` — the new section widget.
+- `test/widget/screens/settings/widgets/tmdb_lists_section_test.dart` — widget test.
+
+### Modify (~2)
+
+- `lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart` — remove the `if (!PlatformCapability.isDesktop) return SizedBox.shrink()` line. No other changes; the rest of the card is already responsive.
+- `lib/presentation/screens/settings/settings_screen.dart` — append `TmdbListsSection()` to the API Integrations group children list, after `TmdbAccountSyncSection()`.
+
+That's it. Slice 3b is genuinely small — most of the work was done by enforcing cross-platform discipline in slices A and 2.
+
+---
+
+## Mobile readiness — verification checklist
+
+After implementation:
+
+- `flutter build apk --debug --flavor dev` succeeds.
+- `flutter build ios --no-codesign` succeeds (or pending if Linux-only host).
+- Manual on-device run of Android emulator: settings card renders, connect dialog opens, after manual approval the user reaches Connected state.
+- Manual on-device run of Android: TMDB Lists tiles route to bucket screens. The bucket screens' AppBar shows on mobile (slice-A behaviour).
+- `TmdbAccountControlsSection` on item-detail still works (cross-platform from slice 2).
+- `TmdbAccountPanel` on metadata-confirm still works (cross-platform from slice A).
+- `TmdbBridgeBadge` overlays on collection grid still work (cross-platform from slice A).
+
+---
+
+## Acceptance criteria
+
+- An Android user with the TMDB API key configured can:
+  - See the TMDB Account Sync card in Settings.
+  - Connect a TMDB account via the manual continue dialog.
+  - Run the import and sync flows.
+  - Navigate to the three bucket views via the new TMDB Lists tiles.
+  - Disconnect (with the warning dialog if dirty rows exist).
+- All existing tests still pass.
+- New widget test for `TmdbListsSection` covers the four states.
+- `flutter analyze` clean.
+- iOS and Android compile builds succeed.
+- No new platform plugins, no manifest changes, no new packages.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Settings card looks cramped on a narrow (360dp) phone screen | Standard Material 3 widgets are responsive. If specific overflow shows up during manual testing, address with `Wrap` for action button rows or single-column SwitchListTile arrangement. The existing card already uses `Wrap` for action buttons. |
+| Mobile users find the manual continue dialog clunky | Documented as out of scope. Future polish slice can add custom URL scheme / app links if friction becomes a complaint. |
+| Bucket-view branch routing fails when navigated from Settings on mobile (vs sidebar on desktop) | `GoRouter.go('/tmdb/watchlist')` is a top-level route call — works the same regardless of source. Will verify in widget test. |
+| Widget tests over-mock and miss the platform-conditional rendering | New widget test for `TmdbListsSection` runs without any platform override and verifies behaviour by provider state, not platform. |
+
+---
+
+## Implementation order (high level — detailed plan in writing-plans output)
+
+1. Create `TmdbListsSection` widget.
+2. Write its widget test (TDD).
+3. Remove the desktop early-return in `TmdbAccountSyncSection`.
+4. Embed `TmdbListsSection` in `settings_screen.dart`.
+5. Update any existing widget tests that assumed desktop-only `TmdbAccountSyncSection` rendering.
+6. Final verification: `flutter analyze`, full test suite, Android + Linux builds.

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -13,6 +13,7 @@ import 'package:mymediascanner/presentation/providers/replay_gain_provider.dart'
 import 'package:mymediascanner/presentation/screens/settings/widgets/api_key_form.dart';
 import 'package:mymediascanner/presentation/screens/settings/widgets/gnudb_settings_section.dart';
 import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_account_sync_section.dart';
+import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_lists_section.dart';
 import 'package:mymediascanner/presentation/providers/settings_provider.dart';
 import 'package:mymediascanner/presentation/screens/settings/widgets/sync_status_tile.dart';
 import 'package:mymediascanner/presentation/widgets/screen_header.dart';
@@ -70,7 +71,11 @@ class SettingsScreen extends ConsumerWidget {
             title: 'API Integrations',
             colors: colors,
             theme: theme,
-            children: const [ApiKeyForm(), TmdbAccountSyncSection()],
+            children: const [
+              ApiKeyForm(),
+              TmdbAccountSyncSection(),
+              TmdbListsSection(),
+            ],
           ),
           const SizedBox(height: 16),
 

--- a/lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart
+++ b/lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:mymediascanner/core/utils/platform_utils.dart';
 import 'package:mymediascanner/domain/entities/tmdb_connection_state.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/settings_provider.dart';
@@ -10,14 +9,12 @@ import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_connec
 import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_disconnect_warning_dialog.dart';
 import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_import_dialog.dart';
 
-/// Settings card for TMDB account sync. Desktop only.
+/// Settings card for TMDB account sync.
 class TmdbAccountSyncSection extends ConsumerWidget {
   const TmdbAccountSyncSection({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    if (!PlatformCapability.isDesktop) return const SizedBox.shrink();
-
     final tmdbKey = (ref.watch(apiKeysProvider).value ?? {})['tmdb'] ?? '';
     if (tmdbKey.trim().isEmpty) return const SizedBox.shrink();
 

--- a/lib/presentation/screens/settings/widgets/tmdb_lists_section.dart
+++ b/lib/presentation/screens/settings/widgets/tmdb_lists_section.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/domain/entities/tmdb_conflict_policy.dart';
+import 'package:mymediascanner/domain/entities/tmdb_connection_state.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+import 'package:mymediascanner/presentation/providers/tmdb_account_sync_provider.dart';
+
+/// TMDB-account list entries surfaced in the Settings screen.
+///
+/// Renders three route tiles (Watchlist / Rated / Favourites) when
+/// connected, plus a fourth Resolve-Conflicts tile when the user has
+/// chosen the ask-user conflict policy and there are conflicts pending.
+///
+/// Cross-platform: this is the mobile entry point for the bucket views,
+/// and on desktop it complements the existing sidebar entries.
+class TmdbListsSection extends ConsumerWidget {
+  const TmdbListsSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final connectionAsync = ref.watch(tmdbAccountConnectionProvider);
+    final isConnected = connectionAsync.value is TmdbConnected;
+    if (!isConnected) return const SizedBox.shrink();
+
+    final settings = ref.watch(tmdbAccountSyncSettingsProvider);
+    final conflictsCount = ref.watch(tmdbConflictedRowsProvider).maybeWhen(
+          data: (rows) => rows.length,
+          orElse: () => 0,
+        );
+    final showConflicts =
+        settings.conflictPolicy == TmdbConflictPolicy.askUser &&
+            conflictsCount > 0;
+
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text('TMDB Lists',
+                  style: Theme.of(context).textTheme.titleMedium),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.bookmark_border),
+            title: const Text('TMDB Watchlist'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => GoRouter.of(context).go('/tmdb/watchlist'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.star_border),
+            title: const Text('TMDB Rated'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => GoRouter.of(context).go('/tmdb/rated'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.favorite_border),
+            title: const Text('TMDB Favourites'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () => GoRouter.of(context).go('/tmdb/favourites'),
+          ),
+          if (showConflicts)
+            ListTile(
+              leading: Icon(Icons.warning_amber,
+                  color: Theme.of(context).colorScheme.error),
+              title: Text('Resolve Conflicts ($conflictsCount)'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => GoRouter.of(context).go('/tmdb/conflicts'),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/widget/screens/settings/widgets/tmdb_lists_section_test.dart
+++ b/test/widget/screens/settings/widgets/tmdb_lists_section_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/domain/entities/tmdb_bridge_item.dart';
+import 'package:mymediascanner/domain/entities/tmdb_conflict_policy.dart';
+import 'package:mymediascanner/domain/entities/tmdb_connection_state.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+import 'package:mymediascanner/presentation/providers/tmdb_account_sync_provider.dart';
+import 'package:mymediascanner/presentation/screens/settings/widgets/tmdb_lists_section.dart';
+
+Widget harness({
+  required TmdbConnectionState connection,
+  required TmdbAccountSyncSettings settings,
+  List<TmdbBridgeItem> conflicts = const [],
+}) {
+  return ProviderScope(
+    overrides: [
+      tmdbAccountConnectionProvider.overrideWith(
+          () => _StubConnectionNotifier(connection)),
+      tmdbAccountSyncSettingsProvider.overrideWith(
+          () => _StubSettingsNotifier(settings)),
+      tmdbConflictedRowsProvider.overrideWith(
+          (ref) => Stream<List<TmdbBridgeItem>>.value(conflicts)),
+    ],
+    child: MaterialApp.router(
+      routerConfig: GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) =>
+                const Scaffold(body: SafeArea(child: TmdbListsSection())),
+          ),
+          GoRoute(
+              path: '/tmdb/watchlist',
+              builder: (context, state) =>
+                  const Scaffold(body: Text('Watchlist'))),
+          GoRoute(
+              path: '/tmdb/rated',
+              builder: (context, state) =>
+                  const Scaffold(body: Text('Rated'))),
+          GoRoute(
+              path: '/tmdb/favourites',
+              builder: (context, state) =>
+                  const Scaffold(body: Text('Favourites'))),
+          GoRoute(
+              path: '/tmdb/conflicts',
+              builder: (context, state) =>
+                  const Scaffold(body: Text('Conflicts'))),
+        ],
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders nothing when disconnected', (tester) async {
+    await tester.pumpWidget(harness(
+      connection: const TmdbDisconnected(),
+      settings: const TmdbAccountSyncSettings(),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('TMDB Watchlist'), findsNothing);
+    expect(find.text('TMDB Rated'), findsNothing);
+    expect(find.text('TMDB Favourites'), findsNothing);
+  });
+
+  testWidgets('renders three tiles when connected', (tester) async {
+    await tester.pumpWidget(harness(
+      connection: const TmdbConnected(accountId: 1, username: 'p'),
+      settings: const TmdbAccountSyncSettings(),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('TMDB Watchlist'), findsOneWidget);
+    expect(find.text('TMDB Rated'), findsOneWidget);
+    expect(find.text('TMDB Favourites'), findsOneWidget);
+    expect(find.textContaining('Resolve Conflicts'), findsNothing);
+  });
+
+  testWidgets(
+      'shows Resolve Conflicts tile under ask-user policy with conflicts',
+      (tester) async {
+    const conflict = TmdbBridgeItem(
+      id: 'br-1',
+      tmdbId: 100,
+      mediaType: 'movie',
+    );
+    await tester.pumpWidget(harness(
+      connection: const TmdbConnected(accountId: 1, username: 'p'),
+      settings: const TmdbAccountSyncSettings(
+        conflictPolicy: TmdbConflictPolicy.askUser,
+      ),
+      conflicts: [conflict],
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('Resolve Conflicts (1)'), findsOneWidget);
+  });
+
+  testWidgets(
+      'hides Resolve Conflicts tile when policy is not askUser even if conflicts exist',
+      (tester) async {
+    const conflict = TmdbBridgeItem(
+      id: 'br-1',
+      tmdbId: 100,
+      mediaType: 'movie',
+    );
+    await tester.pumpWidget(harness(
+      connection: const TmdbConnected(accountId: 1, username: 'p'),
+      settings: const TmdbAccountSyncSettings(
+        conflictPolicy: TmdbConflictPolicy.preferLatestTimestamp,
+      ),
+      conflicts: [conflict],
+    ));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('Resolve Conflicts'), findsNothing);
+  });
+}
+
+class _StubConnectionNotifier extends TmdbAccountConnectionNotifier {
+  _StubConnectionNotifier(this._initial);
+  final TmdbConnectionState _initial;
+  @override
+  Future<TmdbConnectionState> build() async => _initial;
+}
+
+class _StubSettingsNotifier extends TmdbAccountSyncSettingsNotifier {
+  _StubSettingsNotifier(this._initial);
+  final TmdbAccountSyncSettings _initial;
+  @override
+  TmdbAccountSyncSettings build() => _initial;
+}


### PR DESCRIPTION
Builds on slice A (#70) and slice 2 (#71). Makes the TMDB Account Sync feature usable from Android and iOS by exposing it through the existing Settings screen.

## Summary

Slice 3b is small because the cross-platform discipline of slices A and 2 left only the connection-management surfaces gated to desktop. This PR removes that gate and adds a Settings-screen tile group that routes mobile users to the existing bucket views.

- **`TmdbAccountSyncSection`** — desktop early-return removed. The card now renders on any platform when a TMDB API key is configured (the API-key gate stays).
- **New `TmdbListsSection`** — three route tiles (TMDB Watchlist / Rated / Favourites) + a conditional fourth tile (Resolve Conflicts (N)) when the user has chosen the ask-user conflict policy and there are conflicts pending. Visible whenever the user is connected.
- **Embedded in Settings** — `TmdbListsSection()` lives directly below the existing `TmdbAccountSyncSection()` in the API Integrations group, so mobile users find both in one place.
- **Desktop sidebar entries** — unchanged. Both the sidebar and the new settings tiles route to the same screens. They coexist and complement each other on desktop.

The cross-platform widgets from slices A and 2 (`TmdbBridgeBadge` overlay on collection grid, item-detail strip and controls section, metadata-confirm panel) already render on iOS/Android — they were never desktop-gated.

## What's NOT in this PR

- Custom URL schemes / Universal Links / App Links for post-approval auto-return on mobile. The slice-A/2 manual continue button still works on mobile via the same `AlertDialog`. Deferred until friction is observed.
- Mobile-specific dialog reskinning. Material 3 `AlertDialog` is responsive enough.
- Bottom-nav reorganisation.
- Anything else from the original PRD's deferred list (remote-first save, TV mirror via TMDB v4, custom-list management, background sync, auto-remove-from-mirror).

## Test plan

- [x] All 1372 tests pass (slice 2 baseline 1368 + 4 new `TmdbListsSection` tests covering disconnected / connected / conflicts-with-ask-user / conflicts-without-ask-user states).
- [x] `flutter analyze` zero issues.
- [x] Linux debug build succeeds.
- [x] Android debug build succeeds.
- [ ] iOS / macOS builds — pending verification on macOS host.
- [ ] Manual smoke test on Android emulator: open Settings → see TMDB Account Sync card → tap Connect → manual continue dialog works → connected state → tap "TMDB Watchlist" tile → bucket screen renders with mobile AppBar.

## References

- Slice A merged via #70.
- Slice 2 merged via #71.
- Slice 3b design: `docs/superpowers/specs/2026-04-28-tmdb-account-sync-slice-3b-mobile-design.md`
- Slice 3b plan: `docs/superpowers/plans/2026-04-28-tmdb-account-sync-slice-3b-mobile.md`