### PR TITLE
fix(tmdb-sync): harden no-token state across settings UI

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -95,7 +95,18 @@ class _AppState extends ConsumerState<App> {
 
 /// Bridges the deep-link handler's broadcast stream into Riverpod so
 /// `ref.listen` can observe events.
+///
+/// `tmdbDeepLinkHandlerProvider` transitively depends on
+/// `tmdbAccountSyncRepositoryProvider`, which throws `StateError` when
+/// no TMDB Read Access Token is configured. We swallow that here so the
+/// app can boot without a token; the handler will be re-evaluated when
+/// the user enters one (provider invalidation propagates from the
+/// `apiKeysProvider`).
 final _deepLinkEventStreamProvider =
     StreamProvider.autoDispose<TmdbDeepLinkEvent>((ref) {
-  return ref.watch(tmdbDeepLinkHandlerProvider).events;
+  try {
+    return ref.watch(tmdbDeepLinkHandlerProvider).events;
+  } on StateError {
+    return const Stream<TmdbDeepLinkEvent>.empty();
+  }
 });

--- a/lib/presentation/screens/settings/widgets/api_key_form.dart
+++ b/lib/presentation/screens/settings/widgets/api_key_form.dart
@@ -90,8 +90,18 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
         // Primary sources
         Text('Primary Sources',
             style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 4),
+        Text(
+          'TMDB needs the v4 "API Read Access Token" (a long ~250-char '
+          'string starting with "eyJ…") — not the 32-char v3 API Key. '
+          'Find it on themoviedb.org → Settings → API → '
+          '"API Read Access Token (v4 auth)".',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.outline,
+              ),
+        ),
         const SizedBox(height: 8),
-        _keyField('TMDB API Key', _tmdbController, (key) {
+        _keyField('TMDB Read Access Token (v4)', _tmdbController, (key) {
           ref.read(apiKeysProvider.notifier).setTmdbKey(key);
         }),
         const SizedBox(height: 12),
@@ -160,21 +170,65 @@ class _ApiKeyFormState extends ConsumerState<ApiKeyForm> {
     TextEditingController controller,
     Function(String) onSave,
   ) {
-    return TextField(
+    return _ApiKeyField(
+      label: label,
       controller: controller,
+      onSave: onSave,
+    );
+  }
+}
+
+/// A masked API-key field with a per-field reveal toggle and a save
+/// button. Visibility state is local so revealing one key does not
+/// expose the others.
+class _ApiKeyField extends StatefulWidget {
+  const _ApiKeyField({
+    required this.label,
+    required this.controller,
+    required this.onSave,
+  });
+
+  final String label;
+  final TextEditingController controller;
+  final void Function(String) onSave;
+
+  @override
+  State<_ApiKeyField> createState() => _ApiKeyFieldState();
+}
+
+class _ApiKeyFieldState extends State<_ApiKeyField> {
+  bool _obscured = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: widget.controller,
+      obscureText: _obscured,
       decoration: InputDecoration(
-        labelText: label,
-        suffixIcon: IconButton(
-          icon: const Icon(Icons.save),
-          onPressed: () {
-            onSave(controller.text.trim());
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('$label saved')),
-            );
-          },
+        labelText: widget.label,
+        suffixIcon: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              icon: Icon(
+                _obscured ? Icons.visibility : Icons.visibility_off,
+              ),
+              tooltip: _obscured ? 'Reveal' : 'Hide',
+              onPressed: () => setState(() => _obscured = !_obscured),
+            ),
+            IconButton(
+              icon: const Icon(Icons.save),
+              tooltip: 'Save',
+              onPressed: () {
+                widget.onSave(widget.controller.text.trim());
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('${widget.label} saved')),
+                );
+              },
+            ),
+          ],
         ),
       ),
-      obscureText: true,
     );
   }
 }

--- a/lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart
+++ b/lib/presentation/screens/settings/widgets/tmdb_account_sync_section.dart
@@ -20,7 +20,7 @@ class TmdbAccountSyncSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final tmdbKey = (ref.watch(apiKeysProvider).value ?? {})['tmdb'] ?? '';
-    if (tmdbKey.trim().isEmpty) return const SizedBox.shrink();
+    if (tmdbKey.trim().isEmpty) return const _TmdbAccountSyncCta();
 
     final connectionAsync = ref.watch(tmdbAccountConnectionProvider);
     final settings = ref.watch(tmdbAccountSyncSettingsProvider);
@@ -302,6 +302,39 @@ Future<void> _toggleRemoteFirst(
   await ref
       .read(tmdbAccountSyncSettingsProvider.notifier)
       .setRemoteFirstSaveEnabled(requested);
+}
+
+/// Placeholder rendered in place of the full sync card when no TMDB
+/// Read Access Token is configured. Surfaces the precondition the user
+/// must satisfy before any account-sync provider is reachable, instead
+/// of leaving the section silently empty (or letting downstream
+/// providers throw `StateError`).
+class _TmdbAccountSyncCta extends StatelessWidget {
+  const _TmdbAccountSyncCta();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('TMDB Account Sync', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              'Add your TMDB Read Access Token under "API Keys" above to '
+              'enable account sync. Once it is set, you can sign in to '
+              'TMDB to import your ratings, watchlist, and favourites.',
+              style: theme.textTheme.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _LastSyncSummary extends StatelessWidget {

--- a/lib/presentation/screens/settings/widgets/tmdb_lists_section.dart
+++ b/lib/presentation/screens/settings/widgets/tmdb_lists_section.dart
@@ -20,6 +20,13 @@ class TmdbListsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // Short-circuit when no TMDB token is configured — watching
+    // `tmdbAccountConnectionProvider` in that state would surface the
+    // `StateError: TMDB API key not configured` from
+    // `tmdbAccountSyncRepositoryProvider`.
+    final tmdbKey = (ref.watch(apiKeysProvider).value ?? {})['tmdb'] ?? '';
+    if (tmdbKey.trim().isEmpty) return const SizedBox.shrink();
+
     final connectionAsync = ref.watch(tmdbAccountConnectionProvider);
     final isConnected = connectionAsync.value is TmdbConnected;
     if (!isConnected) return const SizedBox.shrink();

--- a/test/widget/presentation/screens/settings/settings_screen_test.dart
+++ b/test/widget/presentation/screens/settings/settings_screen_test.dart
@@ -178,13 +178,13 @@ void main() {
 
     // Scroll until the TMDB field is visible.
     await tester.scrollUntilVisible(
-      find.widgetWithText(TextField, 'TMDB API Key'),
+      find.widgetWithText(TextField, 'TMDB Read Access Token (v4)'),
       200,
       scrollable: find.byType(Scrollable).first,
     );
 
     await tester.enterText(
-      find.widgetWithText(TextField, 'TMDB API Key'),
+      find.widgetWithText(TextField, 'TMDB Read Access Token (v4)'),
       'my-tmdb-key',
     );
     await tester.pump();
@@ -204,7 +204,9 @@ void main() {
         )).called(1);
 
     // Snackbar should confirm the save.
-    expect(find.textContaining('TMDB API Key saved'), findsOneWidget);
+    expect(
+        find.textContaining('TMDB Read Access Token (v4) saved'),
+        findsOneWidget);
   });
 
   // -------------------------------------------------------------------------
@@ -329,7 +331,7 @@ void main() {
 
     expect(find.textContaining('MusicBrainz'), findsOneWidget);
     expect(find.textContaining('no key'), findsOneWidget);
-    expect(find.widgetWithText(TextField, 'TMDB API Key'), findsOneWidget);
+    expect(find.widgetWithText(TextField, 'TMDB Read Access Token (v4)'), findsOneWidget);
   });
 }
 

--- a/test/widget/screens/settings/widgets/tmdb_lists_section_test.dart
+++ b/test/widget/screens/settings/widgets/tmdb_lists_section_test.dart
@@ -18,6 +18,9 @@ Widget harness({
 }) {
   return ProviderScope(
     overrides: [
+      // The section short-circuits when no TMDB token is configured —
+      // stub the provider so the connected-state tests reach the body.
+      apiKeysProvider.overrideWith(_StubApiKeysNotifier.new),
       tmdbAccountConnectionProvider.overrideWith(
           () => _StubConnectionNotifier(connection)),
       tmdbAccountSyncSettingsProvider.overrideWith(
@@ -149,6 +152,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.textContaining('TMDB Saved'), findsNothing);
   });
+}
+
+class _StubApiKeysNotifier extends ApiKeysNotifier {
+  @override
+  Future<Map<String, String?>> build() async => {'tmdb': 'stub-token'};
 }
 
 class _StubConnectionNotifier extends TmdbAccountConnectionNotifier {


### PR DESCRIPTION
## Summary

When the TMDB Read Access Token is missing, several call sites of `tmdbAccountSyncRepositoryProvider` throw `StateError`. #79 covered the eager read in `_AppState.initState`; this PR mops up the remaining ones and improves the no-token UX:

- `lib/app/app.dart`: `_deepLinkEventStreamProvider` now wraps `ref.watch` in try/`on StateError`, returning an empty stream so the bridge stays inert until a token is supplied (provider invalidation re-evaluates).
- `tmdb_lists_section.dart`: short-circuits on empty token before watching the connection provider, which would otherwise hit the same `StateError`.
- `tmdb_account_sync_section.dart`: replaces silent `SizedBox.shrink()` with a CTA card pointing the user at the API Keys field above.
- `api_key_form.dart`: rename the TMDB field to **"TMDB Read Access Token (v4)"** with helper text disambiguating the v3 32-char key from the v4 ~250-char `eyJ…` token; new stateful `_ApiKeyField` wrapper adds a **per-field reveal toggle** so long pasted tokens can be verified without exposing the others.

Tests updated to track the rename and to stub `apiKeysProvider` in the lists-section harness so connected-state cases reach the body.

## Test plan
- [x] \`flutter analyze\` on touched files — no issues
- [x] \`flutter test test/widget/screens/settings/widgets/tmdb_lists_section_test.dart test/widget/presentation/screens/settings/settings_screen_test.dart\` — 12/12 pass
- [ ] Manual: launch with no TMDB key → Settings shows the CTA card; deep-link stream provider does not throw
- [ ] Manual: set a TMDB key → reveal toggle works per-field; full account-sync section appears