### PR TITLE
test(rip-quality): inject IsolateRunner so click-detection path is testable

### DIFF
--- a/lib/domain/usecases/analyse_rip_quality_usecase.dart
+++ b/lib/domain/usecases/analyse_rip_quality_usecase.dart
@@ -35,6 +35,15 @@ class QualityAnalysisProgress {
   final String currentStep;
 }
 
+/// Signature for executing a CPU-bound computation off the main thread.
+///
+/// Defaults to [Isolate.run]; tests inject a synchronous runner so they
+/// can drive the FLAC-decode, AccurateRip, and click-detection paths
+/// without spinning up real isolates (closures captured in tests reach
+/// into mocks that are not isolate-safe).
+typedef IsolateRunner = Future<R> Function<R>(
+    FutureOr<R> Function() computation);
+
 /// Analyses the audio quality of all tracks in a rip album.
 class AnalyseRipQualityUseCase {
   AnalyseRipQualityUseCase({
@@ -42,14 +51,21 @@ class AnalyseRipQualityUseCase {
     required FlacDecoder flacDecoder,
     required ar.AccurateRipClient accurateRipClient,
     this.sensitivity = add.Sensitivity.medium,
+    IsolateRunner? isolateRunner,
   })  : _repository = repository,
         _flacDecoder = flacDecoder,
-        _arClient = accurateRipClient;
+        _arClient = accurateRipClient,
+        _isolateRunner = isolateRunner ?? _defaultIsolateRunner;
+
+  static Future<R> _defaultIsolateRunner<R>(
+          FutureOr<R> Function() computation) =>
+      Isolate.run(computation);
 
   final IRipLibraryRepository _repository;
   final FlacDecoder _flacDecoder;
   final ar.AccurateRipClient _arClient;
   final add.Sensitivity sensitivity;
+  final IsolateRunner _isolateRunner;
 
   /// Execute the analysis pipeline for the given album.
   ///
@@ -170,7 +186,8 @@ class AnalyseRipQualityUseCase {
 
       Uint8List pcmData;
       try {
-        pcmData = await Isolate.run(() => _flacDecoder.decode(track.filePath));
+        pcmData =
+            await _isolateRunner(() => _flacDecoder.decode(track.filePath));
       } catch (_) {
         await _repository.updateTrackQuality(
           track.id,
@@ -187,7 +204,7 @@ class AnalyseRipQualityUseCase {
         currentStep: 'Computing checksums for track ${track.trackNumber}',
       );
 
-      final crcResults = await Isolate.run(() {
+      final crcResults = await _isolateRunner(() {
         final v1 = ar.computeArV1(pcmData,
             isFirstTrack: isFirst, isLastTrack: isLast);
         final v2 = ar.computeArV2(pcmData,
@@ -247,7 +264,7 @@ class AnalyseRipQualityUseCase {
         currentStep: 'Detecting clicks on track ${track.trackNumber}',
       );
 
-      final clickResult = await Isolate.run(() {
+      final clickResult = await _isolateRunner(() {
         return add.analysePcm(
           pcmData,
           format: const add.PcmFormat(

--- a/test/unit/domain/analyse_rip_quality_usecase_test.dart
+++ b/test/unit/domain/analyse_rip_quality_usecase_test.dart
@@ -1,6 +1,8 @@
 // Author: Paul Snow
 
+import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -9,6 +11,17 @@ import 'package:dart_accuraterip/dart_accuraterip.dart';
 import 'package:mymediascanner/domain/entities/rip_track.dart';
 import 'package:mymediascanner/domain/repositories/i_rip_library_repository.dart';
 import 'package:mymediascanner/domain/usecases/analyse_rip_quality_usecase.dart';
+
+// ---------------------------------------------------------------------------
+// Synchronous IsolateRunner — runs the closure inline on the test thread so
+// tests can drive the FLAC decode, AccurateRip CRC, and click-detection
+// paths without spinning up real isolates (closures capture mocks that are
+// not isolate-safe).
+// ---------------------------------------------------------------------------
+
+Future<R> _syncIsolateRunner<R>(FutureOr<R> Function() computation) async {
+  return await computation();
+}
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -62,11 +75,9 @@ void main() {
       repository: mockRepo,
       flacDecoder: mockFlacDecoder,
       accurateRipClient: mockArClient,
+      isolateRunner: _syncIsolateRunner,
     );
   });
-
-  // TODO: Tests for AccurateRip and click detection paths require refactoring
-  // Isolate.run to be injectable.
 
   group('execute', () {
     group('returns empty stream when album has no tracks', () {
@@ -274,6 +285,54 @@ End of status report
               arStatus: 'not_checked',
               qualityCheckedAt: any(named: 'qualityCheckedAt'),
             ));
+      });
+    });
+
+    group(
+        'falls through to click detection when AccurateRip is unreachable',
+        () {
+      test(
+          'execute_withFlacAvailable_andUnknownSampleCounts_runsClickDetection',
+          () async {
+        // Arrange
+        // The fake file path means _tryParseLog fails (no log) and
+        // FlacReader.readMetadata returns null, which makes
+        // sampleCounts.every((c) => c > 0) false, so the AR query is
+        // skipped and the pipeline falls into step 3 (click detection).
+        final track = _track(id: 'track-1', trackNumber: 1);
+        // 0.1 s of 16-bit stereo silence at 44.1 kHz: 4 bytes/frame *
+        // 4410 frames = 17 640 bytes. Silence has no clicks/pops, so the
+        // detector returns an empty defects list deterministically.
+        final pcmData = Uint8List(17640);
+
+        when(() => mockRepo.getTracksForAlbum('album-1'))
+            .thenAnswer((_) async => [track]);
+        when(() => mockFlacDecoder.isAvailable())
+            .thenAnswer((_) async => true);
+        when(() => mockFlacDecoder.decode(any()))
+            .thenAnswer((_) async => pcmData);
+        when(() => mockRepo.updateTrackQuality(
+              any(),
+              arStatus: any(named: 'arStatus'),
+              clickCount: any(named: 'clickCount'),
+              qualityCheckedAt: any(named: 'qualityCheckedAt'),
+            )).thenAnswer((_) async {});
+
+        // Act
+        await useCase.execute('album-1').drain<void>();
+
+        // Assert — track is marked not_found (AR could not verify) with a
+        // clickCount derived from the click-detection pass. AccurateRip
+        // must NOT be queried because sample counts were unknown.
+        verify(() => mockRepo.updateTrackQuality(
+              'track-1',
+              arStatus: 'not_found',
+              clickCount: 0,
+              qualityCheckedAt: any(named: 'qualityCheckedAt'),
+            )).called(1);
+        // AccurateRip is unreachable when sample counts are unknown, so the
+        // client should not be touched at all.
+        verifyZeroInteractions(mockArClient);
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes the deferred TODO in \`test/unit/domain/analyse_rip_quality_usecase_test.dart\` (\"Tests for AccurateRip and click detection paths require refactoring \`Isolate.run\` to be injectable\").

\`AnalyseRipQualityUseCase\` used \`Isolate.run\` directly for FLAC decode, AR CRC compute, and click detection. Closures captured into \`Isolate.run\` cannot reach into mocktail mocks, so those branches were untestable.

### Production change (\`lib/domain/usecases/analyse_rip_quality_usecase.dart\`)
- Add an \`IsolateRunner\` typedef.
- Add an optional \`isolateRunner\` constructor parameter that defaults to \`Isolate.run\`, so existing callers (\`rip_provider.dart\`) are unaffected.
- Replace the three \`Isolate.run\` callsites with the injected runner.

### Test change
- Existing \`setUp\` now passes a synchronous \`_syncIsolateRunner\` so any newly reachable path runs inline against the mocks.
- New test \`execute_withFlacAvailable_andUnknownSampleCounts_runsClickDetection\`: flac available, sample counts unknown (AR query skipped), inject 0.1 s of silence → click detection deterministically returns no defects → assert track is marked \`not_found\` with \`clickCount=0\` and \`verifyZeroInteractions(mockArClient)\`.

### Out of scope
The AR-verified and AR-mismatch branches stay untested for now — exercising them needs a heavier fixture (PCM whose CRCs match/don't match a controlled AR query result). Future follow-up.

## Test plan
- [x] \`flutter test test/unit/domain/analyse_rip_quality_usecase_test.dart\` — 6/6 pass (5 existing + 1 new)
- [x] \`flutter analyze\` clean on the touched files