### PR TITLE
docs: TMDB account sync user guide

### DIFF
--- a/src/docs/modules/ROOT/nav.adoc
+++ b/src/docs/modules/ROOT/nav.adoc
@@ -21,6 +21,7 @@
 ** xref:progress.adoc[Reading and Watching Progress]
 ** xref:recommendations.adoc[Recommendations Engine]
 ** xref:wishlist.adoc[Wishlist and Suggestions]
+** xref:tmdb-account-sync.adoc[TMDB Account Sync]
 ** xref:static-export.adoc[Static HTML Export]
 * xref:api-configuration.adoc[API Configuration]
 * xref:integrations.adoc[Metadata Integrations]

--- a/src/docs/modules/ROOT/pages/api-configuration.adoc
+++ b/src/docs/modules/ROOT/pages/api-configuration.adoc
@@ -69,6 +69,10 @@ The built-in `RateLimitAwareClient` enforces the ~1 req/s guideline so you will 
 
 TMDB:: Create a free account at https://www.themoviedb.org/, then go to *Settings > API* and request a Developer API key. The v3 auth token is used.
 
+NOTE: The TMDB API key enables metadata lookups (title search, cover art, cast information).
+It is separate from the optional TMDB account connection that powers rating, watchlist, and favourite sync.
+See xref:tmdb-account-sync.adoc[TMDB Account Sync] for details on linking your TMDB account once the API key is in place.
+
 Discogs:: Registration is optional. If you want Discogs as a music fallback, register at https://www.discogs.com/settings/developers and generate a personal access token. OAuth is not required.
 
 UPCitemdb:: Sign up at https://www.upcitemdb.com/ and copy the trial or paid API key from your dashboard.

--- a/src/docs/modules/ROOT/pages/integrations.adoc
+++ b/src/docs/modules/ROOT/pages/integrations.adoc
@@ -230,6 +230,13 @@ Standard scanning use is well within limits.
   If the barcode belongs to a specific season box set, the description may reflect the overall series rather than the season.
   Edit the item's metadata manually after saving.
 
+==== TMDB Account Sync
+
+In addition to metadata lookup, MyMediaScanner can connect to your personal TMDB account to import ratings, watchlist entries, and favourites, and optionally push local changes back to TMDB.
+This is an optional, opt-in feature that operates independently of your metadata API key and of PostgreSQL sync.
+
+See xref:tmdb-account-sync.adoc[TMDB Account Sync] for a full setup and usage guide.
+
 ---
 
 [#imdb-id-scanning]

--- a/src/docs/modules/ROOT/pages/sync-strategy.adoc
+++ b/src/docs/modules/ROOT/pages/sync-strategy.adoc
@@ -6,6 +6,10 @@ MyMediaScanner can optionally sync collection data to a self-hosted PostgreSQL d
 The sync engine connects directly from the Dart client using the `postgres` package — there is no intermediary API or proxy service.
 All sync operations are performed over TLS by default.
 
+NOTE: This page describes *PostgreSQL replication* — the engine that copies your local SQLite collection to a self-hosted database server.
+If you are looking for information on syncing ratings, watchlists, and favourites with your themoviedb.org account, see xref:tmdb-account-sync.adoc[TMDB Account Sync] instead.
+The two systems are independent and do not interact.
+
 NOTE: Sync is entirely optional.
 The application works fully offline without any PostgreSQL configuration.
 

--- a/src/docs/modules/ROOT/pages/tmdb-account-sync.adoc
+++ b/src/docs/modules/ROOT/pages/tmdb-account-sync.adoc
@@ -1,0 +1,287 @@
+= TMDB Account Sync
+include::_attributes.adoc[]
+:description: Connect your TMDB account to import ratings, watchlist, and favourites, and push edits back to TMDB.
+
+TMDB Account Sync is an optional feature that links MyMediaScanner to your personal themoviedb.org account.
+Once connected, the app can pull your existing ratings, watchlist entries, and favourites from TMDB and display them alongside your local collection.
+When two-way sync is enabled, changes you make in MyMediaScanner — ratings, watchlist toggles, favourite toggles — are pushed back to your TMDB account immediately.
+
+NOTE: TMDB Account Sync is entirely separate from xref:sync-strategy.adoc[PostgreSQL Sync].
+The two systems do not interact; you can use either, both, or neither independently.
+
+== When to Use This Feature
+
+Use TMDB Account Sync if you:
+
+* Already have a TMDB account with an established ratings history or watchlist and want that data to appear in MyMediaScanner without re-entering it.
+* Want rating, watchlist, and favourite changes you make in MyMediaScanner to be reflected on TMDB automatically.
+* Would like to mirror your physical ownership of movies to a private TMDB list so other TMDB-aware services can see what you own.
+* Scan or save movies and TV shows and want to see at a glance whether you have already rated or watchlisted that title on TMDB.
+
+The feature covers film and TV items only.
+Music, books, games, and other media types are not synchronised to TMDB.
+
+== Prerequisites
+
+. *TMDB API key* — Account Sync requires a working TMDB API key to already be configured.
+  If you have not yet set up your TMDB API key, see xref:api-configuration.adoc[API Configuration] first.
+  The metadata API key and the account connection are separate: the key enables metadata lookups; the account connection enables rating and watchlist sync.
+. *TMDB account* — A free TMDB account at `https://www.themoviedb.org/`.
+  No paid subscription is required.
+
+== Connecting Your TMDB Account
+
+. Open *Settings* from the desktop sidebar or, on mobile, from the bottom navigation bar.
+. Scroll to the *API Integrations* section.
+. Find the *TMDB Account Sync* card.
+. Tap *Connect*.
+. A dialog appears explaining the authorisation flow.
+   The app will open `themoviedb.org` in your browser.
+. In the browser, sign in to your TMDB account (if not already signed in) and approve the connection request.
+. Return to MyMediaScanner and tap *I've approved it — continue*.
+. The card updates to show *Connected as @username*.
+
+After connecting, the app prompts you to import your existing TMDB account contents.
+You can run the import immediately or skip it and run it later from the settings card.
+
+TIP: The approval step uses a manual continue button so that you can take as long as you need in the browser.
+The app does not time out waiting for you to tap continue.
+
+== Importing Existing TMDB Content
+
+The import dialog lets you choose which buckets to pull from your TMDB account.
+Six options are available as individual checkboxes:
+
+[cols="1,3", options="header"]
+|===
+| Bucket | What is imported
+
+| Rated movies
+| All movies you have rated on TMDB.
+
+| Rated TV
+| All TV series you have rated on TMDB.
+
+| Watchlist movies
+| All movies on your TMDB watchlist.
+
+| Watchlist TV
+| All TV series on your TMDB watchlist.
+
+| Favourite movies
+| All movies marked as a favourite on TMDB.
+
+| Favourite TV
+| All TV series marked as a favourite on TMDB.
+|===
+
+Tick the buckets you want and tap *Import*.
+The app fetches all pages from each selected bucket and creates bridge rows for each title.
+
+IMPORTANT: Imported items appear as bridge-only rows — they are *not* added to your main collection grid.
+They appear exclusively in the TMDB Lists views (TMDB Watchlist, TMDB Rated, TMDB Favourites) described in <<_tmdb_lists_views>>.
+To add an item to your main collection, use the *Convert to local item* action on any row in those views.
+
+After the initial import, you can refresh the data at any time by tapping *Sync TMDB now* on the settings card.
+This runs the same six-bucket pull and removes any bridge rows whose titles are no longer in your TMDB account.
+
+== Two-Way Sync
+
+Two-way sync allows MyMediaScanner to push changes back to your TMDB account when you edit a film or TV item.
+
+The *Push local changes to TMDB* toggle appears on the TMDB Account Sync settings card once you are connected.
+It is on by default.
+Turn it off if you want read-only behaviour — pulling from TMDB but never writing back.
+
+When two-way sync is on, the following changes push to TMDB immediately:
+
+* Rating changes on any movie or TV item that has a TMDB ID.
+* Watchlist toggle on the item-detail screen or in the TMDB Watchlist view.
+* Favourite toggle on the item-detail screen or in the TMDB Lists views.
+
+If a push fails (for example because of a temporary network error), the row is flagged internally and a count of pending changes appears on the settings card.
+Tap *Push pending now* to retry all flagged rows.
+
+If a push fails because the session has expired (HTTP 401), the card shows a *Session expired — reconnect* message.
+Reconnect using the same *Connect* flow described above.
+
+NOTE: TMDB ratings use a 0.5–10 scale.
+MyMediaScanner stores ratings on a 0–5 scale and converts automatically (pull: `local = tmdb / 2`; push: `tmdb = local × 2`).
+The raw TMDB value is retained internally so no precision is lost.
+
+== Mirror Ownership to a TMDB List
+
+The *Mirror ownership to TMDB list (movies only)* toggle appears on the settings card once you are connected.
+It is off by default.
+
+When turned on, every movie in your local collection that has a TMDB ID is added to a private TMDB list named *MyMediaScanner*.
+The list is created automatically on the first addition if it does not already exist; if a list with that name already exists in your TMDB account, it is reused.
+
+Ownership mirroring applies to movies only.
+TMDB v3 list endpoints support movies exclusively — TV series ownership cannot be mirrored by this mechanism.
+
+When you mark a film as owned (for example by scanning a Blu-ray or tapping *Mark as Owned* in the TMDB Watchlist view), the app adds it to the mirror list.
+When a movie is removed from your collection, it is removed from the list.
+
+== Conflict Policy
+
+A conflict arises when both the local value and the TMDB value for the same field (such as a rating) have changed since the last sync.
+The conflict policy controls how the app resolves these situations during a pull.
+
+Open *Settings → API Integrations → TMDB Account Sync* and look for the *Conflict policy* control.
+Four options are available:
+
+Prefer latest timestamp (default)::
+Whichever side has the more recent change wins automatically.
+No user interaction is needed.
+
+Prefer local::
+The local MyMediaScanner value always wins.
+TMDB changes are ignored if a local change exists.
+
+Prefer TMDB::
+The TMDB value always wins.
+Local changes are overwritten by whatever TMDB holds.
+
+Ask me each time::
+Conflicted rows are staged and not applied automatically.
+The <<_resolve_conflicts_screen>> becomes accessible and lists all rows awaiting your decision.
+
+== TMDB Lists Views
+
+Three dedicated views surface the content imported from your TMDB account:
+
+* *TMDB Watchlist* — movies and TV series on your TMDB watchlist.
+* *TMDB Rated* — movies and TV series you have rated on TMDB.
+* *TMDB Favourites* — movies and TV series you have marked as a favourite on TMDB.
+
+On desktop, these appear as entries in the sidebar under a *TMDB* group when your account is connected.
+
+On mobile, navigate to *Settings → API Integrations → TMDB Account Sync* and scroll down.
+A *TMDB Lists* section provides tiles for each of the three views.
+
+=== Rows and Actions
+
+Each row in a TMDB Lists view shows:
+
+* Poster thumbnail.
+* Title and media type.
+* TMDB rating (if rated).
+
+Available actions on every row:
+
+Open on TMDB::
+Opens the title's page on `themoviedb.org` in your browser.
+
+Convert to local item::
+Creates a full `media_items` record from the bridge row, adding the title to your main collection.
+
+Additional actions available in the *TMDB Watchlist* view only:
+
+Mark as owned::
+Combines three steps in a single action: converts the bridge row to a local item, removes the title from your TMDB watchlist, and adds it to the MyMediaScanner mirror list (if the mirror toggle is on).
+Use this after you have physically acquired an item that was previously only on your wishlist.
+
+Remove from TMDB watchlist::
+Removes the title from your TMDB watchlist without converting it to a local item.
+
+== Resolve Conflicts Screen
+
+The Resolve Conflicts screen is visible only when the conflict policy is set to *Ask me each time* and there are unresolved conflicts waiting.
+
+On desktop it appears as an entry in the TMDB sidebar group.
+On mobile it appears as a tile below the TMDB Lists tiles in *Settings → API Integrations → TMDB Account Sync*, but only when there are pending conflicts.
+
+Each row on the screen shows the conflicted title with two options:
+
+Keep mine::
+Applies the local MyMediaScanner value and pushes it to TMDB (if two-way sync is on).
+
+Use TMDB::
+Overwrites the local value with the TMDB value.
+
+After all conflicts are resolved the screen disappears from the sidebar (desktop) and the tile disappears from Settings (mobile).
+
+== Per-Item Indicators
+
+Regardless of platform, items that have a linked bridge row display additional information on various screens.
+
+*Item-detail screen* — Any movie or TV item with a TMDB ID shows a *TMDB Account* section when your account is connected.
+This section displays:
+
+* Your TMDB rating for the title (if any).
+* A watchlist toggle chip.
+* A favourite toggle chip.
+* A pending or retry indicator when a push is queued or has failed.
+
+*Collection grid* — A small TMDB badge overlays the cover art of any item that has a bridge row, so you can see at a glance which items are linked to your TMDB account.
+
+*Metadata-confirm screen* — After scanning a title that resolves to an existing bridge row, the confirmation screen shows the current TMDB account state (rating, watchlist, favourite) alongside the local metadata.
+
+== Disconnecting Safely
+
+Tap *Disconnect* on the TMDB Account Sync settings card.
+
+If there are pending changes that have not yet been pushed to TMDB, a warning dialog offers three choices:
+
+Push and disconnect::
+Pushes all pending changes to TMDB and then clears the session.
+
+Disconnect anyway::
+Clears the session without pushing the pending changes.
+Those changes are lost.
+
+Cancel::
+Returns to the settings card without disconnecting.
+
+After disconnecting, bridge rows are *preserved*.
+The TMDB Lists views become empty (the connection is gone) but the bridge data remains in the local database.
+If you reconnect in the future, the app merges the fresh pull with the preserved rows, and any items you converted to local items remain in your collection regardless.
+
+To remove the bridge rows permanently, disconnect and then use *Settings → Storage → Clear TMDB bridge data*.
+
+WARNING: Clearing bridge data cannot be undone.
+Any titles that existed only as bridge rows (never converted to local items) will be gone.
+
+== Troubleshooting
+
+=== The Connect button does not appear
+
+Account Sync requires a TMDB API key to be configured first.
+Check that *Settings → API Integrations → TMDB API Key* shows a masked key value (e.g. `••••••••ab3f`).
+If it is blank, add your key and save, then return to the TMDB Account Sync card.
+See xref:api-configuration.adoc[API Configuration] for setup instructions.
+
+=== The browser opened but I accidentally closed it before approving
+
+Tap *Connect* again to restart the flow.
+Each connect attempt requests a fresh approval token from TMDB; previous tokens are discarded.
+
+=== Status shows "Session expired"
+
+TMDB sessions do not expire on a fixed schedule, but certain account changes (such as a password reset or revoking app access from the TMDB website) invalidate the session.
+Tap *Connect* to authorise a new session.
+
+=== Ratings or watchlist changes are not appearing on TMDB
+
+. Check that the *Push local changes to TMDB* toggle is on.
+. Look for a *Push pending* count on the settings card.
+  If a number is shown, tap *Push pending now*.
+. If the status shows "Session expired", reconnect first.
+. Confirm your device has an active internet connection and can reach `https://api.themoviedb.org`.
+
+=== Import shows zero items
+
+Your TMDB account may genuinely have no content in the selected buckets.
+Log in to `https://www.themoviedb.org/` and check your ratings, watchlist, and favourites pages directly to confirm.
+
+=== Sync conflicts keep appearing even after resolving them
+
+If the conflict policy is set to *Ask me each time* and two-way sync is on, each pull can introduce new conflicts if both sides are being edited.
+Consider switching the policy to *Prefer latest timestamp* for less active accounts.
+
+== Related Pages
+
+* xref:api-configuration.adoc[API Configuration] — TMDB API key setup and secure storage details
+* xref:integrations.adoc[Metadata Integrations] — full guide to the TMDB metadata provider and all other external services
+* xref:sync-strategy.adoc[Sync Strategy] — PostgreSQL replication, which operates independently of TMDB Account Sync


### PR DESCRIPTION
Adds user-facing AsciiDoc documentation for the merged TMDB Account Sync slices (A: pull-only #70; 2: push + ownership mirror #71; 3b: mobile UI #72).

Slice 3a (remote-first save mode) is still in flight in PR #73 and is intentionally **not** covered here — its docs should be added in a follow-up commit once #73 merges (either as part of #73 itself, or in a small follow-up PR).

## What's new

**New page:** `src/docs/modules/ROOT/pages/tmdb-account-sync.adoc`

Sections:
1. Overview
2. When to use this feature
3. Prerequisites
4. Connecting your TMDB account
5. Importing existing TMDB content
6. Two-way sync
7. Mirror ownership to a TMDB list
8. Conflict policy
9. TMDB Lists views
10. Resolve Conflicts screen
11. Per-item indicators
12. Disconnecting safely
13. Troubleshooting
14. Related pages

## Cross-references added

- Nav: new entry under Features.
- `api-configuration.adoc`: callout near the TMDB key section pointing to the new page.
- `sync-strategy.adoc`: clarifying note that "sync" on that page means PostgreSQL replication, with cross-ref to TMDB account sync as a separate feature.
- `integrations.adoc`: new subsection under TMDB pointing to the new page.

## Verification

- `gradle21w antora` exit code 0 (clean build, no errors or warnings).
- All existing cross-references unchanged.

## Out of scope

- Slice 3a (remote-first save mode). To be documented after #73 merges.
- Future slices (TV mirror via TMDB v4, auto-remove from mirror on ownership change, background sync).