### PR TITLE
test: correct misleading TODO comments on deferred lending coverage

### DIFF
--- a/test/widget/presentation/screens/borrowers/borrower_detail_screen_test.dart
+++ b/test/widget/presentation/screens/borrowers/borrower_detail_screen_test.dart
@@ -6,9 +6,11 @@
 //   3. returnLoan — the "Return" flow triggers loanRepository.returnItem.
 //
 // Note: BorrowerDetailScreen does not expose a "Return" button directly;
-// it renders read-only _LoanCard widgets.  Returning a loan is handled via
-// ItemDetailScreen / LoanSection.  Test 3 is therefore skipped with a TODO
-// explaining the tight coupling.
+// it renders read-only _LoanCard widgets.  The Return action is wired
+// inline inside ItemDetailScreen (see lib/presentation/screens/item_detail/
+// item_detail_screen.dart, the FilledButton.tonal that calls
+// ReturnItemUseCase).  Test 3 is therefore skipped because exercising it
+// requires the ItemDetailScreen widget tree, not BorrowerDetailScreen.
 //
 // Author: Paul Snow
 // Since: 0.0.0
@@ -145,11 +147,14 @@ void main() {
   });
 
   // --------------------------------------------------------------------------
-  // Test 3: return loan — skipped due to tight coupling
+  // Test 3: return loan — gap, no widget-level coverage
   // --------------------------------------------------------------------------
-  // TODO: BorrowerDetailScreen renders read-only _LoanCard widgets with no
-  // "Return" action button.  The return-loan interaction is handled inside
-  // ItemDetailScreen / LoanSection and cannot be triggered from this screen
-  // without navigating there.  A dedicated LoanSection widget test covers
-  // that behaviour instead.
+  // BorrowerDetailScreen renders read-only _LoanCard widgets with no "Return"
+  // button.  The return-loan action is the FilledButton.tonal inside
+  // ItemDetailScreen which invokes ReturnItemUseCase directly (see
+  // lib/presentation/screens/item_detail/item_detail_screen.dart).  That
+  // button is not currently covered by any widget or integration test —
+  // exercising it would either require a dedicated ItemDetailScreen widget
+  // test that stubs an active loan, or a new lending integration test that
+  // drives the screen end-to-end.
 }

--- a/test/widget/presentation/screens/item_detail/item_detail_screen_test.dart
+++ b/test/widget/presentation/screens/item_detail/item_detail_screen_test.dart
@@ -287,10 +287,15 @@ void main() {
     );
 
     // -----------------------------------------------------------------------
-    // 4. Lend button / loan creation — skipped
-    // TODO: The BorrowerPickerDialog resolves borrowers through provider
-    // chains that require a live Drift DAO; properly isolating this requires
-    // production-code changes.  Covered by integration_test/.
+    // 4. Lend button / loan creation — exercised elsewhere
+    //
+    // Covered by test/widget/presentation/screens/item_detail/widgets/
+    // borrower_picker_dialog_test.dart, which mocks the loan/borrower repos
+    // and verifies: listing borrowers, tap-to-create-loan dismissing the
+    // dialog and calling loanRepo.createLoan, and the "Add new borrower"
+    // button opening the form.  Driving the flow from this screen's Lend
+    // button would require live Drift DAOs, so the picker is tested in
+    // isolation.
     // -----------------------------------------------------------------------
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two test-skip TODO notes pointed at coverage that does not exist. Comment-only fixes — no production code touched.

- **\`item_detail_screen_test.dart:291\`** claimed the Lend / loan-creation flow was *"Covered by integration_test/"* — but that integration test does not actually exercise the Lend button or BorrowerPickerDialog. It IS covered (with mocked repos) by \`test/widget/presentation/screens/item_detail/widgets/borrower_picker_dialog_test.dart\` (lists borrowers, tap-to-create-loan calls \`loanRepo.createLoan\`, "Add new borrower" button). Updated the note to point at the real test and describe its scope.

- **\`borrower_detail_screen_test.dart:150\`** claimed return-loan was *"covered with a dedicated LoanSection widget test"* — but no \`LoanSection\` widget or test exists. The Return button is the \`FilledButton.tonal\` wired inline inside \`ItemDetailScreen\` (\`item_detail_screen.dart\`), and it is not currently covered anywhere. Rewrote the note to honestly describe the gap and what filling it would require.

## Test plan
- [x] \`flutter test test/widget/presentation/screens/borrowers/borrower_detail_screen_test.dart test/widget/presentation/screens/item_detail/item_detail_screen_test.dart\` — 6/6 pass (comment-only changes)