### PR TITLE
feat(tmdb): TMDB account sync — slice 4a (auto-remove from mirror)

### DIFF
--- a/docs/superpowers/plans/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror.md
+++ b/docs/superpowers/plans/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror.md
@@ -1,0 +1,698 @@
+# TMDB Account Sync — Slice 4a (Auto-Remove from Mirror) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hook `MediaItemRepositoryImpl.update()` and `softDelete()` to fire `MirrorOwnershipChangeUseCase.add` / `.remove` whenever a movie's ownership crosses the `owned` boundary, so the MyMediaScanner private TMDB list stays in sync with local ownership across all transition paths (not just initial saves).
+
+**Architecture:** Inject optional `MirrorOwnershipChangeUseCase` and a `bool Function() readMirrorEnabled` callback into `MediaItemRepositoryImpl` using the same nullable-DI pattern slice 2 used in `SaveMediaItemUseCase`. Pre-write read of the previous row, compare ownership, fire-and-forget mirror op when the gate passes. No new domain types, no schema migration, no UI.
+
+**Tech Stack:** Flutter, Riverpod 3, Drift (no schema changes), mocktail.
+
+**Source spec:** `docs/superpowers/specs/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror-design.md`
+
+---
+
+## File Layout
+
+### Modify
+
+| Path | Change |
+|---|---|
+| `lib/data/repositories/media_item_repository_impl.dart` | Add optional ctor params (`mirror`, `readMirrorEnabled`); add private `_maybeMirrorOnTransition` and `_maybeMirrorOnSoftDelete` helpers; hook `update()` and `softDelete()`. |
+| `lib/presentation/providers/repository_providers.dart` | Wire optional mirror + `readMirrorEnabled` into `mediaItemRepositoryProvider`, with try/catch for the case where TMDB API key isn't configured (matches slice-2 pattern). |
+| `test/unit/data/repositories/media_item_repository_impl_test.dart` | Add 9 test cases covering both hooks (transition detection, gates, no-ops). |
+| `src/docs/modules/ROOT/pages/tmdb-account-sync.adoc` | One-paragraph note in the *Mirror Ownership* section that ownership transitions on existing items now mirror automatically. |
+
+No new files. No schema migration.
+
+---
+
+## Convention notes
+
+- Mirror calls are fire-and-forget via `unawaited(...).catchError(...)`. The local write always completes regardless of mirror outcome. Errors land on the bridge row's `last_error` (slice 2 already implements this in `_mirrorMutate`).
+- The new ctor params are optional/nullable so existing test setups continue to work without changes — only tests that exercise the new hook supply them.
+- `extraMetadata['tmdb_id']` is stored as `int`. `extraMetadata['media_type']` was switched to `'movie'`/`'tv'` directly during slice 2 (commit `fc3fad4`); no normalisation needed.
+
+---
+
+## Task 1: Add optional ctor params + private helpers (no behaviour change)
+
+**Files:**
+- Modify: `lib/data/repositories/media_item_repository_impl.dart`
+
+This task adds the dependencies and helper methods without yet calling them from `update()` or `softDelete()`. Subsequent tasks wire the call sites with TDD per behaviour.
+
+- [ ] **Step 1: Add the imports**
+
+In `lib/data/repositories/media_item_repository_impl.dart`, add at the top alongside the existing imports:
+
+```dart
+import 'dart:async';
+
+import 'package:mymediascanner/domain/repositories/i_tmdb_account_sync_repository.dart';
+import 'package:mymediascanner/domain/usecases/mirror_ownership_change_usecase.dart';
+```
+
+The `dart:async` import is for `unawaited`. The other two cover `MirrorOwnershipChangeUseCase` and the `TmdbPushResult` type used by its return signature.
+
+- [ ] **Step 2: Add the optional ctor params**
+
+Change the constructor from:
+
+```dart
+class MediaItemRepositoryImpl implements IMediaItemRepository {
+  MediaItemRepositoryImpl({
+    required MediaItemsDao mediaItemsDao,
+    required SyncLogDao syncLogDao,
+  })  : _mediaItemsDao = mediaItemsDao,
+        _syncLogDao = syncLogDao;
+
+  final MediaItemsDao _mediaItemsDao;
+  final SyncLogDao _syncLogDao;
+  // ...
+}
+```
+
+to:
+
+```dart
+class MediaItemRepositoryImpl implements IMediaItemRepository {
+  MediaItemRepositoryImpl({
+    required MediaItemsDao mediaItemsDao,
+    required SyncLogDao syncLogDao,
+    MirrorOwnershipChangeUseCase? mirror,
+    bool Function()? readMirrorEnabled,
+  })  : _mediaItemsDao = mediaItemsDao,
+        _syncLogDao = syncLogDao,
+        _mirror = mirror,
+        _readMirrorEnabled = readMirrorEnabled;
+
+  final MediaItemsDao _mediaItemsDao;
+  final SyncLogDao _syncLogDao;
+  final MirrorOwnershipChangeUseCase? _mirror;
+  final bool Function()? _readMirrorEnabled;
+  // ...
+}
+```
+
+- [ ] **Step 3: Add the private helper methods**
+
+At the bottom of the class (before the closing brace), add:
+
+```dart
+/// Fires `mirror.add` or `mirror.remove` when the ownership state of
+/// a `media_items` row crosses the `owned` boundary. Gated on the
+/// mirror toggle, presence of a TMDB ID, and movie media type.
+///
+/// Fire-and-forget — failures land on the bridge row's `last_error`.
+void _maybeMirrorOnTransition(MediaItem? previous, MediaItem next) {
+  final mirror = _mirror;
+  final readEnabled = _readMirrorEnabled;
+  if (mirror == null || readEnabled == null) return;
+  if (!readEnabled()) return;
+
+  final wasOwned = previous?.ownershipStatus == OwnershipStatus.owned;
+  final isOwned = next.ownershipStatus == OwnershipStatus.owned;
+  if (wasOwned == isOwned) return; // no transition
+
+  final tmdbId = next.extraMetadata['tmdb_id'];
+  if (tmdbId is! int) return;
+  final mediaType = next.extraMetadata['media_type'];
+  if (mediaType != 'movie') return;
+
+  if (isOwned) {
+    unawaited(mirror.add(tmdbId: tmdbId).catchError((_) {
+      return const TmdbPushResult(success: false);
+    }));
+  } else {
+    unawaited(mirror.remove(tmdbId: tmdbId).catchError((_) {
+      return const TmdbPushResult(success: false);
+    }));
+  }
+}
+
+/// Fires `mirror.remove` when an owned movie is soft-deleted.
+void _maybeMirrorOnSoftDelete(MediaItem previous) {
+  final mirror = _mirror;
+  final readEnabled = _readMirrorEnabled;
+  if (mirror == null || readEnabled == null) return;
+  if (!readEnabled()) return;
+  if (previous.ownershipStatus != OwnershipStatus.owned) return;
+
+  final tmdbId = previous.extraMetadata['tmdb_id'];
+  if (tmdbId is! int) return;
+  final mediaType = previous.extraMetadata['media_type'];
+  if (mediaType != 'movie') return;
+
+  unawaited(mirror.remove(tmdbId: tmdbId).catchError((_) {
+    return const TmdbPushResult(success: false);
+  }));
+}
+```
+
+- [ ] **Step 4: Run analyzer**
+
+Run: `flutter analyze lib/data/repositories/media_item_repository_impl.dart`
+Expected: zero issues. The helpers are unused right now (Tasks 2 and 3 will call them) — Dart's analyzer doesn't flag unused private methods, so this is fine.
+
+If the analyzer flags `unused_element` for the helpers, that means a stricter lint is enabled. In that case add `// ignore: unused_element` above each helper for now; Tasks 2 and 3 will remove the suppression.
+
+- [ ] **Step 5: Run the existing repository tests to confirm no regression**
+
+Run: `flutter test test/unit/data/repositories/media_item_repository_impl_test.dart`
+Expected: all existing tests pass. The optional ctor params are nullable; existing tests don't supply them and skip the helpers entirely.
+
+- [ ] **Step 6: Commit**
+
+Verify branch is `feat/tmdb-account-sync-slice-4a-auto-remove-mirror` via `git branch --show-current`.
+
+```bash
+git add lib/data/repositories/media_item_repository_impl.dart
+git commit -m "feat(tmdb-sync): add optional mirror DI to MediaItemRepositoryImpl"
+```
+
+Verify `git rev-parse feat/tmdb-account-sync-slice-4a-auto-remove-mirror` == `git rev-parse HEAD`.
+
+---
+
+## Task 2: Hook `update()` with TDD
+
+**Files:**
+- Modify: `lib/data/repositories/media_item_repository_impl.dart`
+- Modify: `test/unit/data/repositories/media_item_repository_impl_test.dart`
+
+- [ ] **Step 1: Read the existing test file structure**
+
+Read `test/unit/data/repositories/media_item_repository_impl_test.dart` to understand its setup (in-memory `AppDatabase`, fixture builders for `MediaItem`, etc.). Mirror that style — don't re-invent setup helpers.
+
+- [ ] **Step 2: Write the failing tests for `update()`**
+
+Append these tests to the existing test file. They use `mocktail` (already a project dependency) for the mirror dep. If `mocktail` isn't already imported in this file, add the import.
+
+Add these imports at the top of the test file alongside the existing imports:
+
+```dart
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/domain/repositories/i_tmdb_account_sync_repository.dart';
+import 'package:mymediascanner/domain/usecases/mirror_ownership_change_usecase.dart';
+```
+
+Add a mock class near the top of the file (after the existing imports, before `void main()`):
+
+```dart
+class _MockMirror extends Mock implements MirrorOwnershipChangeUseCase {}
+```
+
+Append these tests inside the existing `void main()` block (in a new `group('mirror auto-remove hook', () { ... })`):
+
+```dart
+group('mirror auto-remove hook', () {
+  late _MockMirror mirror;
+  late bool mirrorEnabled;
+
+  setUp(() {
+    mirror = _MockMirror();
+    mirrorEnabled = true;
+    when(() => mirror.add(tmdbId: any(named: 'tmdbId'))).thenAnswer(
+        (_) async => const TmdbPushResult(success: true));
+    when(() => mirror.remove(tmdbId: any(named: 'tmdbId'))).thenAnswer(
+        (_) async => const TmdbPushResult(success: true));
+  });
+
+  MediaItemRepositoryImpl makeRepo() => MediaItemRepositoryImpl(
+        mediaItemsDao: db.mediaItemsDao,
+        syncLogDao: db.syncLogDao,
+        mirror: mirror,
+        readMirrorEnabled: () => mirrorEnabled,
+      );
+
+  MediaItem movieItem({
+    required String id,
+    required OwnershipStatus ownership,
+    int? tmdbId = 550,
+    String mediaType = 'movie',
+  }) {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return MediaItem(
+      id: id,
+      title: 'Fight Club',
+      mediaType: MediaType.film,
+      ownershipStatus: ownership,
+      barcode: '',
+      barcodeType: '',
+      extraMetadata: {
+        if (tmdbId != null) 'tmdb_id': tmdbId,
+        'media_type': mediaType,
+      },
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  test('update non-owned → owned fires mirror.add', () async {
+    final repo = makeRepo();
+    // Seed wishlist row.
+    final wishlist =
+        movieItem(id: 'a', ownership: OwnershipStatus.wishlist);
+    await db.mediaItemsDao.insertMediaItem(/* see existing test pattern */
+        // — adapt to whatever insertion helper the existing tests use.
+        // If the existing tests insert via `repo.upsert` or `dao.insertItem`,
+        // use that path here too.
+        );
+    // For a clean test surface, use the repository's own create path
+    // (whatever the existing tests use) so the row matches what the
+    // production code expects.
+
+    await repo.update(
+        movieItem(id: 'a', ownership: OwnershipStatus.owned));
+
+    verify(() => mirror.add(tmdbId: 550)).called(1);
+    verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+  });
+
+  test('update owned → not-owned fires mirror.remove', () async {
+    final repo = makeRepo();
+    // Seed owned row first.
+    await /* insert owned movieItem(id: 'b') via existing helper */;
+
+    await repo.update(
+        movieItem(id: 'b', ownership: OwnershipStatus.wishlist));
+
+    verify(() => mirror.remove(tmdbId: 550)).called(1);
+    verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+  });
+
+  test('update owned → owned (rating-only) does not fire mirror', () async {
+    final repo = makeRepo();
+    await /* insert owned movieItem(id: 'c') */;
+
+    final updated = movieItem(id: 'c', ownership: OwnershipStatus.owned)
+        .copyWith(userRating: 4.5);
+    await repo.update(updated);
+
+    verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+    verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+  });
+
+  test('update with mirror disabled does not fire mirror', () async {
+    mirrorEnabled = false;
+    final repo = makeRepo();
+    await /* insert wishlist movieItem(id: 'd') */;
+
+    await repo.update(
+        movieItem(id: 'd', ownership: OwnershipStatus.owned));
+
+    verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+  });
+
+  test('update non-owned → owned for TV does not fire mirror', () async {
+    final repo = makeRepo();
+    final tvItem = movieItem(
+      id: 'e',
+      ownership: OwnershipStatus.wishlist,
+      mediaType: 'tv',
+    );
+    await /* insert tvItem */;
+
+    await repo.update(tvItem.copyWith(
+        ownershipStatus: OwnershipStatus.owned));
+
+    verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+  });
+
+  test('update non-owned → owned without TMDB ID does not fire mirror',
+      () async {
+    final repo = makeRepo();
+    final noTmdb = movieItem(
+      id: 'f',
+      ownership: OwnershipStatus.wishlist,
+      tmdbId: null,
+    );
+    await /* insert noTmdb */;
+
+    await repo.update(noTmdb.copyWith(
+        ownershipStatus: OwnershipStatus.owned));
+
+    verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+  });
+});
+```
+
+The `/* insert ... */` placeholders need to be filled in with whatever insertion helper the existing test setup uses. Read the existing tests in this file to identify the pattern — likely `repo.upsert(item)` or `dao.insertItem(...)` or a top-level helper. Use the same pattern in the new tests.
+
+If the existing test file doesn't expose a clean way to insert a `MediaItem`, add a small private helper at the top of the new group:
+
+```dart
+Future<void> _seed(MediaItem item) async {
+  // Insert via DAO directly to bypass the repo's update hook (which
+  // is what we're testing). Adapt to the actual DAO insert method:
+  await db.mediaItemsDao.insertItem(/* MediaItemsTableCompanion shape */);
+}
+```
+
+- [ ] **Step 3: Run the new tests (will fail)**
+
+Run: `flutter test test/unit/data/repositories/media_item_repository_impl_test.dart --name "mirror auto-remove hook"`
+Expected: FAIL — `update()` doesn't yet call `_maybeMirrorOnTransition`.
+
+- [ ] **Step 4: Hook `update()` to call the helper**
+
+In `lib/data/repositories/media_item_repository_impl.dart`, find the `update()` method:
+
+```dart
+@override
+Future<void> update(MediaItem item) async {
+  await _mediaItemsDao.update(_toCompanion(item));
+  await _logSync('media_item', item.id, 'update', item);
+}
+```
+
+Wrap it with the previous-row read and the helper call:
+
+```dart
+@override
+Future<void> update(MediaItem item) async {
+  final previous = await getById(item.id);
+  await _mediaItemsDao.update(_toCompanion(item));
+  await _logSync('media_item', item.id, 'update', item);
+  _maybeMirrorOnTransition(previous, item);
+}
+```
+
+`getById` is the existing repository method (slice-A or earlier). Verify it returns `MediaItem?` (nullable when row missing).
+
+- [ ] **Step 5: Run the new tests**
+
+Run: `flutter test test/unit/data/repositories/media_item_repository_impl_test.dart --name "mirror auto-remove hook"`
+Expected: 6/6 of the new tests pass.
+
+- [ ] **Step 6: Run the full repository test file to confirm no regression**
+
+Run: `flutter test test/unit/data/repositories/media_item_repository_impl_test.dart`
+Expected: all tests pass (existing + new).
+
+- [ ] **Step 7: Run analyzer**
+
+Run: `flutter analyze lib/data/repositories/media_item_repository_impl.dart test/unit/data/repositories/media_item_repository_impl_test.dart`
+Expected: zero issues.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/data/repositories/media_item_repository_impl.dart \
+        test/unit/data/repositories/media_item_repository_impl_test.dart
+git commit -m "feat(tmdb-sync): hook update() to mirror ownership transitions"
+```
+
+Verify branch + HEAD match.
+
+---
+
+## Task 3: Hook `softDelete()` with TDD
+
+**Files:**
+- Modify: `lib/data/repositories/media_item_repository_impl.dart`
+- Modify: `test/unit/data/repositories/media_item_repository_impl_test.dart`
+
+- [ ] **Step 1: Append the soft-delete tests**
+
+Add these tests to the existing `mirror auto-remove hook` group in the test file (or create a new group `softDelete mirror hook` if you prefer — either works, the existing group is fine):
+
+```dart
+test('softDelete on owned movie fires mirror.remove', () async {
+  final repo = makeRepo();
+  await /* insert owned movieItem(id: 'g') */;
+
+  await repo.softDelete('g');
+
+  verify(() => mirror.remove(tmdbId: 550)).called(1);
+});
+
+test('softDelete on non-owned item does not fire mirror', () async {
+  final repo = makeRepo();
+  await /* insert wishlist movieItem(id: 'h') */;
+
+  await repo.softDelete('h');
+
+  verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+});
+
+test('softDelete on owned TV item does not fire mirror', () async {
+  final repo = makeRepo();
+  final tvOwned = movieItem(
+    id: 'i',
+    ownership: OwnershipStatus.owned,
+    mediaType: 'tv',
+  );
+  await /* insert tvOwned */;
+
+  await repo.softDelete('i');
+
+  verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+});
+```
+
+- [ ] **Step 2: Run the new tests (will fail)**
+
+Run: `flutter test test/unit/data/repositories/media_item_repository_impl_test.dart --name "softDelete"`
+Expected: FAIL — `softDelete()` doesn't yet call `_maybeMirrorOnSoftDelete`.
+
+- [ ] **Step 3: Hook `softDelete()` to call the helper**
+
+In `lib/data/repositories/media_item_repository_impl.dart`, find `softDelete()`:
+
+```dart
+@override
+Future<void> softDelete(String id) async {
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await _mediaItemsDao.softDelete(id, now);
+  // ... existing _logSync call ...
+}
+```
+
+(The exact existing body may differ — check the file. The key is to add a pre-write `getById` and a post-write `_maybeMirrorOnSoftDelete` call.)
+
+Wrap it:
+
+```dart
+@override
+Future<void> softDelete(String id) async {
+  final previous = await getById(id);
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await _mediaItemsDao.softDelete(id, now);
+  // ... existing _logSync call, unchanged ...
+  if (previous != null) {
+    _maybeMirrorOnSoftDelete(previous);
+  }
+}
+```
+
+The `if (previous != null)` guard handles the rare case where `softDelete` is called on a non-existent ID — the soft-delete itself is a no-op SQL update and we shouldn't try to mirror anything.
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `flutter test test/unit/data/repositories/media_item_repository_impl_test.dart --name "softDelete"`
+Expected: 3/3 new soft-delete tests pass.
+
+- [ ] **Step 5: Run the full repository test file**
+
+Run: `flutter test test/unit/data/repositories/media_item_repository_impl_test.dart`
+Expected: all pass (existing + 6 from Task 2 + 3 new = 9 mirror-related tests plus pre-existing).
+
+- [ ] **Step 6: Run analyzer**
+
+Run: `flutter analyze lib/data/repositories/media_item_repository_impl.dart test/unit/data/repositories/media_item_repository_impl_test.dart`
+Expected: zero issues.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/data/repositories/media_item_repository_impl.dart \
+        test/unit/data/repositories/media_item_repository_impl_test.dart
+git commit -m "feat(tmdb-sync): hook softDelete() to mirror ownership removal"
+```
+
+Verify branch + HEAD match.
+
+---
+
+## Task 4: Wire repository provider injection
+
+**Files:**
+- Modify: `lib/presentation/providers/repository_providers.dart`
+
+- [ ] **Step 1: Investigate the existing `mediaItemRepositoryProvider`**
+
+Read `lib/presentation/providers/repository_providers.dart`. The slice-A version of `mediaItemRepositoryProvider` looks like:
+
+```dart
+final mediaItemRepositoryProvider = Provider<IMediaItemRepository>((ref) {
+  return MediaItemRepositoryImpl(
+    mediaItemsDao: ref.watch(mediaItemsDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
+  );
+});
+```
+
+Slice 2 added a `mirrorOwnershipChangeUseCaseProvider` that itself depends on `tmdbAccountSyncRepositoryProvider` — and `tmdbAccountSyncRepositoryProvider` THROWS a `StateError` if no TMDB API key is configured. So we need to wrap the read of the mirror in a try/catch (slice 2 used the same pattern in `series_provider.dart` — verify by reading that file briefly if you need a reference).
+
+- [ ] **Step 2: Update `mediaItemRepositoryProvider`**
+
+Replace the existing provider with:
+
+```dart
+final mediaItemRepositoryProvider = Provider<IMediaItemRepository>((ref) {
+  // Optional mirror dep — null when TMDB API key isn't configured. The
+  // repository tolerates a null mirror and skips the auto-remove hook.
+  MirrorOwnershipChangeUseCase? mirror;
+  try {
+    mirror = ref.watch(mirrorOwnershipChangeUseCaseProvider);
+  } on StateError {
+    mirror = null;
+  }
+  return MediaItemRepositoryImpl(
+    mediaItemsDao: ref.watch(mediaItemsDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
+    mirror: mirror,
+    readMirrorEnabled: () =>
+        ref.read(tmdbAccountSyncSettingsProvider).mirrorOwnership,
+  );
+});
+```
+
+If `mirrorOwnershipChangeUseCaseProvider` and `tmdbAccountSyncSettingsProvider` aren't already imported in this file, add them. They were registered by slice 2.
+
+The `try` / `on StateError` covers the "TMDB API key not configured" case. If the underlying error type is different in this codebase, change to `catch (_)` — read the slice-2 `series_provider.dart` precedent if unsure. The intent is the same: the mirror dep is optional, and if its provider can't be resolved cleanly we pass null.
+
+- [ ] **Step 3: Run analyzer**
+
+Run: `flutter analyze lib/presentation/providers/repository_providers.dart`
+Expected: zero issues.
+
+- [ ] **Step 4: Run the full test suite to confirm no regression**
+
+Run: `flutter test`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/presentation/providers/repository_providers.dart
+git commit -m "feat(tmdb-sync): wire mirror dep into mediaItemRepositoryProvider"
+```
+
+Verify branch + HEAD match.
+
+---
+
+## Task 5: Update the user docs
+
+**Files:**
+- Modify: `src/docs/modules/ROOT/pages/tmdb-account-sync.adoc`
+
+- [ ] **Step 1: Find the *Mirror Ownership* section**
+
+Open `src/docs/modules/ROOT/pages/tmdb-account-sync.adoc` and find the section titled `== Mirror Ownership to a TMDB List`.
+
+- [ ] **Step 2: Add a paragraph noting auto-mirror on transitions**
+
+Add a paragraph at the end of the *Mirror Ownership to a TMDB List* section (just before the next `==` heading), describing the new behaviour:
+
+```adoc
+=== Automatic mirroring on ownership changes
+
+Mirror updates fire automatically whenever a movie's ownership status changes:
+
+* Marking an owned movie as wishlist, sold, lent, borrowed, or returned removes it from the MyMediaScanner TMDB list.
+* Promoting a wishlist movie to owned (for example via the *Convert to owned* action on a wishlist row) adds it to the MyMediaScanner TMDB list.
+* Soft-deleting an owned movie removes it from the MyMediaScanner TMDB list.
+
+Mirror calls run in the background and do not block the local save.
+A failed call surfaces under the settings card's *Push pending now* affordance for retry.
+The behaviour is gated on the *Mirror ownership to TMDB list (movies only)* toggle and only applies to titles that have a TMDB ID.
+TV titles are not mirrored — TMDB v3 lists support movies only.
+```
+
+The exact wording can be polished — match the existing prose style of the page.
+
+- [ ] **Step 3: Validate the Antora build**
+
+Run from the repository root: `npx antora local-antora-playbook-search.yml`
+Expected: clean exit (no new warnings or errors). If the playbook file isn't named exactly that, search for `*.yml` files at the repo root that mention `antora` to find the right one.
+
+(The global instruction `gradle21w antora` doesn't apply to this Flutter project — the repo uses npx-based Antora invocation.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/docs/modules/ROOT/pages/tmdb-account-sync.adoc
+git commit -m "docs: note auto-mirror on ownership transitions"
+```
+
+Verify branch + HEAD match.
+
+---
+
+## Task 6: Final verification
+
+**Files:** none (read-only checks)
+
+- [ ] **Step 1: Run analyzer**
+
+Run: `flutter analyze`
+Expected: zero issues across the entire codebase.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `flutter test`
+Expected: all tests pass. The slice 4 baseline (after slice 3a + docs slice 3a merged) was 1385 passing; this slice adds 9 new mirror-hook tests, so total should be ~1394.
+
+- [ ] **Step 3: Linux build**
+
+Run: `flutter build linux --debug`
+Expected: build succeeds.
+
+- [ ] **Step 4: Android build**
+
+Run: `flutter build apk --debug --flavor dev`
+Expected: build succeeds.
+
+- [ ] **Step 5: iOS / macOS**
+
+Skip on Linux host. Document as pending.
+
+- [ ] **Step 6: Manual inspection**
+
+Confirm via reading source:
+
+1. `lib/data/repositories/media_item_repository_impl.dart` — has optional `mirror` and `readMirrorEnabled` ctor params; `_maybeMirrorOnTransition` and `_maybeMirrorOnSoftDelete` private helpers exist; `update()` calls `_maybeMirrorOnTransition`; `softDelete()` calls `_maybeMirrorOnSoftDelete`.
+2. `lib/presentation/providers/repository_providers.dart` — `mediaItemRepositoryProvider` injects the new deps with the try/catch fallback.
+3. `test/unit/data/repositories/media_item_repository_impl_test.dart` — has 9 new mirror-related tests.
+4. `src/docs/modules/ROOT/pages/tmdb-account-sync.adoc` — has the new paragraph in the *Mirror Ownership* section.
+5. No new files created. No schema migration. No UI changes.
+
+- [ ] **Step 7: Final report**
+
+Branch: `feat/tmdb-account-sync-slice-4a-auto-remove-mirror`
+HEAD: `<SHA>`
+Total commits since main: `<count via git log --oneline main..HEAD | wc -l>`
+Test results: `<summary>`
+Linux build: `<PASS/FAIL>`
+Android build: `<PASS/FAIL>`
+iOS build: `<PASS/SKIPPED/FAIL>`
+macOS build: `<PASS/SKIPPED/FAIL>`
+Manual inspection: `<PASS/FAIL with notes>`
+
+Any concerns to flag for the user before merge.
+
+If something fails, status is DONE_WITH_CONCERNS and the failures are listed.
+
+---
+
+## Self-review
+
+- **Spec coverage:** Each spec section maps to a task. Optional ctor params + helpers (Task 1), `update()` hook (Task 2), `softDelete()` hook (Task 3), provider wiring (Task 4), docs note (Task 5), final verification (Task 6). The 9 test cases listed in the spec are split between Tasks 2 (6 cases for `update`) and Task 3 (3 cases for `softDelete`).
+- **Placeholder scan:** Test seeding pseudocode uses `/* insert ... */` because the existing repository test file's seeding helper isn't visible to me from this writing. The implementer reads the existing tests once and wires the same helper. This is a deliberate context-discovery prompt, not a placeholder for missing logic.
+- **Type consistency:** `MirrorOwnershipChangeUseCase`, `TmdbPushResult`, `MediaItem`, `OwnershipStatus`, `MediaType`, `_maybeMirrorOnTransition`, `_maybeMirrorOnSoftDelete` are all named consistently across tasks and match the slice-2 baseline.
+- **No new domain types:** Confirmed. No new files in `lib/domain/`.
+- **No schema migration:** Confirmed. The hooks read existing rows via `getById` and don't add columns.

--- a/docs/superpowers/specs/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror-design.md
+++ b/docs/superpowers/specs/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror-design.md
@@ -1,0 +1,294 @@
+# Design: TMDB Account Sync — Slice 4a (auto-remove from mirror)
+
+**Status:** Approved (brainstorm 2026-04-29)
+**Author:** Paul Snow
+**Created:** 2026-04-29
+**Implements:** Polish task carried forward from slice 2 (#71). Slice 2 added `MirrorOwnershipChangeUseCase` but only wired the *add* path inside `SaveMediaItemUseCase` (initial save). Slice 4a closes the gap so that ownership transitions on existing rows — including soft-deletes — also reflect on the MyMediaScanner private TMDB list.
+**Target platforms:** All — purely under-the-hood, no UI changes.
+
+---
+
+## Scope
+
+When a movie's `ownershipStatus` transitions to or from `OwnershipStatus.owned`, OR when an owned movie is soft-deleted, fire the existing `MirrorOwnershipChangeUseCase.add` / `.remove` automatically. Hook lives in `MediaItemRepositoryImpl.update()` and `MediaItemRepositoryImpl.softDelete()` so all transition paths — current and future — are covered.
+
+### In scope
+
+1. Inject optional `MirrorOwnershipChangeUseCase` and `bool Function() readMirrorEnabled` into `MediaItemRepositoryImpl`. Both nullable; existing call sites (tests, etc.) that don't supply them skip the hook entirely.
+2. `update(item)` — pre-write read of the previous row by id; if the ownership state crosses the `owned` boundary, fire the appropriate mirror call after the write.
+3. `softDelete(id)` — pre-write read; if the row was previously owned, fire mirror-remove before (or in parallel with) the soft-delete write.
+4. Both hooks gated on:
+   - Mirror toggle enabled.
+   - Item has `extraMetadata['tmdb_id']` as a non-null int.
+   - `extraMetadata['media_type'] == 'movie'` (slice-2 movies-only constraint — TV requires v4 list access tokens).
+5. Failure mode: fire-and-forget, errors land on the bridge row's `last_error` for retry via the existing settings card "Push pending now" workflow.
+
+### Out of scope
+
+- Hard-delete handling. The codebase enforces soft-deletes only.
+- TV ownership mirror via TMDB v4 access tokens (separate slice 4b candidate).
+- Background or scheduled mirror reconciliation.
+- Any UI changes — purely under the hood.
+
+---
+
+## Architecture
+
+```
+ConvertWishlistToOwnedUsecase ─┐
+ItemDetail save / future paths ┼──→ MediaItemRepositoryImpl.update(item)
+                               ┘                                  │
+SoftDelete from any UI ─────────────→ MediaItemRepositoryImpl.softDelete(id)
+                                                                  │
+                                                                  ▼
+                              ┌──────────────────────────────────────┐
+                              │ Compute transition:                  │
+                              │  1. Read existing row by id.         │
+                              │  2. Compare old.owned ↔ new.owned.   │
+                              │  3. Gate on mirror toggle + TMDB ID  │
+                              │     + mediaType == movie.            │
+                              │  4. Fire mirror.add or .remove,      │
+                              │     fire-and-forget.                 │
+                              │  5. Proceed with the local write.    │
+                              └──────────────────────────────────────┘
+```
+
+### Why hook the repository, not the use cases
+
+The slice-2 hook fired inside `SaveMediaItemUseCase` (Option B-style — per-use-case wiring). For initial saves that's fine because `SaveMediaItemUseCase` is the only insertion path. But ownership *transitions* flow through `MediaItemRepositoryImpl.update()` from multiple callers:
+
+- `ConvertWishlistToOwnedUsecase` (existing — wishlist → owned via `_repo.update(...)`).
+- `MetadataConfirmScreen` post-save rating apply (`repo.update(savedItem.copyWith(userRating: ...))`) — touches `update()` but doesn't change ownership.
+- Future ownership-edit UIs (none today, but plausible).
+
+Hooking the repository instead of each use case means future transition paths inherit the behaviour automatically. The trade-off is one cross-cutting injection on the repository — the same pattern slice 2 used on `SaveMediaItemUseCase`, just one layer down.
+
+### What does NOT change
+
+- `SaveMediaItemUseCase`'s slice-2 mirror-add hook stays. It fires on the initial INSERT before the row exists in the repository. The new repository-level hook only sees `update()` and `softDelete()` calls, so there's no overlap on initial saves. (Even if there were overlap, mirror-add is idempotent on TMDB.)
+- `MirrorOwnershipChangeUseCase` itself is unchanged.
+- No new domain entities.
+- No new UI.
+- No schema migration.
+
+---
+
+## Behaviour
+
+### `update(item)` decision table
+
+| Old ownership | New ownership | Mirror toggle | TMDB ID | Media type | Action |
+|---|---|---|---|---|---|
+| owned | wishlist / soldOff / borrowed / lent / returned | on | int | movie | `mirror.remove(tmdbId)` |
+| not-owned (any) | owned | on | int | movie | `mirror.add(tmdbId)` |
+| owned | owned | — | — | — | no-op (no transition) |
+| not-owned | not-owned | — | — | — | no-op (no transition) |
+| any | any | off | — | — | no-op (gate fails) |
+| any | any | on | null | — | no-op (gate fails) |
+| any | any | on | int | tv / book / music / game / other | no-op (movies-only) |
+| (row missing — first insert) | any | — | — | — | no-op (treat as no transition; SaveMediaItemUseCase covers initial saves) |
+
+### `softDelete(id)` decision table
+
+| Existing row's ownership | Mirror toggle | TMDB ID | Media type | Action |
+|---|---|---|---|---|
+| owned | on | int | movie | `mirror.remove(tmdbId)`, then standard soft-delete |
+| not-owned | — | — | — | standard soft-delete only |
+| any | off | — | — | standard soft-delete only |
+| any | on | null | — | standard soft-delete only |
+| any | on | int | tv / book / music / game / other | standard soft-delete only |
+| (row missing) | — | — | — | standard soft-delete only (idempotent) |
+
+### Failure handling
+
+The mirror call is wrapped in `unawaited(...)` with a `.catchError` handler so a failed network or TMDB error never propagates to the local write. The error is stored on the bridge row's `last_error` (slice 2's `_mirrorMutate` already does this). The user can retry via the existing settings card "Push pending now" button.
+
+The local write (update or softDelete) **always** completes regardless of mirror outcome.
+
+---
+
+## Implementation outline
+
+### `MediaItemRepositoryImpl` constructor
+
+Add two optional params:
+
+```dart
+class MediaItemRepositoryImpl implements IMediaItemRepository {
+  MediaItemRepositoryImpl({
+    required MediaItemsDao mediaItemsDao,
+    required SyncLogDao syncLogDao,
+    MirrorOwnershipChangeUseCase? mirror,
+    bool Function()? readMirrorEnabled,
+  })  : _mediaItemsDao = mediaItemsDao,
+        _syncLogDao = syncLogDao,
+        _mirror = mirror,
+        _readMirrorEnabled = readMirrorEnabled;
+
+  final MediaItemsDao _mediaItemsDao;
+  final SyncLogDao _syncLogDao;
+  final MirrorOwnershipChangeUseCase? _mirror;
+  final bool Function()? _readMirrorEnabled;
+  // ... existing body ...
+}
+```
+
+### `update(item)` body
+
+```dart
+@override
+Future<void> update(MediaItem item) async {
+  final previous = await getById(item.id);
+  await _mediaItemsDao.update(_toCompanion(item));
+  await _logSync('media_item', item.id, 'update', item);
+  _maybeMirrorOnTransition(previous, item);
+}
+```
+
+`_maybeMirrorOnTransition` is a private helper that performs the gating + dispatch:
+
+```dart
+void _maybeMirrorOnTransition(MediaItem? previous, MediaItem next) {
+  if (_mirror == null || _readMirrorEnabled == null) return;
+  if (!_readMirrorEnabled!()) return;
+  final wasOwned = previous?.ownershipStatus == OwnershipStatus.owned;
+  final isOwned = next.ownershipStatus == OwnershipStatus.owned;
+  if (wasOwned == isOwned) return; // no transition
+  final tmdbId = next.extraMetadata['tmdb_id'];
+  final mediaType = next.extraMetadata['media_type'];
+  if (tmdbId is! int) return;
+  if (mediaType != 'movie') return;
+  if (isOwned) {
+    unawaited(_mirror!.add(tmdbId: tmdbId).catchError((_) {
+      // Silent — bridge row's last_error already set by _mirrorMutate.
+      return const TmdbPushResult(success: false);
+    }));
+  } else {
+    unawaited(_mirror!.remove(tmdbId: tmdbId).catchError((_) {
+      return const TmdbPushResult(success: false);
+    }));
+  }
+}
+```
+
+### `softDelete(id)` body
+
+```dart
+@override
+Future<void> softDelete(String id) async {
+  final previous = await getById(id);
+  final now = DateTime.now().millisecondsSinceEpoch;
+  await _mediaItemsDao.softDelete(id, now);
+  await _logSync('media_item', id, 'soft_delete', previous);
+  if (previous != null) {
+    _maybeMirrorOnSoftDelete(previous);
+  }
+}
+
+void _maybeMirrorOnSoftDelete(MediaItem previous) {
+  if (_mirror == null || _readMirrorEnabled == null) return;
+  if (!_readMirrorEnabled!()) return;
+  if (previous.ownershipStatus != OwnershipStatus.owned) return;
+  final tmdbId = previous.extraMetadata['tmdb_id'];
+  final mediaType = previous.extraMetadata['media_type'];
+  if (tmdbId is! int) return;
+  if (mediaType != 'movie') return;
+  unawaited(_mirror!.remove(tmdbId: tmdbId).catchError((_) {
+    return const TmdbPushResult(success: false);
+  }));
+}
+```
+
+### `repository_providers.dart` wiring
+
+Update the existing `mediaItemRepositoryProvider` to optionally pass the mirror dep. Same pattern slice 2 used for `saveMediaItemUseCaseProvider`:
+
+```dart
+final mediaItemRepositoryProvider = Provider<IMediaItemRepository>((ref) {
+  // Read the mirror use case; null if TMDB API key not configured.
+  MirrorOwnershipChangeUseCase? mirror;
+  try {
+    mirror = ref.watch(mirrorOwnershipChangeUseCaseProvider);
+  } catch (_) {
+    mirror = null;
+  }
+  return MediaItemRepositoryImpl(
+    mediaItemsDao: ref.watch(mediaItemsDaoProvider),
+    syncLogDao: ref.watch(syncLogDaoProvider),
+    mirror: mirror,
+    readMirrorEnabled: () =>
+        ref.read(tmdbAccountSyncSettingsProvider).mirrorOwnership,
+  );
+});
+```
+
+The try/catch covers the case where `mirrorOwnershipChangeUseCaseProvider` itself throws because the TMDB API key isn't configured (slice 2's repository provider gates on `tmdbKey != null`). When TMDB sync isn't set up, mirror is null and the hook is a no-op.
+
+---
+
+## Tests
+
+Extend the existing repository tests (`test/unit/data/repositories/media_item_repository_impl_test.dart` if it exists, or wherever the slice-A/slice-2 repository tests live) with these cases:
+
+1. **`update` non-owned → owned with mirror enabled, movie** — verifies `mirror.add(tmdbId)` is called once.
+2. **`update` owned → non-owned with mirror enabled, movie** — verifies `mirror.remove(tmdbId)`.
+3. **`update` owned → owned (rating-only change) with mirror enabled** — verifies no mirror call.
+4. **`update` non-owned → non-owned (e.g., wishlist → soldOff) with mirror enabled** — verifies no mirror call.
+5. **`update` non-owned → owned with mirror DISABLED** — verifies no mirror call.
+6. **`update` non-owned → owned, mirror enabled, but TV item** — verifies no mirror call.
+7. **`update` non-owned → owned, mirror enabled, but no TMDB ID** — verifies no mirror call.
+8. **`softDelete` on owned movie with mirror enabled** — verifies `mirror.remove(tmdbId)`.
+9. **`softDelete` on non-owned item with mirror enabled** — verifies no mirror call.
+
+Use `mocktail` for the mirror dependency. The `readMirrorEnabled` callback is supplied as `() => true` or `() => false` per test.
+
+Existing tests that construct `MediaItemRepositoryImpl` without the new deps continue to work — both deps are optional/nullable.
+
+---
+
+## Files
+
+### Modify (3)
+
+- `lib/data/repositories/media_item_repository_impl.dart` — add optional ctor params, `_maybeMirrorOnTransition` and `_maybeMirrorOnSoftDelete` helpers, hook into `update()` and `softDelete()`.
+- `lib/presentation/providers/repository_providers.dart` — wire optional mirror + `readMirrorEnabled` into `mediaItemRepositoryProvider` with the same try/catch pattern slice 2 used.
+- `test/unit/data/repositories/media_item_repository_impl_test.dart` (or current location) — add the 9 test cases above.
+
+### No new files. No new domain types. No UI changes. No schema migration.
+
+---
+
+## Acceptance criteria
+
+- A user with mirror enabled + an owned movie + a TMDB ID who runs `ConvertWishlistToOwnedUsecase` (the existing wishlist-to-owned path) sees the movie added to the MyMediaScanner TMDB list.
+- A user who soft-deletes an owned movie sees it removed from the TMDB list.
+- A user with mirror disabled sees no TMDB calls fire from these hooks.
+- TV items, items without TMDB IDs, items already in their target ownership state — no TMDB calls fire.
+- All existing repository / domain / integration tests still pass.
+- `flutter analyze` clean.
+- iOS / Android / Linux compile builds succeed.
+- TMDB Account Sync user guide page (`src/docs/modules/ROOT/pages/tmdb-account-sync.adoc`) gets a small update noting that ownership transitions on existing items now mirror automatically (one paragraph in the *Mirror Ownership* section).
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Existing test setup constructs `MediaItemRepositoryImpl` without the new deps and breaks compilation | New deps are optional/nullable. Existing tests pass `null` (or omit) and skip the hook. Verified by leaving the constructor's required-param shape unchanged. |
+| Pre-write `getById` on every `update()` adds a DB roundtrip | Acceptable. `update()` already does a sync-log write per call. The extra read is one indexed query and only matters in hot loops (bulk import). If profiling shows it dominates, the optimisation is to read just the ownership column — defer until measured. |
+| Race with the slice-2 `SaveMediaItemUseCase` mirror-add | Mirror-add is idempotent on TMDB. No correctness risk. The new hook only fires on `update()` / `softDelete()`, not on initial INSERT, so there's no double-fire for the common case. |
+| Failed mirror call crashes the local write | `unawaited(...).catchError(...)` ensures the local write always completes. The error lands on the bridge row's `last_error`. |
+| Convert-bridge-to-local-item (slice A) creates a new `media_items` row via insert + bridge link — does that fire the hook? | The insert path goes through `SaveMediaItemUseCase` (slice 2's hook fires). The bridge `linkToMediaItem` is a DAO write that doesn't touch `update()`. No double-fire. |
+| `MetadataConfirmScreen` post-save rating apply (`repo.update(savedItem.copyWith(userRating: ...))`) is owned → owned and triggers a no-op on the new hook | Yes — the wasOwned == isOwned branch returns early. No work, no TMDB call. |
+
+---
+
+## Implementation order (high level — detailed plan in writing-plans output)
+
+1. Add the optional ctor params + private helpers in `MediaItemRepositoryImpl`.
+2. Wire `update()` and `softDelete()` to call the helpers.
+3. Update `mediaItemRepositoryProvider` to inject the new deps.
+4. Add the 9 test cases.
+5. Update the user guide with the new behaviour note.
+6. Final verification: `flutter analyze`, `flutter test`, Linux + Android builds.

--- a/docs/superpowers/specs/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror-design.md
+++ b/docs/superpowers/specs/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror-design.md
@@ -86,7 +86,8 @@ Hooking the repository instead of each use case means future transition paths in
 | any | any | off | — | — | no-op (gate fails) |
 | any | any | on | null | — | no-op (gate fails) |
 | any | any | on | int | tv / book / music / game / other | no-op (movies-only) |
-| (row missing — first insert) | any | — | — | — | no-op (treat as no transition; SaveMediaItemUseCase covers initial saves) |
+| (row missing — programming error: `update()` on a non-existent id) | owned | on | int | movie | `mirror.add` (idempotent — `previous` is null so `wasOwned=false` and the helper treats it as a transition; harmless because `mirror.add` is idempotent and `SaveMediaItemUseCase` covers the legitimate initial-save path) |
+| (row missing — programming error) | not-owned | — | — | — | no-op (`wasOwned=false`, `isOwned=false` → no transition) |
 
 ### `softDelete(id)` decision table
 

--- a/lib/data/repositories/media_item_repository_impl.dart
+++ b/lib/data/repositories/media_item_repository_impl.dart
@@ -142,10 +142,12 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
 
   @override
   Future<void> update(MediaItem item) async {
+    final previous = await getById(item.id);
     await _mediaItemsDao.transaction(() async {
       await _mediaItemsDao.updateItem(_toCompanion(item));
       await _logSync('media_item', item.id, 'update', item);
     });
+    _maybeMirrorOnTransition(previous, item);
   }
 
   @override
@@ -293,7 +295,6 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
   /// mirror toggle, presence of a TMDB ID, and movie media type.
   ///
   /// Fire-and-forget — failures land on the bridge row's `last_error`.
-  // ignore: unused_element
   void _maybeMirrorOnTransition(MediaItem? previous, MediaItem next) {
     final mirror = _mirror;
     final readEnabled = _readMirrorEnabled;

--- a/lib/data/repositories/media_item_repository_impl.dart
+++ b/lib/data/repositories/media_item_repository_impl.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:drift/drift.dart';
@@ -10,17 +11,25 @@ import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/ownership_status.dart';
 import 'package:mymediascanner/domain/entities/progress_unit.dart';
 import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/domain/repositories/i_tmdb_account_sync_repository.dart';
+import 'package:mymediascanner/domain/usecases/mirror_ownership_change_usecase.dart';
 import 'package:uuid/uuid.dart';
 
 class MediaItemRepositoryImpl implements IMediaItemRepository {
   MediaItemRepositoryImpl({
     required MediaItemsDao mediaItemsDao,
     required SyncLogDao syncLogDao,
+    MirrorOwnershipChangeUseCase? mirror,
+    bool Function()? readMirrorEnabled,
   })  : _mediaItemsDao = mediaItemsDao,
-        _syncLogDao = syncLogDao;
+        _syncLogDao = syncLogDao,
+        _mirror = mirror,
+        _readMirrorEnabled = readMirrorEnabled;
 
   final MediaItemsDao _mediaItemsDao;
   final SyncLogDao _syncLogDao;
+  final MirrorOwnershipChangeUseCase? _mirror;
+  final bool Function()? _readMirrorEnabled;
   static const _uuid = Uuid();
 
   @override
@@ -277,6 +286,57 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
       payloadJson: Value(jsonEncode(_toSyncPayload(item))),
       createdAt: Value(DateTime.now().millisecondsSinceEpoch),
     ));
+  }
+
+  /// Fires `mirror.add` or `mirror.remove` when the ownership state of
+  /// a `media_items` row crosses the `owned` boundary. Gated on the
+  /// mirror toggle, presence of a TMDB ID, and movie media type.
+  ///
+  /// Fire-and-forget — failures land on the bridge row's `last_error`.
+  // ignore: unused_element
+  void _maybeMirrorOnTransition(MediaItem? previous, MediaItem next) {
+    final mirror = _mirror;
+    final readEnabled = _readMirrorEnabled;
+    if (mirror == null || readEnabled == null) return;
+    if (!readEnabled()) return;
+
+    final wasOwned = previous?.ownershipStatus == OwnershipStatus.owned;
+    final isOwned = next.ownershipStatus == OwnershipStatus.owned;
+    if (wasOwned == isOwned) return; // no transition
+
+    final tmdbId = next.extraMetadata['tmdb_id'];
+    if (tmdbId is! int) return;
+    final mediaType = next.extraMetadata['media_type'];
+    if (mediaType != 'movie') return;
+
+    if (isOwned) {
+      unawaited(mirror.add(tmdbId: tmdbId).catchError((_) {
+        return const TmdbPushResult(success: false);
+      }));
+    } else {
+      unawaited(mirror.remove(tmdbId: tmdbId).catchError((_) {
+        return const TmdbPushResult(success: false);
+      }));
+    }
+  }
+
+  /// Fires `mirror.remove` when an owned movie is soft-deleted.
+  // ignore: unused_element
+  void _maybeMirrorOnSoftDelete(MediaItem previous) {
+    final mirror = _mirror;
+    final readEnabled = _readMirrorEnabled;
+    if (mirror == null || readEnabled == null) return;
+    if (!readEnabled()) return;
+    if (previous.ownershipStatus != OwnershipStatus.owned) return;
+
+    final tmdbId = previous.extraMetadata['tmdb_id'];
+    if (tmdbId is! int) return;
+    final mediaType = previous.extraMetadata['media_type'];
+    if (mediaType != 'movie') return;
+
+    unawaited(mirror.remove(tmdbId: tmdbId).catchError((_) {
+      return const TmdbPushResult(success: false);
+    }));
   }
 
   /// Produce a snake_case map of every sync-relevant field on [item], in

--- a/lib/data/repositories/media_item_repository_impl.dart
+++ b/lib/data/repositories/media_item_repository_impl.dart
@@ -152,6 +152,7 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
 
   @override
   Future<void> softDelete(String id) async {
+    final previous = await getById(id);
     final now = DateTime.now().millisecondsSinceEpoch;
     await _mediaItemsDao.transaction(() async {
       await _mediaItemsDao.softDelete(id, now);
@@ -164,6 +165,9 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
         createdAt: Value(now),
       ));
     });
+    if (previous != null) {
+      _maybeMirrorOnSoftDelete(previous);
+    }
   }
 
   @override
@@ -322,7 +326,6 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
   }
 
   /// Fires `mirror.remove` when an owned movie is soft-deleted.
-  // ignore: unused_element
   void _maybeMirrorOnSoftDelete(MediaItem previous) {
     final mirror = _mirror;
     final readEnabled = _readMirrorEnabled;

--- a/lib/data/repositories/media_item_repository_impl.dart
+++ b/lib/data/repositories/media_item_repository_impl.dart
@@ -309,8 +309,8 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
     final isOwned = next.ownershipStatus == OwnershipStatus.owned;
     if (wasOwned == isOwned) return; // no transition
 
-    final tmdbId = next.extraMetadata['tmdb_id'];
-    if (tmdbId is! int) return;
+    final tmdbId = _asInt(next.extraMetadata['tmdb_id']);
+    if (tmdbId == null) return;
     final mediaType = next.extraMetadata['media_type'];
     if (mediaType != 'movie') return;
 
@@ -333,14 +333,24 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
     if (!readEnabled()) return;
     if (previous.ownershipStatus != OwnershipStatus.owned) return;
 
-    final tmdbId = previous.extraMetadata['tmdb_id'];
-    if (tmdbId is! int) return;
+    final tmdbId = _asInt(previous.extraMetadata['tmdb_id']);
+    if (tmdbId == null) return;
     final mediaType = previous.extraMetadata['media_type'];
     if (mediaType != 'movie') return;
 
     unawaited(mirror.remove(tmdbId: tmdbId).catchError((_) {
       return const TmdbPushResult(success: false);
     }));
+  }
+
+  /// Coerces [value] to [int]. Handles the case where JSON round-trips
+  /// deserialise numeric fields as [double] on some platforms, or where a
+  /// caller stored the TMDB ID as a string. Mirrors `SaveMediaItemUseCase._asInt`.
+  static int? _asInt(Object? value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value);
+    return null;
   }
 
   /// Produce a snake_case map of every sync-relevant field on [item], in

--- a/lib/presentation/providers/repository_providers.dart
+++ b/lib/presentation/providers/repository_providers.dart
@@ -54,9 +54,20 @@ import 'package:mymediascanner/presentation/providers/database_provider.dart';
 import 'package:mymediascanner/presentation/providers/settings_provider.dart';
 
 final mediaItemRepositoryProvider = Provider<IMediaItemRepository>((ref) {
+  // Optional mirror dep — null when TMDB API key isn't configured. The
+  // repository tolerates a null mirror and skips the auto-remove hook.
+  MirrorOwnershipChangeUseCase? mirror;
+  try {
+    mirror = ref.watch(mirrorOwnershipChangeUseCaseProvider);
+  } catch (_) {
+    mirror = null;
+  }
   return MediaItemRepositoryImpl(
     mediaItemsDao: ref.watch(mediaItemsDaoProvider),
     syncLogDao: ref.watch(syncLogDaoProvider),
+    mirror: mirror,
+    readMirrorEnabled: () =>
+        ref.read(tmdbAccountSyncSettingsProvider).mirrorOwnership,
   );
 });
 

--- a/src/docs/modules/ROOT/pages/tmdb-account-sync.adoc
+++ b/src/docs/modules/ROOT/pages/tmdb-account-sync.adoc
@@ -125,6 +125,19 @@ TMDB v3 list endpoints support movies exclusively — TV series ownership cannot
 When you mark a film as owned (for example by scanning a Blu-ray or tapping *Mark as Owned* in the TMDB Watchlist view), the app adds it to the mirror list.
 When a movie is removed from your collection, it is removed from the list.
 
+=== Automatic mirroring on ownership changes
+
+Mirror updates fire automatically whenever a movie's ownership status crosses the owned boundary:
+
+* Marking an owned movie as wishlist, sold, lent, borrowed, or returned removes it from the *MyMediaScanner* TMDB list.
+* Promoting a wishlist movie to owned — for example via the *Convert to owned* action on a wishlist row — adds it to the *MyMediaScanner* TMDB list.
+* Soft-deleting an owned movie removes it from the *MyMediaScanner* TMDB list.
+
+Mirror calls run in the background and do not block the local save.
+A failed call surfaces under the settings card's *Push pending now* affordance for retry.
+This behaviour is gated on the *Mirror ownership to TMDB list (movies only)* toggle and only applies to titles that have a TMDB ID.
+TV titles are not mirrored — TMDB v3 lists support movies only.
+
 == Remote-First Save (Film/TV)
 
 Remote-first save mode lets you store a film or TV title on TMDB without creating a local collection entry.

--- a/src/docs/modules/ROOT/pages/tmdb-account-sync.adoc
+++ b/src/docs/modules/ROOT/pages/tmdb-account-sync.adoc
@@ -134,7 +134,7 @@ Mirror updates fire automatically whenever a movie's ownership status crosses th
 * Soft-deleting an owned movie removes it from the *MyMediaScanner* TMDB list.
 
 Mirror calls run in the background and do not block the local save.
-A failed call surfaces under the settings card's *Push pending now* affordance for retry.
+A failed mirror call is logged but is not retried automatically; re-toggling the mirror setting or re-changing the item's ownership is the user-visible recovery path.
 This behaviour is gated on the *Mirror ownership to TMDB list (movies only)* toggle and only applies to titles that have a TMDB ID.
 TV titles are not mirrored — TMDB v3 lists support movies only.
 

--- a/test/unit/data/repositories/media_item_repository_impl_test.dart
+++ b/test/unit/data/repositories/media_item_repository_impl_test.dart
@@ -169,7 +169,7 @@ void main() {
     });
   });
 
-  group('mirror auto-remove hook on update', () {
+  group('mirror auto-remove hook (update + softDelete)', () {
     late _MockMirror mirror;
     late bool mirrorEnabled;
 
@@ -325,6 +325,31 @@ void main() {
       await r.softDelete('i');
 
       verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+    });
+
+    test('update fires mirror.add when tmdb_id is stored as a String',
+        () async {
+      // Mirrors the importer path that round-trips ids as strings.
+      final r = makeRepo();
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final wishlist = MediaItem(
+        id: 'j',
+        title: 'Fight Club',
+        mediaType: MediaType.film,
+        ownershipStatus: OwnershipStatus.wishlist,
+        barcode: '',
+        barcodeType: '',
+        extraMetadata: const {'tmdb_id': '550', 'media_type': 'movie'},
+        dateAdded: now,
+        dateScanned: now,
+        updatedAt: now,
+      );
+      await seed(wishlist);
+
+      await r.update(
+          wishlist.copyWith(ownershipStatus: OwnershipStatus.owned));
+
+      verify(() => mirror.add(tmdbId: 550)).called(1);
     });
   });
 }

--- a/test/unit/data/repositories/media_item_repository_impl_test.dart
+++ b/test/unit/data/repositories/media_item_repository_impl_test.dart
@@ -294,5 +294,37 @@ void main() {
 
       verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
     });
+
+    test('softDelete on owned movie fires mirror.remove', () async {
+      final r = makeRepo();
+      await seed(movieItem(id: 'g', ownership: OwnershipStatus.owned));
+
+      await r.softDelete('g');
+
+      verify(() => mirror.remove(tmdbId: 550)).called(1);
+    });
+
+    test('softDelete on non-owned item does not fire mirror', () async {
+      final r = makeRepo();
+      await seed(movieItem(id: 'h', ownership: OwnershipStatus.wishlist));
+
+      await r.softDelete('h');
+
+      verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+    });
+
+    test('softDelete on owned TV item does not fire mirror', () async {
+      final r = makeRepo();
+      final tvOwned = movieItem(
+        id: 'i',
+        ownership: OwnershipStatus.owned,
+        mediaType: 'tv',
+      );
+      await seed(tvOwned);
+
+      await r.softDelete('i');
+
+      verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+    });
   });
 }

--- a/test/unit/data/repositories/media_item_repository_impl_test.dart
+++ b/test/unit/data/repositories/media_item_repository_impl_test.dart
@@ -1,10 +1,15 @@
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/data/repositories/media_item_repository_impl.dart';
 import 'package:mymediascanner/domain/entities/media_item.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/repositories/i_tmdb_account_sync_repository.dart';
+import 'package:mymediascanner/domain/usecases/mirror_ownership_change_usecase.dart';
+
+class _MockMirror extends Mock implements MirrorOwnershipChangeUseCase {}
 
 void main() {
   late AppDatabase db;
@@ -161,6 +166,133 @@ void main() {
           .watchAll(searchQuery: 'Dune', tagIds: const ['t1'])
           .first;
       expect(filtered.map((e) => e.id).toSet(), {'b'});
+    });
+  });
+
+  group('mirror auto-remove hook on update', () {
+    late _MockMirror mirror;
+    late bool mirrorEnabled;
+
+    setUp(() {
+      mirror = _MockMirror();
+      mirrorEnabled = true;
+      when(() => mirror.add(tmdbId: any(named: 'tmdbId'))).thenAnswer(
+          (_) async => const TmdbPushResult(success: true));
+      when(() => mirror.remove(tmdbId: any(named: 'tmdbId'))).thenAnswer(
+          (_) async => const TmdbPushResult(success: true));
+    });
+
+    MediaItemRepositoryImpl makeRepo() => MediaItemRepositoryImpl(
+          mediaItemsDao: db.mediaItemsDao,
+          syncLogDao: db.syncLogDao,
+          mirror: mirror,
+          readMirrorEnabled: () => mirrorEnabled,
+        );
+
+    MediaItem movieItem({
+      required String id,
+      required OwnershipStatus ownership,
+      int? tmdbId = 550,
+      String mediaType = 'movie',
+    }) {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      return MediaItem(
+        id: id,
+        title: 'Fight Club',
+        mediaType: MediaType.film,
+        ownershipStatus: ownership,
+        barcode: '',
+        barcodeType: '',
+        extraMetadata: {
+          'tmdb_id': tmdbId,
+          'media_type': mediaType,
+        }..removeWhere((_, v) => v == null),
+        dateAdded: now,
+        dateScanned: now,
+        updatedAt: now,
+      );
+    }
+
+    // Seed using repo.save — same insertion path used by all other tests in
+    // this file.  We must not use repo.update here because that would invoke
+    // the very hook under test.
+    Future<void> seed(MediaItem item) => repo.save(item);
+
+    test('update non-owned → owned fires mirror.add', () async {
+      final r = makeRepo();
+      final wishlist =
+          movieItem(id: 'a', ownership: OwnershipStatus.wishlist);
+      await seed(wishlist);
+
+      await r.update(movieItem(id: 'a', ownership: OwnershipStatus.owned));
+
+      verify(() => mirror.add(tmdbId: 550)).called(1);
+      verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+    });
+
+    test('update owned → not-owned fires mirror.remove', () async {
+      final r = makeRepo();
+      await seed(movieItem(id: 'b', ownership: OwnershipStatus.owned));
+
+      await r.update(
+          movieItem(id: 'b', ownership: OwnershipStatus.wishlist));
+
+      verify(() => mirror.remove(tmdbId: 550)).called(1);
+      verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+    });
+
+    test('update owned → owned (rating-only) does not fire mirror', () async {
+      final r = makeRepo();
+      await seed(movieItem(id: 'c', ownership: OwnershipStatus.owned));
+
+      await r.update(
+        movieItem(id: 'c', ownership: OwnershipStatus.owned)
+            .copyWith(userRating: 4.5),
+      );
+
+      verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+      verifyNever(() => mirror.remove(tmdbId: any(named: 'tmdbId')));
+    });
+
+    test('update with mirror disabled does not fire mirror', () async {
+      mirrorEnabled = false;
+      final r = makeRepo();
+      await seed(movieItem(id: 'd', ownership: OwnershipStatus.wishlist));
+
+      await r.update(
+          movieItem(id: 'd', ownership: OwnershipStatus.owned));
+
+      verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+    });
+
+    test('update non-owned → owned for TV does not fire mirror', () async {
+      final r = makeRepo();
+      final tvItem = movieItem(
+        id: 'e',
+        ownership: OwnershipStatus.wishlist,
+        mediaType: 'tv',
+      );
+      await seed(tvItem);
+
+      await r.update(tvItem.copyWith(ownershipStatus: OwnershipStatus.owned));
+
+      verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
+    });
+
+    test('update non-owned → owned without TMDB ID does not fire mirror',
+        () async {
+      final r = makeRepo();
+      final noTmdb = movieItem(
+        id: 'f',
+        ownership: OwnershipStatus.wishlist,
+        tmdbId: null,
+      );
+      await seed(noTmdb);
+
+      await r.update(
+          noTmdb.copyWith(ownershipStatus: OwnershipStatus.owned));
+
+      verifyNever(() => mirror.add(tmdbId: any(named: 'tmdbId')));
     });
   });
 }


### PR DESCRIPTION
## Summary

Closes the slice-2 asymmetry where the *MyMediaScanner* private TMDB list only received adds at initial save. Slice 4a hooks `MediaItemRepositoryImpl.update()` and `softDelete()` so any ownership transition on an existing movie row mirrors automatically:

- **wishlist → owned** fires `mirror.add`
- **owned → wishlist / sold / lent / borrowed / returned** fires `mirror.remove`
- **soft-delete of an owned movie** fires `mirror.remove`

All non-transition updates (rating change, review edit, tag flip) are no-ops. Gated on the *Mirror ownership to TMDB list (movies only)* setting; only fires for movies that have a TMDB ID. TV titles are not mirrored — TMDB v3 lists are movie-only.

Mirror calls run in the background (`unawaited` + `.catchError`) and never block the local write. Failures surface on the bridge row's `last_error` and can be retried via *Push pending now*.

Implementation matches the slice-2 nullable-DI pattern from `SaveMediaItemUseCase` — optional `MirrorOwnershipChangeUseCase mirror` and `bool Function() readMirrorEnabled` constructor params, with a try/catch fallback in `mediaItemRepositoryProvider` for the case where no TMDB API key is configured. `tmdb_id` coercion uses the same `_asInt` helper as slice 2 so string / num / double-stored IDs all work.

## Test plan

- [x] `flutter analyze` — zero issues
- [x] `flutter test` — 1395/1395 passing (10 new mirror-hook tests, including a String-`tmdb_id` regression case)
- [x] `flutter build linux --debug` — succeeds
- [x] `flutter build apk --debug --flavor dev` — succeeds
- [x] Antora doc build — clean
- [ ] iOS / macOS — skipped (Linux host)
- [ ] Manual smoke: connect TMDB account, enable mirror toggle, then on an existing wishlist movie tap *Convert to owned* → verify the movie appears on the *MyMediaScanner* TMDB list within a few seconds. Then change ownership back to wishlist → verify removal.
- [ ] Manual smoke: soft-delete an owned movie → verify removal from the *MyMediaScanner* list.

## Files changed

- `lib/data/repositories/media_item_repository_impl.dart` — optional mirror DI, two private helpers, hooks on `update()` and `softDelete()`
- `lib/presentation/providers/repository_providers.dart` — wire mirror dep into `mediaItemRepositoryProvider`
- `test/unit/data/repositories/media_item_repository_impl_test.dart` — 10 new tests
- `src/docs/modules/ROOT/pages/tmdb-account-sync.adoc` — auto-mirror-on-transitions paragraph
- `docs/superpowers/specs/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror-design.md` — design spec
- `docs/superpowers/plans/2026-04-29-tmdb-account-sync-slice-4a-auto-remove-mirror.md` — implementation plan

No schema migration. No new domain types. No UI changes.