### PR TITLE
feat(rip-quality): adopt audio_defect_detector 0.2.0 with per-type defect breakdown

### DIFF
--- a/lib/data/local/dao/rip_library_dao.dart
+++ b/lib/data/local/dao/rip_library_dao.dart
@@ -171,6 +171,10 @@ class RipLibraryDao extends DatabaseAccessor<AppDatabase>
     double? trackQuality,
     String? copyCrc,
     int? clickCount,
+    int? popCount,
+    int? clippingCount,
+    int? dropoutCount,
+    double? defectConfidence,
     String? ripLogSource,
     int? qualityCheckedAt,
   }) {
@@ -190,6 +194,16 @@ class RipLibraryDao extends DatabaseAccessor<AppDatabase>
         copyCrc: copyCrc != null ? Value(copyCrc) : const Value.absent(),
         clickCount:
             clickCount != null ? Value(clickCount) : const Value.absent(),
+        popCount: popCount != null ? Value(popCount) : const Value.absent(),
+        clippingCount: clippingCount != null
+            ? Value(clippingCount)
+            : const Value.absent(),
+        dropoutCount: dropoutCount != null
+            ? Value(dropoutCount)
+            : const Value.absent(),
+        defectConfidence: defectConfidence != null
+            ? Value(defectConfidence)
+            : const Value.absent(),
         ripLogSource:
             ripLogSource != null ? Value(ripLogSource) : const Value.absent(),
         qualityCheckedAt: qualityCheckedAt != null

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -91,7 +91,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 20;
+  int get schemaVersion => 21;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -269,6 +269,40 @@ class AppDatabase extends _$AppDatabase {
               'CREATE INDEX IF NOT EXISTS idx_tmdb_bridge_dirty '
               'ON tmdb_account_sync_items(local_dirty, remote_dirty)',
             );
+          }
+          if (from < 21) {
+            // audio_defect_detector 0.2.0 partitions defects into four
+            // DefectType buckets (click/pop/clipping/dropout) and reports
+            // an aggregate confidence per analysis. Existing rows keep
+            // their clickCount; the new columns are nullable so a re-run
+            // of "Analyse Quality" is what backfills them.
+            //
+            // The v17 branch above drops and recreates rip_tracks using
+            // the *current* Dart definition, which now includes these
+            // four columns. Upgrades from < 17 therefore arrive here
+            // with the columns already present and addColumn would fail
+            // with `duplicate column name`. Guard on the live schema so
+            // the branch is a no-op when v17 already rebuilt the table
+            // at the v21 shape.
+            final tableInfo = await customSelect(
+              'PRAGMA table_info(rip_tracks)',
+            ).get();
+            final existing = tableInfo
+                .map((r) => r.read<String>('name'))
+                .toSet();
+            if (!existing.contains('pop_count')) {
+              await m.addColumn(ripTracksTable, ripTracksTable.popCount);
+            }
+            if (!existing.contains('clipping_count')) {
+              await m.addColumn(ripTracksTable, ripTracksTable.clippingCount);
+            }
+            if (!existing.contains('dropout_count')) {
+              await m.addColumn(ripTracksTable, ripTracksTable.dropoutCount);
+            }
+            if (!existing.contains('defect_confidence')) {
+              await m.addColumn(
+                  ripTracksTable, ripTracksTable.defectConfidence);
+            }
           }
         },
       );

--- a/lib/data/local/database/app_database.g.dart
+++ b/lib/data/local/database/app_database.g.dart
@@ -6421,6 +6421,50 @@ class $RipTracksTableTable extends RipTracksTable
     type: DriftSqlType.int,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _popCountMeta = const VerificationMeta(
+    'popCount',
+  );
+  @override
+  late final GeneratedColumn<int> popCount = GeneratedColumn<int>(
+    'pop_count',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _clippingCountMeta = const VerificationMeta(
+    'clippingCount',
+  );
+  @override
+  late final GeneratedColumn<int> clippingCount = GeneratedColumn<int>(
+    'clipping_count',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _dropoutCountMeta = const VerificationMeta(
+    'dropoutCount',
+  );
+  @override
+  late final GeneratedColumn<int> dropoutCount = GeneratedColumn<int>(
+    'dropout_count',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _defectConfidenceMeta = const VerificationMeta(
+    'defectConfidence',
+  );
+  @override
+  late final GeneratedColumn<double> defectConfidence = GeneratedColumn<double>(
+    'defect_confidence',
+    aliasedName,
+    true,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _ripLogSourceMeta = const VerificationMeta(
     'ripLogSource',
   );
@@ -6462,6 +6506,10 @@ class $RipTracksTableTable extends RipTracksTable
     trackQuality,
     copyCrc,
     clickCount,
+    popCount,
+    clippingCount,
+    dropoutCount,
+    defectConfidence,
     ripLogSource,
     qualityCheckedAt,
   ];
@@ -6612,6 +6660,39 @@ class $RipTracksTableTable extends RipTracksTable
         clickCount.isAcceptableOrUnknown(data['click_count']!, _clickCountMeta),
       );
     }
+    if (data.containsKey('pop_count')) {
+      context.handle(
+        _popCountMeta,
+        popCount.isAcceptableOrUnknown(data['pop_count']!, _popCountMeta),
+      );
+    }
+    if (data.containsKey('clipping_count')) {
+      context.handle(
+        _clippingCountMeta,
+        clippingCount.isAcceptableOrUnknown(
+          data['clipping_count']!,
+          _clippingCountMeta,
+        ),
+      );
+    }
+    if (data.containsKey('dropout_count')) {
+      context.handle(
+        _dropoutCountMeta,
+        dropoutCount.isAcceptableOrUnknown(
+          data['dropout_count']!,
+          _dropoutCountMeta,
+        ),
+      );
+    }
+    if (data.containsKey('defect_confidence')) {
+      context.handle(
+        _defectConfidenceMeta,
+        defectConfidence.isAcceptableOrUnknown(
+          data['defect_confidence']!,
+          _defectConfidenceMeta,
+        ),
+      );
+    }
     if (data.containsKey('rip_log_source')) {
       context.handle(
         _ripLogSourceMeta,
@@ -6707,6 +6788,22 @@ class $RipTracksTableTable extends RipTracksTable
         DriftSqlType.int,
         data['${effectivePrefix}click_count'],
       ),
+      popCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}pop_count'],
+      ),
+      clippingCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}clipping_count'],
+      ),
+      dropoutCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}dropout_count'],
+      ),
+      defectConfidence: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}defect_confidence'],
+      ),
       ripLogSource: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}rip_log_source'],
@@ -6743,6 +6840,10 @@ class RipTracksTableData extends DataClass
   final double? trackQuality;
   final String? copyCrc;
   final int? clickCount;
+  final int? popCount;
+  final int? clippingCount;
+  final int? dropoutCount;
+  final double? defectConfidence;
   final String? ripLogSource;
   final int? qualityCheckedAt;
   const RipTracksTableData({
@@ -6763,6 +6864,10 @@ class RipTracksTableData extends DataClass
     this.trackQuality,
     this.copyCrc,
     this.clickCount,
+    this.popCount,
+    this.clippingCount,
+    this.dropoutCount,
+    this.defectConfidence,
     this.ripLogSource,
     this.qualityCheckedAt,
   });
@@ -6805,6 +6910,18 @@ class RipTracksTableData extends DataClass
     }
     if (!nullToAbsent || clickCount != null) {
       map['click_count'] = Variable<int>(clickCount);
+    }
+    if (!nullToAbsent || popCount != null) {
+      map['pop_count'] = Variable<int>(popCount);
+    }
+    if (!nullToAbsent || clippingCount != null) {
+      map['clipping_count'] = Variable<int>(clippingCount);
+    }
+    if (!nullToAbsent || dropoutCount != null) {
+      map['dropout_count'] = Variable<int>(dropoutCount);
+    }
+    if (!nullToAbsent || defectConfidence != null) {
+      map['defect_confidence'] = Variable<double>(defectConfidence);
     }
     if (!nullToAbsent || ripLogSource != null) {
       map['rip_log_source'] = Variable<String>(ripLogSource);
@@ -6854,6 +6971,18 @@ class RipTracksTableData extends DataClass
       clickCount: clickCount == null && nullToAbsent
           ? const Value.absent()
           : Value(clickCount),
+      popCount: popCount == null && nullToAbsent
+          ? const Value.absent()
+          : Value(popCount),
+      clippingCount: clippingCount == null && nullToAbsent
+          ? const Value.absent()
+          : Value(clippingCount),
+      dropoutCount: dropoutCount == null && nullToAbsent
+          ? const Value.absent()
+          : Value(dropoutCount),
+      defectConfidence: defectConfidence == null && nullToAbsent
+          ? const Value.absent()
+          : Value(defectConfidence),
       ripLogSource: ripLogSource == null && nullToAbsent
           ? const Value.absent()
           : Value(ripLogSource),
@@ -6890,6 +7019,10 @@ class RipTracksTableData extends DataClass
       trackQuality: serializer.fromJson<double?>(json['trackQuality']),
       copyCrc: serializer.fromJson<String?>(json['copyCrc']),
       clickCount: serializer.fromJson<int?>(json['clickCount']),
+      popCount: serializer.fromJson<int?>(json['popCount']),
+      clippingCount: serializer.fromJson<int?>(json['clippingCount']),
+      dropoutCount: serializer.fromJson<int?>(json['dropoutCount']),
+      defectConfidence: serializer.fromJson<double?>(json['defectConfidence']),
       ripLogSource: serializer.fromJson<String?>(json['ripLogSource']),
       qualityCheckedAt: serializer.fromJson<int?>(json['qualityCheckedAt']),
     );
@@ -6915,6 +7048,10 @@ class RipTracksTableData extends DataClass
       'trackQuality': serializer.toJson<double?>(trackQuality),
       'copyCrc': serializer.toJson<String?>(copyCrc),
       'clickCount': serializer.toJson<int?>(clickCount),
+      'popCount': serializer.toJson<int?>(popCount),
+      'clippingCount': serializer.toJson<int?>(clippingCount),
+      'dropoutCount': serializer.toJson<int?>(dropoutCount),
+      'defectConfidence': serializer.toJson<double?>(defectConfidence),
       'ripLogSource': serializer.toJson<String?>(ripLogSource),
       'qualityCheckedAt': serializer.toJson<int?>(qualityCheckedAt),
     };
@@ -6938,6 +7075,10 @@ class RipTracksTableData extends DataClass
     Value<double?> trackQuality = const Value.absent(),
     Value<String?> copyCrc = const Value.absent(),
     Value<int?> clickCount = const Value.absent(),
+    Value<int?> popCount = const Value.absent(),
+    Value<int?> clippingCount = const Value.absent(),
+    Value<int?> dropoutCount = const Value.absent(),
+    Value<double?> defectConfidence = const Value.absent(),
     Value<String?> ripLogSource = const Value.absent(),
     Value<int?> qualityCheckedAt = const Value.absent(),
   }) => RipTracksTableData(
@@ -6966,6 +7107,14 @@ class RipTracksTableData extends DataClass
     trackQuality: trackQuality.present ? trackQuality.value : this.trackQuality,
     copyCrc: copyCrc.present ? copyCrc.value : this.copyCrc,
     clickCount: clickCount.present ? clickCount.value : this.clickCount,
+    popCount: popCount.present ? popCount.value : this.popCount,
+    clippingCount: clippingCount.present
+        ? clippingCount.value
+        : this.clippingCount,
+    dropoutCount: dropoutCount.present ? dropoutCount.value : this.dropoutCount,
+    defectConfidence: defectConfidence.present
+        ? defectConfidence.value
+        : this.defectConfidence,
     ripLogSource: ripLogSource.present ? ripLogSource.value : this.ripLogSource,
     qualityCheckedAt: qualityCheckedAt.present
         ? qualityCheckedAt.value
@@ -7012,6 +7161,16 @@ class RipTracksTableData extends DataClass
       clickCount: data.clickCount.present
           ? data.clickCount.value
           : this.clickCount,
+      popCount: data.popCount.present ? data.popCount.value : this.popCount,
+      clippingCount: data.clippingCount.present
+          ? data.clippingCount.value
+          : this.clippingCount,
+      dropoutCount: data.dropoutCount.present
+          ? data.dropoutCount.value
+          : this.dropoutCount,
+      defectConfidence: data.defectConfidence.present
+          ? data.defectConfidence.value
+          : this.defectConfidence,
       ripLogSource: data.ripLogSource.present
           ? data.ripLogSource.value
           : this.ripLogSource,
@@ -7041,6 +7200,10 @@ class RipTracksTableData extends DataClass
           ..write('trackQuality: $trackQuality, ')
           ..write('copyCrc: $copyCrc, ')
           ..write('clickCount: $clickCount, ')
+          ..write('popCount: $popCount, ')
+          ..write('clippingCount: $clippingCount, ')
+          ..write('dropoutCount: $dropoutCount, ')
+          ..write('defectConfidence: $defectConfidence, ')
           ..write('ripLogSource: $ripLogSource, ')
           ..write('qualityCheckedAt: $qualityCheckedAt')
           ..write(')'))
@@ -7048,7 +7211,7 @@ class RipTracksTableData extends DataClass
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     ripAlbumId,
     discNumber,
@@ -7066,9 +7229,13 @@ class RipTracksTableData extends DataClass
     trackQuality,
     copyCrc,
     clickCount,
+    popCount,
+    clippingCount,
+    dropoutCount,
+    defectConfidence,
     ripLogSource,
     qualityCheckedAt,
-  );
+  ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -7090,6 +7257,10 @@ class RipTracksTableData extends DataClass
           other.trackQuality == this.trackQuality &&
           other.copyCrc == this.copyCrc &&
           other.clickCount == this.clickCount &&
+          other.popCount == this.popCount &&
+          other.clippingCount == this.clippingCount &&
+          other.dropoutCount == this.dropoutCount &&
+          other.defectConfidence == this.defectConfidence &&
           other.ripLogSource == this.ripLogSource &&
           other.qualityCheckedAt == this.qualityCheckedAt);
 }
@@ -7112,6 +7283,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
   final Value<double?> trackQuality;
   final Value<String?> copyCrc;
   final Value<int?> clickCount;
+  final Value<int?> popCount;
+  final Value<int?> clippingCount;
+  final Value<int?> dropoutCount;
+  final Value<double?> defectConfidence;
   final Value<String?> ripLogSource;
   final Value<int?> qualityCheckedAt;
   final Value<int> rowid;
@@ -7133,6 +7308,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
     this.trackQuality = const Value.absent(),
     this.copyCrc = const Value.absent(),
     this.clickCount = const Value.absent(),
+    this.popCount = const Value.absent(),
+    this.clippingCount = const Value.absent(),
+    this.dropoutCount = const Value.absent(),
+    this.defectConfidence = const Value.absent(),
     this.ripLogSource = const Value.absent(),
     this.qualityCheckedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -7155,6 +7334,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
     this.trackQuality = const Value.absent(),
     this.copyCrc = const Value.absent(),
     this.clickCount = const Value.absent(),
+    this.popCount = const Value.absent(),
+    this.clippingCount = const Value.absent(),
+    this.dropoutCount = const Value.absent(),
+    this.defectConfidence = const Value.absent(),
     this.ripLogSource = const Value.absent(),
     this.qualityCheckedAt = const Value.absent(),
     this.rowid = const Value.absent(),
@@ -7182,6 +7365,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
     Expression<double>? trackQuality,
     Expression<String>? copyCrc,
     Expression<int>? clickCount,
+    Expression<int>? popCount,
+    Expression<int>? clippingCount,
+    Expression<int>? dropoutCount,
+    Expression<double>? defectConfidence,
     Expression<String>? ripLogSource,
     Expression<int>? qualityCheckedAt,
     Expression<int>? rowid,
@@ -7205,6 +7392,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
       if (trackQuality != null) 'track_quality': trackQuality,
       if (copyCrc != null) 'copy_crc': copyCrc,
       if (clickCount != null) 'click_count': clickCount,
+      if (popCount != null) 'pop_count': popCount,
+      if (clippingCount != null) 'clipping_count': clippingCount,
+      if (dropoutCount != null) 'dropout_count': dropoutCount,
+      if (defectConfidence != null) 'defect_confidence': defectConfidence,
       if (ripLogSource != null) 'rip_log_source': ripLogSource,
       if (qualityCheckedAt != null) 'quality_checked_at': qualityCheckedAt,
       if (rowid != null) 'rowid': rowid,
@@ -7229,6 +7420,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
     Value<double?>? trackQuality,
     Value<String?>? copyCrc,
     Value<int?>? clickCount,
+    Value<int?>? popCount,
+    Value<int?>? clippingCount,
+    Value<int?>? dropoutCount,
+    Value<double?>? defectConfidence,
     Value<String?>? ripLogSource,
     Value<int?>? qualityCheckedAt,
     Value<int>? rowid,
@@ -7252,6 +7447,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
       trackQuality: trackQuality ?? this.trackQuality,
       copyCrc: copyCrc ?? this.copyCrc,
       clickCount: clickCount ?? this.clickCount,
+      popCount: popCount ?? this.popCount,
+      clippingCount: clippingCount ?? this.clippingCount,
+      dropoutCount: dropoutCount ?? this.dropoutCount,
+      defectConfidence: defectConfidence ?? this.defectConfidence,
       ripLogSource: ripLogSource ?? this.ripLogSource,
       qualityCheckedAt: qualityCheckedAt ?? this.qualityCheckedAt,
       rowid: rowid ?? this.rowid,
@@ -7314,6 +7513,18 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
     if (clickCount.present) {
       map['click_count'] = Variable<int>(clickCount.value);
     }
+    if (popCount.present) {
+      map['pop_count'] = Variable<int>(popCount.value);
+    }
+    if (clippingCount.present) {
+      map['clipping_count'] = Variable<int>(clippingCount.value);
+    }
+    if (dropoutCount.present) {
+      map['dropout_count'] = Variable<int>(dropoutCount.value);
+    }
+    if (defectConfidence.present) {
+      map['defect_confidence'] = Variable<double>(defectConfidence.value);
+    }
     if (ripLogSource.present) {
       map['rip_log_source'] = Variable<String>(ripLogSource.value);
     }
@@ -7346,6 +7557,10 @@ class RipTracksTableCompanion extends UpdateCompanion<RipTracksTableData> {
           ..write('trackQuality: $trackQuality, ')
           ..write('copyCrc: $copyCrc, ')
           ..write('clickCount: $clickCount, ')
+          ..write('popCount: $popCount, ')
+          ..write('clippingCount: $clippingCount, ')
+          ..write('dropoutCount: $dropoutCount, ')
+          ..write('defectConfidence: $defectConfidence, ')
           ..write('ripLogSource: $ripLogSource, ')
           ..write('qualityCheckedAt: $qualityCheckedAt, ')
           ..write('rowid: $rowid')
@@ -16048,6 +16263,10 @@ typedef $$RipTracksTableTableCreateCompanionBuilder =
       Value<double?> trackQuality,
       Value<String?> copyCrc,
       Value<int?> clickCount,
+      Value<int?> popCount,
+      Value<int?> clippingCount,
+      Value<int?> dropoutCount,
+      Value<double?> defectConfidence,
       Value<String?> ripLogSource,
       Value<int?> qualityCheckedAt,
       Value<int> rowid,
@@ -16071,6 +16290,10 @@ typedef $$RipTracksTableTableUpdateCompanionBuilder =
       Value<double?> trackQuality,
       Value<String?> copyCrc,
       Value<int?> clickCount,
+      Value<int?> popCount,
+      Value<int?> clippingCount,
+      Value<int?> dropoutCount,
+      Value<double?> defectConfidence,
       Value<String?> ripLogSource,
       Value<int?> qualityCheckedAt,
       Value<int> rowid,
@@ -16228,6 +16451,26 @@ class $$RipTracksTableTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<int> get popCount => $composableBuilder(
+    column: $table.popCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get clippingCount => $composableBuilder(
+    column: $table.clippingCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get dropoutCount => $composableBuilder(
+    column: $table.dropoutCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get defectConfidence => $composableBuilder(
+    column: $table.defectConfidence,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get ripLogSource => $composableBuilder(
     column: $table.ripLogSource,
     builder: (column) => ColumnFilters(column),
@@ -16376,6 +16619,26 @@ class $$RipTracksTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get popCount => $composableBuilder(
+    column: $table.popCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get clippingCount => $composableBuilder(
+    column: $table.clippingCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get dropoutCount => $composableBuilder(
+    column: $table.dropoutCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get defectConfidence => $composableBuilder(
+    column: $table.defectConfidence,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get ripLogSource => $composableBuilder(
     column: $table.ripLogSource,
     builder: (column) => ColumnOrderings(column),
@@ -16484,6 +16747,24 @@ class $$RipTracksTableTableAnnotationComposer
 
   GeneratedColumn<int> get clickCount => $composableBuilder(
     column: $table.clickCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get popCount =>
+      $composableBuilder(column: $table.popCount, builder: (column) => column);
+
+  GeneratedColumn<int> get clippingCount => $composableBuilder(
+    column: $table.clippingCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get dropoutCount => $composableBuilder(
+    column: $table.dropoutCount,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get defectConfidence => $composableBuilder(
+    column: $table.defectConfidence,
     builder: (column) => column,
   );
 
@@ -16597,6 +16878,10 @@ class $$RipTracksTableTableTableManager
                 Value<double?> trackQuality = const Value.absent(),
                 Value<String?> copyCrc = const Value.absent(),
                 Value<int?> clickCount = const Value.absent(),
+                Value<int?> popCount = const Value.absent(),
+                Value<int?> clippingCount = const Value.absent(),
+                Value<int?> dropoutCount = const Value.absent(),
+                Value<double?> defectConfidence = const Value.absent(),
                 Value<String?> ripLogSource = const Value.absent(),
                 Value<int?> qualityCheckedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -16618,6 +16903,10 @@ class $$RipTracksTableTableTableManager
                 trackQuality: trackQuality,
                 copyCrc: copyCrc,
                 clickCount: clickCount,
+                popCount: popCount,
+                clippingCount: clippingCount,
+                dropoutCount: dropoutCount,
+                defectConfidence: defectConfidence,
                 ripLogSource: ripLogSource,
                 qualityCheckedAt: qualityCheckedAt,
                 rowid: rowid,
@@ -16641,6 +16930,10 @@ class $$RipTracksTableTableTableManager
                 Value<double?> trackQuality = const Value.absent(),
                 Value<String?> copyCrc = const Value.absent(),
                 Value<int?> clickCount = const Value.absent(),
+                Value<int?> popCount = const Value.absent(),
+                Value<int?> clippingCount = const Value.absent(),
+                Value<int?> dropoutCount = const Value.absent(),
+                Value<double?> defectConfidence = const Value.absent(),
                 Value<String?> ripLogSource = const Value.absent(),
                 Value<int?> qualityCheckedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
@@ -16662,6 +16955,10 @@ class $$RipTracksTableTableTableManager
                 trackQuality: trackQuality,
                 copyCrc: copyCrc,
                 clickCount: clickCount,
+                popCount: popCount,
+                clippingCount: clippingCount,
+                dropoutCount: dropoutCount,
+                defectConfidence: defectConfidence,
                 ripLogSource: ripLogSource,
                 qualityCheckedAt: qualityCheckedAt,
                 rowid: rowid,

--- a/lib/data/local/database/tables/rip_tracks_table.dart
+++ b/lib/data/local/database/tables/rip_tracks_table.dart
@@ -25,6 +25,14 @@ class RipTracksTable extends Table {
   RealColumn get trackQuality => real().nullable()();
   TextColumn get copyCrc => text().nullable()();
   IntColumn get clickCount => integer().nullable()();
+  // Per-DefectType counts from audio_defect_detector >= 0.2.0. clickCount
+  // continues to track the `click` type so existing read sites keep working;
+  // these three sit alongside it for `pop`, `clipping`, and `dropout`.
+  IntColumn get popCount => integer().nullable()();
+  IntColumn get clippingCount => integer().nullable()();
+  IntColumn get dropoutCount => integer().nullable()();
+  // AnalysisResult.aggregateConfidence (0.0–1.0) from the detector run.
+  RealColumn get defectConfidence => real().nullable()();
   TextColumn get ripLogSource => text().nullable()();
   IntColumn get qualityCheckedAt => integer().nullable()();
 

--- a/lib/data/repositories/rip_library_repository_impl.dart
+++ b/lib/data/repositories/rip_library_repository_impl.dart
@@ -86,29 +86,7 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
 
   @override
   Future<void> insertTracks(List<RipTrack> tracks) async {
-    final companions = tracks
-        .map((t) => RipTracksTableCompanion(
-              id: Value(t.id),
-              ripAlbumId: Value(t.ripAlbumId),
-              discNumber: Value(t.discNumber),
-              trackNumber: Value(t.trackNumber),
-              title: Value(t.title),
-              filePath: Value(t.filePath),
-              durationMs: Value(t.durationMs),
-              fileSizeBytes: Value(t.fileSizeBytes),
-              updatedAt: Value(t.updatedAt),
-              accurateripStatus: Value(t.accurateRipStatus),
-              accurateripConfidence: Value(t.accurateRipConfidence),
-              accurateripCrcV1: Value(t.accurateRipCrcV1),
-              accurateripCrcV2: Value(t.accurateRipCrcV2),
-              peakLevel: Value(t.peakLevel),
-              trackQuality: Value(t.trackQuality),
-              copyCrc: Value(t.copyCrc),
-              clickCount: Value(t.clickCount),
-              ripLogSource: Value(t.ripLogSource),
-              qualityCheckedAt: Value(t.qualityCheckedAt),
-            ))
-        .toList();
+    final companions = tracks.map(_trackCompanion).toList();
     await _dao.insertTracks(companions);
   }
 
@@ -171,6 +149,10 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
         trackQuality: Value(t.trackQuality),
         copyCrc: Value(t.copyCrc),
         clickCount: Value(t.clickCount),
+        popCount: Value(t.popCount),
+        clippingCount: Value(t.clippingCount),
+        dropoutCount: Value(t.dropoutCount),
+        defectConfidence: Value(t.defectConfidence),
         ripLogSource: Value(t.ripLogSource),
         qualityCheckedAt: Value(t.qualityCheckedAt),
       );
@@ -229,6 +211,10 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
     double? trackQuality,
     String? copyCrc,
     int? clickCount,
+    int? popCount,
+    int? clippingCount,
+    int? dropoutCount,
+    double? defectConfidence,
     String? ripLogSource,
     int? qualityCheckedAt,
   }) async {
@@ -242,6 +228,10 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
       trackQuality: trackQuality,
       copyCrc: copyCrc,
       clickCount: clickCount,
+      popCount: popCount,
+      clippingCount: clippingCount,
+      dropoutCount: dropoutCount,
+      defectConfidence: defectConfidence,
       ripLogSource: ripLogSource,
       qualityCheckedAt: qualityCheckedAt,
     );
@@ -265,6 +255,10 @@ class RipLibraryRepositoryImpl implements IRipLibraryRepository {
         trackQuality: row.trackQuality,
         copyCrc: row.copyCrc,
         clickCount: row.clickCount,
+        popCount: row.popCount,
+        clippingCount: row.clippingCount,
+        dropoutCount: row.dropoutCount,
+        defectConfidence: row.defectConfidence,
         ripLogSource: row.ripLogSource,
         qualityCheckedAt: row.qualityCheckedAt,
       );

--- a/lib/domain/entities/rip_track.dart
+++ b/lib/domain/entities/rip_track.dart
@@ -23,7 +23,23 @@ sealed class RipTrack with _$RipTrack {
     double? trackQuality,
     String? copyCrc,
     int? clickCount,
+    int? popCount,
+    int? clippingCount,
+    int? dropoutCount,
+    double? defectConfidence,
     String? ripLogSource,
     int? qualityCheckedAt,
   }) = _RipTrack;
+}
+
+extension RipTrackDefects on RipTrack {
+  /// Sum of every recorded defect-type count, or 0 if no detector run has
+  /// happened yet. UI predicates that previously asked `clickCount > 0`
+  /// should consult this instead so pops, clipping, and dropouts also
+  /// trigger the warning state.
+  int get totalDefects =>
+      (clickCount ?? 0) +
+      (popCount ?? 0) +
+      (clippingCount ?? 0) +
+      (dropoutCount ?? 0);
 }

--- a/lib/domain/entities/rip_track.freezed.dart
+++ b/lib/domain/entities/rip_track.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 mixin _$RipTrack {
 
  String get id; String get ripAlbumId; int get discNumber; int get trackNumber; String? get title; String get filePath; int? get durationMs; int get fileSizeBytes; int get updatedAt;// Audio quality analysis fields (Phase B)
- String? get accurateRipStatus; int? get accurateRipConfidence; String? get accurateRipCrcV1; String? get accurateRipCrcV2; double? get peakLevel; double? get trackQuality; String? get copyCrc; int? get clickCount; String? get ripLogSource; int? get qualityCheckedAt;
+ String? get accurateRipStatus; int? get accurateRipConfidence; String? get accurateRipCrcV1; String? get accurateRipCrcV2; double? get peakLevel; double? get trackQuality; String? get copyCrc; int? get clickCount; int? get popCount; int? get clippingCount; int? get dropoutCount; double? get defectConfidence; String? get ripLogSource; int? get qualityCheckedAt;
 /// Create a copy of RipTrack
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -26,16 +26,16 @@ $RipTrackCopyWith<RipTrack> get copyWith => _$RipTrackCopyWithImpl<RipTrack>(thi
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is RipTrack&&(identical(other.id, id) || other.id == id)&&(identical(other.ripAlbumId, ripAlbumId) || other.ripAlbumId == ripAlbumId)&&(identical(other.discNumber, discNumber) || other.discNumber == discNumber)&&(identical(other.trackNumber, trackNumber) || other.trackNumber == trackNumber)&&(identical(other.title, title) || other.title == title)&&(identical(other.filePath, filePath) || other.filePath == filePath)&&(identical(other.durationMs, durationMs) || other.durationMs == durationMs)&&(identical(other.fileSizeBytes, fileSizeBytes) || other.fileSizeBytes == fileSizeBytes)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.accurateRipStatus, accurateRipStatus) || other.accurateRipStatus == accurateRipStatus)&&(identical(other.accurateRipConfidence, accurateRipConfidence) || other.accurateRipConfidence == accurateRipConfidence)&&(identical(other.accurateRipCrcV1, accurateRipCrcV1) || other.accurateRipCrcV1 == accurateRipCrcV1)&&(identical(other.accurateRipCrcV2, accurateRipCrcV2) || other.accurateRipCrcV2 == accurateRipCrcV2)&&(identical(other.peakLevel, peakLevel) || other.peakLevel == peakLevel)&&(identical(other.trackQuality, trackQuality) || other.trackQuality == trackQuality)&&(identical(other.copyCrc, copyCrc) || other.copyCrc == copyCrc)&&(identical(other.clickCount, clickCount) || other.clickCount == clickCount)&&(identical(other.ripLogSource, ripLogSource) || other.ripLogSource == ripLogSource)&&(identical(other.qualityCheckedAt, qualityCheckedAt) || other.qualityCheckedAt == qualityCheckedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is RipTrack&&(identical(other.id, id) || other.id == id)&&(identical(other.ripAlbumId, ripAlbumId) || other.ripAlbumId == ripAlbumId)&&(identical(other.discNumber, discNumber) || other.discNumber == discNumber)&&(identical(other.trackNumber, trackNumber) || other.trackNumber == trackNumber)&&(identical(other.title, title) || other.title == title)&&(identical(other.filePath, filePath) || other.filePath == filePath)&&(identical(other.durationMs, durationMs) || other.durationMs == durationMs)&&(identical(other.fileSizeBytes, fileSizeBytes) || other.fileSizeBytes == fileSizeBytes)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.accurateRipStatus, accurateRipStatus) || other.accurateRipStatus == accurateRipStatus)&&(identical(other.accurateRipConfidence, accurateRipConfidence) || other.accurateRipConfidence == accurateRipConfidence)&&(identical(other.accurateRipCrcV1, accurateRipCrcV1) || other.accurateRipCrcV1 == accurateRipCrcV1)&&(identical(other.accurateRipCrcV2, accurateRipCrcV2) || other.accurateRipCrcV2 == accurateRipCrcV2)&&(identical(other.peakLevel, peakLevel) || other.peakLevel == peakLevel)&&(identical(other.trackQuality, trackQuality) || other.trackQuality == trackQuality)&&(identical(other.copyCrc, copyCrc) || other.copyCrc == copyCrc)&&(identical(other.clickCount, clickCount) || other.clickCount == clickCount)&&(identical(other.popCount, popCount) || other.popCount == popCount)&&(identical(other.clippingCount, clippingCount) || other.clippingCount == clippingCount)&&(identical(other.dropoutCount, dropoutCount) || other.dropoutCount == dropoutCount)&&(identical(other.defectConfidence, defectConfidence) || other.defectConfidence == defectConfidence)&&(identical(other.ripLogSource, ripLogSource) || other.ripLogSource == ripLogSource)&&(identical(other.qualityCheckedAt, qualityCheckedAt) || other.qualityCheckedAt == qualityCheckedAt));
 }
 
 
 @override
-int get hashCode => Object.hashAll([runtimeType,id,ripAlbumId,discNumber,trackNumber,title,filePath,durationMs,fileSizeBytes,updatedAt,accurateRipStatus,accurateRipConfidence,accurateRipCrcV1,accurateRipCrcV2,peakLevel,trackQuality,copyCrc,clickCount,ripLogSource,qualityCheckedAt]);
+int get hashCode => Object.hashAll([runtimeType,id,ripAlbumId,discNumber,trackNumber,title,filePath,durationMs,fileSizeBytes,updatedAt,accurateRipStatus,accurateRipConfidence,accurateRipCrcV1,accurateRipCrcV2,peakLevel,trackQuality,copyCrc,clickCount,popCount,clippingCount,dropoutCount,defectConfidence,ripLogSource,qualityCheckedAt]);
 
 @override
 String toString() {
-  return 'RipTrack(id: $id, ripAlbumId: $ripAlbumId, discNumber: $discNumber, trackNumber: $trackNumber, title: $title, filePath: $filePath, durationMs: $durationMs, fileSizeBytes: $fileSizeBytes, updatedAt: $updatedAt, accurateRipStatus: $accurateRipStatus, accurateRipConfidence: $accurateRipConfidence, accurateRipCrcV1: $accurateRipCrcV1, accurateRipCrcV2: $accurateRipCrcV2, peakLevel: $peakLevel, trackQuality: $trackQuality, copyCrc: $copyCrc, clickCount: $clickCount, ripLogSource: $ripLogSource, qualityCheckedAt: $qualityCheckedAt)';
+  return 'RipTrack(id: $id, ripAlbumId: $ripAlbumId, discNumber: $discNumber, trackNumber: $trackNumber, title: $title, filePath: $filePath, durationMs: $durationMs, fileSizeBytes: $fileSizeBytes, updatedAt: $updatedAt, accurateRipStatus: $accurateRipStatus, accurateRipConfidence: $accurateRipConfidence, accurateRipCrcV1: $accurateRipCrcV1, accurateRipCrcV2: $accurateRipCrcV2, peakLevel: $peakLevel, trackQuality: $trackQuality, copyCrc: $copyCrc, clickCount: $clickCount, popCount: $popCount, clippingCount: $clippingCount, dropoutCount: $dropoutCount, defectConfidence: $defectConfidence, ripLogSource: $ripLogSource, qualityCheckedAt: $qualityCheckedAt)';
 }
 
 
@@ -46,7 +46,7 @@ abstract mixin class $RipTrackCopyWith<$Res>  {
   factory $RipTrackCopyWith(RipTrack value, $Res Function(RipTrack) _then) = _$RipTrackCopyWithImpl;
 @useResult
 $Res call({
- String id, String ripAlbumId, int discNumber, int trackNumber, String? title, String filePath, int? durationMs, int fileSizeBytes, int updatedAt, String? accurateRipStatus, int? accurateRipConfidence, String? accurateRipCrcV1, String? accurateRipCrcV2, double? peakLevel, double? trackQuality, String? copyCrc, int? clickCount, String? ripLogSource, int? qualityCheckedAt
+ String id, String ripAlbumId, int discNumber, int trackNumber, String? title, String filePath, int? durationMs, int fileSizeBytes, int updatedAt, String? accurateRipStatus, int? accurateRipConfidence, String? accurateRipCrcV1, String? accurateRipCrcV2, double? peakLevel, double? trackQuality, String? copyCrc, int? clickCount, int? popCount, int? clippingCount, int? dropoutCount, double? defectConfidence, String? ripLogSource, int? qualityCheckedAt
 });
 
 
@@ -63,7 +63,7 @@ class _$RipTrackCopyWithImpl<$Res>
 
 /// Create a copy of RipTrack
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? ripAlbumId = null,Object? discNumber = null,Object? trackNumber = null,Object? title = freezed,Object? filePath = null,Object? durationMs = freezed,Object? fileSizeBytes = null,Object? updatedAt = null,Object? accurateRipStatus = freezed,Object? accurateRipConfidence = freezed,Object? accurateRipCrcV1 = freezed,Object? accurateRipCrcV2 = freezed,Object? peakLevel = freezed,Object? trackQuality = freezed,Object? copyCrc = freezed,Object? clickCount = freezed,Object? ripLogSource = freezed,Object? qualityCheckedAt = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? ripAlbumId = null,Object? discNumber = null,Object? trackNumber = null,Object? title = freezed,Object? filePath = null,Object? durationMs = freezed,Object? fileSizeBytes = null,Object? updatedAt = null,Object? accurateRipStatus = freezed,Object? accurateRipConfidence = freezed,Object? accurateRipCrcV1 = freezed,Object? accurateRipCrcV2 = freezed,Object? peakLevel = freezed,Object? trackQuality = freezed,Object? copyCrc = freezed,Object? clickCount = freezed,Object? popCount = freezed,Object? clippingCount = freezed,Object? dropoutCount = freezed,Object? defectConfidence = freezed,Object? ripLogSource = freezed,Object? qualityCheckedAt = freezed,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,ripAlbumId: null == ripAlbumId ? _self.ripAlbumId : ripAlbumId // ignore: cast_nullable_to_non_nullable
@@ -82,7 +82,11 @@ as String?,peakLevel: freezed == peakLevel ? _self.peakLevel : peakLevel // igno
 as double?,trackQuality: freezed == trackQuality ? _self.trackQuality : trackQuality // ignore: cast_nullable_to_non_nullable
 as double?,copyCrc: freezed == copyCrc ? _self.copyCrc : copyCrc // ignore: cast_nullable_to_non_nullable
 as String?,clickCount: freezed == clickCount ? _self.clickCount : clickCount // ignore: cast_nullable_to_non_nullable
-as int?,ripLogSource: freezed == ripLogSource ? _self.ripLogSource : ripLogSource // ignore: cast_nullable_to_non_nullable
+as int?,popCount: freezed == popCount ? _self.popCount : popCount // ignore: cast_nullable_to_non_nullable
+as int?,clippingCount: freezed == clippingCount ? _self.clippingCount : clippingCount // ignore: cast_nullable_to_non_nullable
+as int?,dropoutCount: freezed == dropoutCount ? _self.dropoutCount : dropoutCount // ignore: cast_nullable_to_non_nullable
+as int?,defectConfidence: freezed == defectConfidence ? _self.defectConfidence : defectConfidence // ignore: cast_nullable_to_non_nullable
+as double?,ripLogSource: freezed == ripLogSource ? _self.ripLogSource : ripLogSource // ignore: cast_nullable_to_non_nullable
 as String?,qualityCheckedAt: freezed == qualityCheckedAt ? _self.qualityCheckedAt : qualityCheckedAt // ignore: cast_nullable_to_non_nullable
 as int?,
   ));
@@ -166,10 +170,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String ripAlbumId,  int discNumber,  int trackNumber,  String? title,  String filePath,  int? durationMs,  int fileSizeBytes,  int updatedAt,  String? accurateRipStatus,  int? accurateRipConfidence,  String? accurateRipCrcV1,  String? accurateRipCrcV2,  double? peakLevel,  double? trackQuality,  String? copyCrc,  int? clickCount,  String? ripLogSource,  int? qualityCheckedAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String ripAlbumId,  int discNumber,  int trackNumber,  String? title,  String filePath,  int? durationMs,  int fileSizeBytes,  int updatedAt,  String? accurateRipStatus,  int? accurateRipConfidence,  String? accurateRipCrcV1,  String? accurateRipCrcV2,  double? peakLevel,  double? trackQuality,  String? copyCrc,  int? clickCount,  int? popCount,  int? clippingCount,  int? dropoutCount,  double? defectConfidence,  String? ripLogSource,  int? qualityCheckedAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _RipTrack() when $default != null:
-return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_that.title,_that.filePath,_that.durationMs,_that.fileSizeBytes,_that.updatedAt,_that.accurateRipStatus,_that.accurateRipConfidence,_that.accurateRipCrcV1,_that.accurateRipCrcV2,_that.peakLevel,_that.trackQuality,_that.copyCrc,_that.clickCount,_that.ripLogSource,_that.qualityCheckedAt);case _:
+return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_that.title,_that.filePath,_that.durationMs,_that.fileSizeBytes,_that.updatedAt,_that.accurateRipStatus,_that.accurateRipConfidence,_that.accurateRipCrcV1,_that.accurateRipCrcV2,_that.peakLevel,_that.trackQuality,_that.copyCrc,_that.clickCount,_that.popCount,_that.clippingCount,_that.dropoutCount,_that.defectConfidence,_that.ripLogSource,_that.qualityCheckedAt);case _:
   return orElse();
 
 }
@@ -187,10 +191,10 @@ return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String ripAlbumId,  int discNumber,  int trackNumber,  String? title,  String filePath,  int? durationMs,  int fileSizeBytes,  int updatedAt,  String? accurateRipStatus,  int? accurateRipConfidence,  String? accurateRipCrcV1,  String? accurateRipCrcV2,  double? peakLevel,  double? trackQuality,  String? copyCrc,  int? clickCount,  String? ripLogSource,  int? qualityCheckedAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String ripAlbumId,  int discNumber,  int trackNumber,  String? title,  String filePath,  int? durationMs,  int fileSizeBytes,  int updatedAt,  String? accurateRipStatus,  int? accurateRipConfidence,  String? accurateRipCrcV1,  String? accurateRipCrcV2,  double? peakLevel,  double? trackQuality,  String? copyCrc,  int? clickCount,  int? popCount,  int? clippingCount,  int? dropoutCount,  double? defectConfidence,  String? ripLogSource,  int? qualityCheckedAt)  $default,) {final _that = this;
 switch (_that) {
 case _RipTrack():
-return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_that.title,_that.filePath,_that.durationMs,_that.fileSizeBytes,_that.updatedAt,_that.accurateRipStatus,_that.accurateRipConfidence,_that.accurateRipCrcV1,_that.accurateRipCrcV2,_that.peakLevel,_that.trackQuality,_that.copyCrc,_that.clickCount,_that.ripLogSource,_that.qualityCheckedAt);}
+return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_that.title,_that.filePath,_that.durationMs,_that.fileSizeBytes,_that.updatedAt,_that.accurateRipStatus,_that.accurateRipConfidence,_that.accurateRipCrcV1,_that.accurateRipCrcV2,_that.peakLevel,_that.trackQuality,_that.copyCrc,_that.clickCount,_that.popCount,_that.clippingCount,_that.dropoutCount,_that.defectConfidence,_that.ripLogSource,_that.qualityCheckedAt);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -204,10 +208,10 @@ return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_th
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String ripAlbumId,  int discNumber,  int trackNumber,  String? title,  String filePath,  int? durationMs,  int fileSizeBytes,  int updatedAt,  String? accurateRipStatus,  int? accurateRipConfidence,  String? accurateRipCrcV1,  String? accurateRipCrcV2,  double? peakLevel,  double? trackQuality,  String? copyCrc,  int? clickCount,  String? ripLogSource,  int? qualityCheckedAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String ripAlbumId,  int discNumber,  int trackNumber,  String? title,  String filePath,  int? durationMs,  int fileSizeBytes,  int updatedAt,  String? accurateRipStatus,  int? accurateRipConfidence,  String? accurateRipCrcV1,  String? accurateRipCrcV2,  double? peakLevel,  double? trackQuality,  String? copyCrc,  int? clickCount,  int? popCount,  int? clippingCount,  int? dropoutCount,  double? defectConfidence,  String? ripLogSource,  int? qualityCheckedAt)?  $default,) {final _that = this;
 switch (_that) {
 case _RipTrack() when $default != null:
-return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_that.title,_that.filePath,_that.durationMs,_that.fileSizeBytes,_that.updatedAt,_that.accurateRipStatus,_that.accurateRipConfidence,_that.accurateRipCrcV1,_that.accurateRipCrcV2,_that.peakLevel,_that.trackQuality,_that.copyCrc,_that.clickCount,_that.ripLogSource,_that.qualityCheckedAt);case _:
+return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_that.title,_that.filePath,_that.durationMs,_that.fileSizeBytes,_that.updatedAt,_that.accurateRipStatus,_that.accurateRipConfidence,_that.accurateRipCrcV1,_that.accurateRipCrcV2,_that.peakLevel,_that.trackQuality,_that.copyCrc,_that.clickCount,_that.popCount,_that.clippingCount,_that.dropoutCount,_that.defectConfidence,_that.ripLogSource,_that.qualityCheckedAt);case _:
   return null;
 
 }
@@ -219,7 +223,7 @@ return $default(_that.id,_that.ripAlbumId,_that.discNumber,_that.trackNumber,_th
 
 
 class _RipTrack implements RipTrack {
-  const _RipTrack({required this.id, required this.ripAlbumId, this.discNumber = 1, required this.trackNumber, this.title, required this.filePath, this.durationMs, required this.fileSizeBytes, required this.updatedAt, this.accurateRipStatus, this.accurateRipConfidence, this.accurateRipCrcV1, this.accurateRipCrcV2, this.peakLevel, this.trackQuality, this.copyCrc, this.clickCount, this.ripLogSource, this.qualityCheckedAt});
+  const _RipTrack({required this.id, required this.ripAlbumId, this.discNumber = 1, required this.trackNumber, this.title, required this.filePath, this.durationMs, required this.fileSizeBytes, required this.updatedAt, this.accurateRipStatus, this.accurateRipConfidence, this.accurateRipCrcV1, this.accurateRipCrcV2, this.peakLevel, this.trackQuality, this.copyCrc, this.clickCount, this.popCount, this.clippingCount, this.dropoutCount, this.defectConfidence, this.ripLogSource, this.qualityCheckedAt});
   
 
 @override final  String id;
@@ -240,6 +244,10 @@ class _RipTrack implements RipTrack {
 @override final  double? trackQuality;
 @override final  String? copyCrc;
 @override final  int? clickCount;
+@override final  int? popCount;
+@override final  int? clippingCount;
+@override final  int? dropoutCount;
+@override final  double? defectConfidence;
 @override final  String? ripLogSource;
 @override final  int? qualityCheckedAt;
 
@@ -253,16 +261,16 @@ _$RipTrackCopyWith<_RipTrack> get copyWith => __$RipTrackCopyWithImpl<_RipTrack>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RipTrack&&(identical(other.id, id) || other.id == id)&&(identical(other.ripAlbumId, ripAlbumId) || other.ripAlbumId == ripAlbumId)&&(identical(other.discNumber, discNumber) || other.discNumber == discNumber)&&(identical(other.trackNumber, trackNumber) || other.trackNumber == trackNumber)&&(identical(other.title, title) || other.title == title)&&(identical(other.filePath, filePath) || other.filePath == filePath)&&(identical(other.durationMs, durationMs) || other.durationMs == durationMs)&&(identical(other.fileSizeBytes, fileSizeBytes) || other.fileSizeBytes == fileSizeBytes)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.accurateRipStatus, accurateRipStatus) || other.accurateRipStatus == accurateRipStatus)&&(identical(other.accurateRipConfidence, accurateRipConfidence) || other.accurateRipConfidence == accurateRipConfidence)&&(identical(other.accurateRipCrcV1, accurateRipCrcV1) || other.accurateRipCrcV1 == accurateRipCrcV1)&&(identical(other.accurateRipCrcV2, accurateRipCrcV2) || other.accurateRipCrcV2 == accurateRipCrcV2)&&(identical(other.peakLevel, peakLevel) || other.peakLevel == peakLevel)&&(identical(other.trackQuality, trackQuality) || other.trackQuality == trackQuality)&&(identical(other.copyCrc, copyCrc) || other.copyCrc == copyCrc)&&(identical(other.clickCount, clickCount) || other.clickCount == clickCount)&&(identical(other.ripLogSource, ripLogSource) || other.ripLogSource == ripLogSource)&&(identical(other.qualityCheckedAt, qualityCheckedAt) || other.qualityCheckedAt == qualityCheckedAt));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _RipTrack&&(identical(other.id, id) || other.id == id)&&(identical(other.ripAlbumId, ripAlbumId) || other.ripAlbumId == ripAlbumId)&&(identical(other.discNumber, discNumber) || other.discNumber == discNumber)&&(identical(other.trackNumber, trackNumber) || other.trackNumber == trackNumber)&&(identical(other.title, title) || other.title == title)&&(identical(other.filePath, filePath) || other.filePath == filePath)&&(identical(other.durationMs, durationMs) || other.durationMs == durationMs)&&(identical(other.fileSizeBytes, fileSizeBytes) || other.fileSizeBytes == fileSizeBytes)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.accurateRipStatus, accurateRipStatus) || other.accurateRipStatus == accurateRipStatus)&&(identical(other.accurateRipConfidence, accurateRipConfidence) || other.accurateRipConfidence == accurateRipConfidence)&&(identical(other.accurateRipCrcV1, accurateRipCrcV1) || other.accurateRipCrcV1 == accurateRipCrcV1)&&(identical(other.accurateRipCrcV2, accurateRipCrcV2) || other.accurateRipCrcV2 == accurateRipCrcV2)&&(identical(other.peakLevel, peakLevel) || other.peakLevel == peakLevel)&&(identical(other.trackQuality, trackQuality) || other.trackQuality == trackQuality)&&(identical(other.copyCrc, copyCrc) || other.copyCrc == copyCrc)&&(identical(other.clickCount, clickCount) || other.clickCount == clickCount)&&(identical(other.popCount, popCount) || other.popCount == popCount)&&(identical(other.clippingCount, clippingCount) || other.clippingCount == clippingCount)&&(identical(other.dropoutCount, dropoutCount) || other.dropoutCount == dropoutCount)&&(identical(other.defectConfidence, defectConfidence) || other.defectConfidence == defectConfidence)&&(identical(other.ripLogSource, ripLogSource) || other.ripLogSource == ripLogSource)&&(identical(other.qualityCheckedAt, qualityCheckedAt) || other.qualityCheckedAt == qualityCheckedAt));
 }
 
 
 @override
-int get hashCode => Object.hashAll([runtimeType,id,ripAlbumId,discNumber,trackNumber,title,filePath,durationMs,fileSizeBytes,updatedAt,accurateRipStatus,accurateRipConfidence,accurateRipCrcV1,accurateRipCrcV2,peakLevel,trackQuality,copyCrc,clickCount,ripLogSource,qualityCheckedAt]);
+int get hashCode => Object.hashAll([runtimeType,id,ripAlbumId,discNumber,trackNumber,title,filePath,durationMs,fileSizeBytes,updatedAt,accurateRipStatus,accurateRipConfidence,accurateRipCrcV1,accurateRipCrcV2,peakLevel,trackQuality,copyCrc,clickCount,popCount,clippingCount,dropoutCount,defectConfidence,ripLogSource,qualityCheckedAt]);
 
 @override
 String toString() {
-  return 'RipTrack(id: $id, ripAlbumId: $ripAlbumId, discNumber: $discNumber, trackNumber: $trackNumber, title: $title, filePath: $filePath, durationMs: $durationMs, fileSizeBytes: $fileSizeBytes, updatedAt: $updatedAt, accurateRipStatus: $accurateRipStatus, accurateRipConfidence: $accurateRipConfidence, accurateRipCrcV1: $accurateRipCrcV1, accurateRipCrcV2: $accurateRipCrcV2, peakLevel: $peakLevel, trackQuality: $trackQuality, copyCrc: $copyCrc, clickCount: $clickCount, ripLogSource: $ripLogSource, qualityCheckedAt: $qualityCheckedAt)';
+  return 'RipTrack(id: $id, ripAlbumId: $ripAlbumId, discNumber: $discNumber, trackNumber: $trackNumber, title: $title, filePath: $filePath, durationMs: $durationMs, fileSizeBytes: $fileSizeBytes, updatedAt: $updatedAt, accurateRipStatus: $accurateRipStatus, accurateRipConfidence: $accurateRipConfidence, accurateRipCrcV1: $accurateRipCrcV1, accurateRipCrcV2: $accurateRipCrcV2, peakLevel: $peakLevel, trackQuality: $trackQuality, copyCrc: $copyCrc, clickCount: $clickCount, popCount: $popCount, clippingCount: $clippingCount, dropoutCount: $dropoutCount, defectConfidence: $defectConfidence, ripLogSource: $ripLogSource, qualityCheckedAt: $qualityCheckedAt)';
 }
 
 
@@ -273,7 +281,7 @@ abstract mixin class _$RipTrackCopyWith<$Res> implements $RipTrackCopyWith<$Res>
   factory _$RipTrackCopyWith(_RipTrack value, $Res Function(_RipTrack) _then) = __$RipTrackCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String ripAlbumId, int discNumber, int trackNumber, String? title, String filePath, int? durationMs, int fileSizeBytes, int updatedAt, String? accurateRipStatus, int? accurateRipConfidence, String? accurateRipCrcV1, String? accurateRipCrcV2, double? peakLevel, double? trackQuality, String? copyCrc, int? clickCount, String? ripLogSource, int? qualityCheckedAt
+ String id, String ripAlbumId, int discNumber, int trackNumber, String? title, String filePath, int? durationMs, int fileSizeBytes, int updatedAt, String? accurateRipStatus, int? accurateRipConfidence, String? accurateRipCrcV1, String? accurateRipCrcV2, double? peakLevel, double? trackQuality, String? copyCrc, int? clickCount, int? popCount, int? clippingCount, int? dropoutCount, double? defectConfidence, String? ripLogSource, int? qualityCheckedAt
 });
 
 
@@ -290,7 +298,7 @@ class __$RipTrackCopyWithImpl<$Res>
 
 /// Create a copy of RipTrack
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? ripAlbumId = null,Object? discNumber = null,Object? trackNumber = null,Object? title = freezed,Object? filePath = null,Object? durationMs = freezed,Object? fileSizeBytes = null,Object? updatedAt = null,Object? accurateRipStatus = freezed,Object? accurateRipConfidence = freezed,Object? accurateRipCrcV1 = freezed,Object? accurateRipCrcV2 = freezed,Object? peakLevel = freezed,Object? trackQuality = freezed,Object? copyCrc = freezed,Object? clickCount = freezed,Object? ripLogSource = freezed,Object? qualityCheckedAt = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? ripAlbumId = null,Object? discNumber = null,Object? trackNumber = null,Object? title = freezed,Object? filePath = null,Object? durationMs = freezed,Object? fileSizeBytes = null,Object? updatedAt = null,Object? accurateRipStatus = freezed,Object? accurateRipConfidence = freezed,Object? accurateRipCrcV1 = freezed,Object? accurateRipCrcV2 = freezed,Object? peakLevel = freezed,Object? trackQuality = freezed,Object? copyCrc = freezed,Object? clickCount = freezed,Object? popCount = freezed,Object? clippingCount = freezed,Object? dropoutCount = freezed,Object? defectConfidence = freezed,Object? ripLogSource = freezed,Object? qualityCheckedAt = freezed,}) {
   return _then(_RipTrack(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,ripAlbumId: null == ripAlbumId ? _self.ripAlbumId : ripAlbumId // ignore: cast_nullable_to_non_nullable
@@ -309,7 +317,11 @@ as String?,peakLevel: freezed == peakLevel ? _self.peakLevel : peakLevel // igno
 as double?,trackQuality: freezed == trackQuality ? _self.trackQuality : trackQuality // ignore: cast_nullable_to_non_nullable
 as double?,copyCrc: freezed == copyCrc ? _self.copyCrc : copyCrc // ignore: cast_nullable_to_non_nullable
 as String?,clickCount: freezed == clickCount ? _self.clickCount : clickCount // ignore: cast_nullable_to_non_nullable
-as int?,ripLogSource: freezed == ripLogSource ? _self.ripLogSource : ripLogSource // ignore: cast_nullable_to_non_nullable
+as int?,popCount: freezed == popCount ? _self.popCount : popCount // ignore: cast_nullable_to_non_nullable
+as int?,clippingCount: freezed == clippingCount ? _self.clippingCount : clippingCount // ignore: cast_nullable_to_non_nullable
+as int?,dropoutCount: freezed == dropoutCount ? _self.dropoutCount : dropoutCount // ignore: cast_nullable_to_non_nullable
+as int?,defectConfidence: freezed == defectConfidence ? _self.defectConfidence : defectConfidence // ignore: cast_nullable_to_non_nullable
+as double?,ripLogSource: freezed == ripLogSource ? _self.ripLogSource : ripLogSource // ignore: cast_nullable_to_non_nullable
 as String?,qualityCheckedAt: freezed == qualityCheckedAt ? _self.qualityCheckedAt : qualityCheckedAt // ignore: cast_nullable_to_non_nullable
 as int?,
   ));

--- a/lib/domain/repositories/i_rip_library_repository.dart
+++ b/lib/domain/repositories/i_rip_library_repository.dart
@@ -39,6 +39,10 @@ abstract interface class IRipLibraryRepository {
     double? trackQuality,
     String? copyCrc,
     int? clickCount,
+    int? popCount,
+    int? clippingCount,
+    int? dropoutCount,
+    double? defectConfidence,
     String? ripLogSource,
     int? qualityCheckedAt,
   });

--- a/lib/domain/usecases/analyse_rip_quality_usecase.dart
+++ b/lib/domain/usecases/analyse_rip_quality_usecase.dart
@@ -3,7 +3,8 @@
 /// Implements a three-tier analysis pipeline:
 /// 1. Parse rip log files (cheapest)
 /// 2. Query AccurateRip database
-/// 3. Statistical click/pop detection (most expensive)
+/// 3. Statistical defect detection — clicks, pops, clipping, and
+///    dropouts via [package:audio_defect_detector] (most expensive)
 ///
 /// Author: Paul Snow
 /// Since: 0.0.0
@@ -52,6 +53,19 @@ typedef IsolateRunner = Future<R> Function<R>(
 /// sample counts) without writing real FLAC files to disk.
 typedef FlacMetadataReader = Future<FlacMetadata?> Function(String filePath);
 
+/// Signature for the audio defect detection step.
+///
+/// Defaults to a thin wrapper around [add.analysePcm]; tests inject a
+/// fake that returns a curated [add.AnalysisResult] so the per-DefectType
+/// partition can be verified deterministically without having to craft
+/// PCM data that produces clicks/pops/clipping/dropouts in the real
+/// detector.
+typedef DefectDetector = add.AnalysisResult Function(
+  Uint8List pcmData, {
+  required add.PcmFormat format,
+  required add.DetectorConfig config,
+});
+
 /// Analyses the audio quality of all tracks in a rip album.
 class AnalyseRipQualityUseCase {
   AnalyseRipQualityUseCase({
@@ -61,15 +75,24 @@ class AnalyseRipQualityUseCase {
     this.sensitivity = add.Sensitivity.medium,
     IsolateRunner? isolateRunner,
     FlacMetadataReader? flacMetadataReader,
+    DefectDetector? defectDetector,
   })  : _repository = repository,
         _flacDecoder = flacDecoder,
         _arClient = accurateRipClient,
         _isolateRunner = isolateRunner ?? _defaultIsolateRunner,
-        _metadataReader = flacMetadataReader ?? FlacReader.readMetadata;
+        _metadataReader = flacMetadataReader ?? FlacReader.readMetadata,
+        _defectDetector = defectDetector ?? _defaultDefectDetector;
 
   static Future<R> _defaultIsolateRunner<R>(
           FutureOr<R> Function() computation) =>
       Isolate.run(computation);
+
+  static add.AnalysisResult _defaultDefectDetector(
+    Uint8List pcmData, {
+    required add.PcmFormat format,
+    required add.DetectorConfig config,
+  }) =>
+      add.analysePcm(pcmData, format: format, config: config);
 
   final IRipLibraryRepository _repository;
   final FlacDecoder _flacDecoder;
@@ -77,6 +100,7 @@ class AnalyseRipQualityUseCase {
   final add.Sensitivity sensitivity;
   final IsolateRunner _isolateRunner;
   final FlacMetadataReader _metadataReader;
+  final DefectDetector _defectDetector;
 
   /// Execute the analysis pipeline for the given album.
   ///
@@ -268,29 +292,49 @@ class AnalyseRipQualityUseCase {
         }
       }
 
-      // Step 3: No AR data — run click detection
+      // Step 3: No AR data — run defect detection
       yield QualityAnalysisProgress(
         currentTrack: i + 1,
         totalTracks: totalTracks,
-        currentStep: 'Detecting clicks on track ${track.trackNumber}',
+        currentStep: 'Detecting defects on track ${track.trackNumber}',
       );
 
-      final clickResult = await _isolateRunner(() {
-        return add.analysePcm(
+      // Capture the detector and sensitivity for the isolate closure so
+      // we don't reach back through `this` once we cross the isolate
+      // boundary.
+      final detector = _defectDetector;
+      final detectorSensitivity = sensitivity;
+      final detectionResult = await _isolateRunner(() {
+        return detector(
           pcmData,
           format: const add.PcmFormat(
             sampleRate: 44100,
             bitDepth: 16,
             channels: 2,
           ),
-          config: add.DetectorConfig(sensitivity: sensitivity),
+          config: add.DetectorConfig(sensitivity: detectorSensitivity),
         );
       });
+
+      // Partition defects by DefectType. Initialising every type to 0
+      // means tracks with no detections of a given type record an
+      // explicit zero rather than NULL, so UI predicates can treat
+      // "checked" as "non-null".
+      final byType = <add.DefectType, int>{
+        for (final type in add.DefectType.values) type: 0,
+      };
+      for (final defect in detectionResult.defects) {
+        byType[defect.type] = (byType[defect.type] ?? 0) + 1;
+      }
 
       await _repository.updateTrackQuality(
         track.id,
         arStatus: 'not_found',
-        clickCount: clickResult.defects.length,
+        clickCount: byType[add.DefectType.click] ?? 0,
+        popCount: byType[add.DefectType.pop] ?? 0,
+        clippingCount: byType[add.DefectType.clipping] ?? 0,
+        dropoutCount: byType[add.DefectType.dropout] ?? 0,
+        defectConfidence: detectionResult.aggregateConfidence,
         qualityCheckedAt: now,
       );
     }

--- a/lib/presentation/providers/collection_rip_status_provider.dart
+++ b/lib/presentation/providers/collection_rip_status_provider.dart
@@ -9,6 +9,7 @@ library;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 
@@ -76,8 +77,7 @@ final mediaItemRipStatusProvider =
   if (tracksWithData.isEmpty) return RipStatus.ripped;
 
   final hasIssues = tracksWithData.any((t) =>
-      t.accurateRipStatus != 'verified' ||
-      (t.clickCount != null && t.clickCount! > 0));
+      t.accurateRipStatus != 'verified' || t.totalDefects > 0);
   if (hasIssues) return RipStatus.qualityIssues;
 
   return RipStatus.verified;
@@ -162,7 +162,7 @@ final ripQualityStatusCacheProvider =
     final hasIssues = tracksWithData.any((t) =>
         (t.accurateRipStatus != null &&
             t.accurateRipStatus != 'verified') ||
-        (t.clickCount != null && t.clickCount! > 0));
+        t.totalDefects > 0);
     cache[itemId] =
         hasIssues ? RipStatus.qualityIssues : RipStatus.verified;
   }

--- a/lib/presentation/screens/item_detail/item_detail_screen.dart
+++ b/lib/presentation/screens/item_detail/item_detail_screen.dart
@@ -826,10 +826,10 @@ class _TrackQualityRow extends StatelessWidget {
         colour = Colors.red;
         label = 'AccurateRip CRC mismatch';
       case 'not_found':
-        if (track.clickCount != null && track.clickCount! > 0) {
+        if (track.totalDefects > 0) {
           icon = Icons.warning_amber;
           colour = Colors.amber;
-          label = '${track.clickCount} clicks detected';
+          label = _defectSummary(track);
         } else {
           icon = Icons.check_circle_outline;
           colour = Colors.green;
@@ -867,12 +867,52 @@ class _TrackQualityRow extends StatelessWidget {
                 Text('AR CRC v1: ${track.accurateRipCrcV1}'),
               if (track.accurateRipCrcV2 != null)
                 Text('AR CRC v2: ${track.accurateRipCrcV2}'),
-              if (track.clickCount != null) Text('Clicks: ${track.clickCount}'),
+              // Surface every non-zero defect-type count separately so
+              // the user can tell a clipping-heavy rip from a click-laden
+              // one without the breakdown being collapsed to a total.
+              if ((track.clickCount ?? 0) > 0)
+                Text('Clicks: ${track.clickCount}'),
+              if ((track.popCount ?? 0) > 0) Text('Pops: ${track.popCount}'),
+              if ((track.clippingCount ?? 0) > 0)
+                Text('Clipping: ${track.clippingCount}'),
+              if ((track.dropoutCount ?? 0) > 0)
+                Text('Dropouts: ${track.dropoutCount}'),
+              if (track.defectConfidence != null && track.totalDefects > 0)
+                Text(
+                  'Confidence: '
+                  '${(track.defectConfidence! * 100).toStringAsFixed(0)}%',
+                ),
             ],
           ),
         ),
       ],
     );
+  }
+
+  /// Builds a compact "N clicks, M dropouts" line for the not_found state
+  /// so the user can see _which_ defect categories fired without
+  /// expanding the row.
+  String _defectSummary(RipTrack track) {
+    final parts = <String>[];
+    if ((track.clickCount ?? 0) > 0) {
+      parts.add('${track.clickCount} click${track.clickCount! == 1 ? '' : 's'}');
+    }
+    if ((track.popCount ?? 0) > 0) {
+      parts.add('${track.popCount} pop${track.popCount! == 1 ? '' : 's'}');
+    }
+    if ((track.clippingCount ?? 0) > 0) {
+      parts.add(
+        '${track.clippingCount} clipping',
+      );
+    }
+    if ((track.dropoutCount ?? 0) > 0) {
+      parts.add(
+        '${track.dropoutCount} dropout${track.dropoutCount! == 1 ? '' : 's'}',
+      );
+    }
+    return parts.isEmpty
+        ? 'Defects detected'
+        : '${parts.join(', ')} detected';
   }
 }
 

--- a/lib/presentation/screens/rips/widgets/playlist_detail.dart
+++ b/lib/presentation/screens/rips/widgets/playlist_detail.dart
@@ -280,6 +280,10 @@ class _PlaylistDetailContent extends ConsumerWidget {
                         trackQuality: row.trackQuality,
                         copyCrc: row.copyCrc,
                         clickCount: row.clickCount,
+                        popCount: row.popCount,
+                        clippingCount: row.clippingCount,
+                        dropoutCount: row.dropoutCount,
+                        defectConfidence: row.defectConfidence,
                         ripLogSource: row.ripLogSource,
                         qualityCheckedAt: row.qualityCheckedAt,
                       );

--- a/lib/presentation/screens/rips/widgets/quality_widgets.dart
+++ b/lib/presentation/screens/rips/widgets/quality_widgets.dart
@@ -33,13 +33,13 @@ class QualityIcon extends StatelessWidget {
 
   IconData _icon() {
     if (track.qualityCheckedAt == null) return Icons.help_outline;
-    if (track.accurateRipStatus == 'verified' &&
-        (track.clickCount ?? 0) > 0) {
+    final hasDefects = track.totalDefects > 0;
+    if (track.accurateRipStatus == 'verified' && hasDefects) {
       return Icons.warning_amber;
     }
     if (track.accurateRipStatus == 'verified') return Icons.check_circle;
     if (track.accurateRipStatus == 'mismatch') return Icons.cancel;
-    if ((track.clickCount ?? 0) > 0) return Icons.warning_amber;
+    if (hasDefects) return Icons.warning_amber;
     return Icons.help_outline;
   }
 
@@ -47,13 +47,13 @@ class QualityIcon extends StatelessWidget {
     final colors = Theme.of(context).colorScheme;
     final mediaColors = context.mediaColors;
     if (track.qualityCheckedAt == null) return colors.outline;
-    if (track.accurateRipStatus == 'verified' &&
-        (track.clickCount ?? 0) > 0) {
+    final hasDefects = track.totalDefects > 0;
+    if (track.accurateRipStatus == 'verified' && hasDefects) {
       return mediaColors.tv; // amber-like warning
     }
     if (track.accurateRipStatus == 'verified') return mediaColors.book;
     if (track.accurateRipStatus == 'mismatch') return colors.error;
-    if ((track.clickCount ?? 0) > 0) return mediaColors.tv;
+    if (hasDefects) return mediaColors.tv;
     return colors.outline;
   }
 
@@ -71,8 +71,21 @@ class QualityIcon extends StatelessWidget {
     if (track.peakLevel != null) {
       lines.add('Peak: ${track.peakLevel}');
     }
-    if (track.clickCount != null) {
-      lines.add('Clicks: ${track.clickCount}');
+    // Per-DefectType counts: only emit a line for types that recorded
+    // a non-zero count, so well-ripped tracks read cleanly. clickCount
+    // surfaces independently from popCount/clipping/dropout because
+    // each carries different remediation advice.
+    if ((track.clickCount ?? 0) > 0) lines.add('Clicks: ${track.clickCount}');
+    if ((track.popCount ?? 0) > 0) lines.add('Pops: ${track.popCount}');
+    if ((track.clippingCount ?? 0) > 0) {
+      lines.add('Clipping: ${track.clippingCount}');
+    }
+    if ((track.dropoutCount ?? 0) > 0) {
+      lines.add('Dropouts: ${track.dropoutCount}');
+    }
+    if (track.defectConfidence != null && track.totalDefects > 0) {
+      final pct = (track.defectConfidence! * 100).toStringAsFixed(0);
+      lines.add('Confidence: $pct%');
     }
     return lines.isEmpty ? 'Analysed' : lines.join('\n');
   }

--- a/lib/presentation/screens/rips/widgets/rip_coverage_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_coverage_view.dart
@@ -5,6 +5,7 @@ import 'package:mymediascanner/app/theme/app_media_colors.dart';
 import 'package:mymediascanner/domain/entities/media_item.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/rip_provider.dart';
 import 'package:mymediascanner/presentation/widgets/error_state.dart';
@@ -306,6 +307,6 @@ class _CoverageItemTile extends ConsumerWidget {
     if (!anyChecked) return false;
 
     return tracks.any((t) =>
-        t.accurateRipStatus == 'mismatch' || (t.clickCount ?? 0) > 0);
+        t.accurateRipStatus == 'mismatch' || t.totalDefects > 0);
   }
 }

--- a/lib/presentation/screens/rips/widgets/rip_library_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_library_view.dart
@@ -371,7 +371,7 @@ class _RipAlbumCard extends ConsumerWidget {
     final tracks = tracksAsync.whenOrNull(data: (t) => t) ?? [];
     final arVerified =
         tracks.where((t) => t.accurateRipStatus == 'verified').length;
-    final withClicks = tracks.where((t) => (t.clickCount ?? 0) > 0).length;
+    final withDefects = tracks.where((t) => t.totalDefects > 0).length;
 
     return Card(
       clipBehavior: Clip.antiAlias,
@@ -447,12 +447,12 @@ class _RipAlbumCard extends ConsumerWidget {
                       '$arVerified/${tracks.length} AR',
                       style: theme.textTheme.bodySmall,
                     ),
-                    if (withClicks > 0) ...[
+                    if (withDefects > 0) ...[
                       const SizedBox(width: 8),
                       Icon(Icons.warning_amber,
                           size: 14, color: mediaColors.tv),
                       const SizedBox(width: 4),
-                      Text('$withClicks clicks',
+                      Text('$withDefects defects',
                           style: theme.textTheme.bodySmall),
                     ],
                   ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,10 +85,10 @@ packages:
     dependency: "direct main"
     description:
       name: audio_defect_detector
-      sha256: "0fa5d7eddf042d810071d86509b1ea621a2f81b1a904fa0b812b27451b9ee984"
+      sha256: "4097162d046b519ab0149ae8e5e522eb36dc96a1f4a683afd6541d30b6aab27f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.3"
+    version: "0.2.0"
   audio_session:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,7 +72,7 @@ dependencies:
   dart_metaflac: ^0.0.1
   dart_flac: ^0.0.1
   dart_accuraterip: ^0.0.3
-  audio_defect_detector: ^0.0.2
+  audio_defect_detector: ^0.2.0
   app_links: ^6.4.0
   dart_rip_log: ^0.0.1
   dart_cue: ^0.0.1

--- a/test/unit/data/dao/rip_library_dao_test.dart
+++ b/test/unit/data/dao/rip_library_dao_test.dart
@@ -602,6 +602,74 @@ void main() {
           expect(track.qualityCheckedAt, now);
         },
       );
+
+      test(
+        'partitioned defect counts and aggregate confidence round-trip and survive partial updates',
+        () async {
+          // Regression coverage for the audio_defect_detector 0.2.0 swap:
+          // updateTrackQuality must persist all four DefectType counts +
+          // defectConfidence, and a follow-on partial update that only
+          // touches AR fields must not clobber them.
+          final now = DateTime.now().millisecondsSinceEpoch;
+
+          await dao.insertAlbum(RipAlbumsTableCompanion(
+            id: const Value('rip-defects'),
+            libraryPath: const Value('Artist/Defects'),
+            trackCount: const Value(1),
+            totalSizeBytes: const Value(50000000),
+            lastScannedAt: Value(now),
+            updatedAt: Value(now),
+          ));
+          await dao.insertTracks([
+            RipTracksTableCompanion(
+              id: const Value('track-1'),
+              ripAlbumId: const Value('rip-defects'),
+              trackNumber: const Value(1),
+              filePath: const Value('/music/track1.flac'),
+              fileSizeBytes: const Value(50000000),
+              updatedAt: Value(now),
+            ),
+          ]);
+
+          // First call: detector partition fills in every count plus
+          // aggregate confidence.
+          await dao.updateTrackQuality(
+            'track-1',
+            arStatus: 'not_found',
+            clickCount: 4,
+            popCount: 2,
+            clippingCount: 1,
+            dropoutCount: 0,
+            defectConfidence: 0.62,
+            qualityCheckedAt: now,
+          );
+
+          var tracks = await dao.getTracksForAlbum('rip-defects');
+          expect(tracks.single.clickCount, 4);
+          expect(tracks.single.popCount, 2);
+          expect(tracks.single.clippingCount, 1);
+          expect(tracks.single.dropoutCount, 0);
+          expect(tracks.single.defectConfidence, closeTo(0.62, 1e-9));
+
+          // Second call: a later AR-only update must leave defect data
+          // alone (Value.absent() vs. Value(null) regression).
+          await dao.updateTrackQuality(
+            'track-1',
+            arStatus: 'mismatch',
+            arCrcV1: 'AAAA1111',
+            arCrcV2: 'BBBB2222',
+          );
+
+          tracks = await dao.getTracksForAlbum('rip-defects');
+          final track = tracks.single;
+          expect(track.accurateripStatus, 'mismatch');
+          expect(track.clickCount, 4);
+          expect(track.popCount, 2);
+          expect(track.clippingCount, 1);
+          expect(track.dropoutCount, 0);
+          expect(track.defectConfidence, closeTo(0.62, 1e-9));
+        },
+      );
     });
   });
 }

--- a/test/unit/data/local/dao/tmdb_account_sync_dao_test.dart
+++ b/test/unit/data/local/dao/tmdb_account_sync_dao_test.dart
@@ -34,8 +34,8 @@ void main() {
     );
   }
 
-  test('schemaVersion is 20', () {
-    expect(db.schemaVersion, 20);
+  test('schemaVersion is 21', () {
+    expect(db.schemaVersion, 21);
   });
 
   test('upsertByTmdbId inserts a new row when none exists', () async {

--- a/test/unit/data/repositories/rip_library_repository_impl_test.dart
+++ b/test/unit/data/repositories/rip_library_repository_impl_test.dart
@@ -74,6 +74,10 @@ RipTracksTableData _makeTrackRow({
   double? trackQuality,
   String? copyCrc,
   int? clickCount,
+  int? popCount,
+  int? clippingCount,
+  int? dropoutCount,
+  double? defectConfidence,
   String? ripLogSource,
   int? qualityCheckedAt,
 }) =>
@@ -95,6 +99,10 @@ RipTracksTableData _makeTrackRow({
       trackQuality: trackQuality,
       copyCrc: copyCrc,
       clickCount: clickCount,
+      popCount: popCount,
+      clippingCount: clippingCount,
+      dropoutCount: dropoutCount,
+      defectConfidence: defectConfidence,
       ripLogSource: ripLogSource,
       qualityCheckedAt: qualityCheckedAt,
     );
@@ -236,6 +244,10 @@ void main() {
           trackQuality: 98.7,
           copyCrc: 'EFGH5678',
           clickCount: 3,
+          popCount: 2,
+          clippingCount: 1,
+          dropoutCount: 0,
+          defectConfidence: 0.42,
           ripLogSource: 'EAC',
           qualityCheckedAt: 1700000003000,
         );
@@ -263,8 +275,15 @@ void main() {
         expect(track.trackQuality, 98.7);
         expect(track.copyCrc, 'EFGH5678');
         expect(track.clickCount, 3);
+        expect(track.popCount, 2);
+        expect(track.clippingCount, 1);
+        expect(track.dropoutCount, 0);
+        expect(track.defectConfidence, 0.42);
         expect(track.ripLogSource, 'EAC');
         expect(track.qualityCheckedAt, 1700000003000);
+        // totalDefects extension sums every per-type count regardless of
+        // which ones happen to be zero.
+        expect(track.totalDefects, 6);
       },
     );
 
@@ -280,6 +299,10 @@ void main() {
           trackQuality: null,
           copyCrc: null,
           clickCount: null,
+          popCount: null,
+          clippingCount: null,
+          dropoutCount: null,
+          defectConfidence: null,
           ripLogSource: null,
           qualityCheckedAt: null,
         );
@@ -297,8 +320,15 @@ void main() {
         expect(track.trackQuality, isNull);
         expect(track.copyCrc, isNull);
         expect(track.clickCount, isNull);
+        expect(track.popCount, isNull);
+        expect(track.clippingCount, isNull);
+        expect(track.dropoutCount, isNull);
+        expect(track.defectConfidence, isNull);
         expect(track.ripLogSource, isNull);
         expect(track.qualityCheckedAt, isNull);
+        // Every per-type count NULL ⇒ totalDefects collapses to zero
+        // (the predicate must not page in NULL as a defect).
+        expect(track.totalDefects, 0);
       },
     );
 
@@ -383,6 +413,10 @@ void main() {
             trackQuality: 99.0,
             copyCrc: 'CCRC1',
             clickCount: 0,
+            popCount: 0,
+            clippingCount: 0,
+            dropoutCount: 0,
+            defectConfidence: 0.0,
             ripLogSource: 'dBpoweramp',
             qualityCheckedAt: 1700000002000,
           ),
@@ -422,6 +456,10 @@ void main() {
         expect(first.trackQuality.value, 99.0);
         expect(first.copyCrc.value, 'CCRC1');
         expect(first.clickCount.value, 0);
+        expect(first.popCount.value, 0);
+        expect(first.clippingCount.value, 0);
+        expect(first.dropoutCount.value, 0);
+        expect(first.defectConfidence.value, 0.0);
         expect(first.ripLogSource.value, 'dBpoweramp');
         expect(first.qualityCheckedAt.value, 1700000002000);
 
@@ -502,6 +540,10 @@ void main() {
             trackQuality: any(named: 'trackQuality'),
             copyCrc: any(named: 'copyCrc'),
             clickCount: any(named: 'clickCount'),
+            popCount: any(named: 'popCount'),
+            clippingCount: any(named: 'clippingCount'),
+            dropoutCount: any(named: 'dropoutCount'),
+            defectConfidence: any(named: 'defectConfidence'),
             ripLogSource: any(named: 'ripLogSource'),
             qualityCheckedAt: any(named: 'qualityCheckedAt'),
           ),
@@ -517,6 +559,10 @@ void main() {
           trackQuality: 97.3,
           copyCrc: 'CAFEBABE',
           clickCount: 2,
+          popCount: 1,
+          clippingCount: 0,
+          dropoutCount: 4,
+          defectConfidence: 0.62,
           ripLogSource: 'EAC',
           qualityCheckedAt: 1700000005000,
         );
@@ -532,6 +578,10 @@ void main() {
             trackQuality: 97.3,
             copyCrc: 'CAFEBABE',
             clickCount: 2,
+            popCount: 1,
+            clippingCount: 0,
+            dropoutCount: 4,
+            defectConfidence: 0.62,
             ripLogSource: 'EAC',
             qualityCheckedAt: 1700000005000,
           ),
@@ -553,6 +603,10 @@ void main() {
             trackQuality: any(named: 'trackQuality'),
             copyCrc: any(named: 'copyCrc'),
             clickCount: any(named: 'clickCount'),
+            popCount: any(named: 'popCount'),
+            clippingCount: any(named: 'clippingCount'),
+            dropoutCount: any(named: 'dropoutCount'),
+            defectConfidence: any(named: 'defectConfidence'),
             ripLogSource: any(named: 'ripLogSource'),
             qualityCheckedAt: any(named: 'qualityCheckedAt'),
           ),
@@ -571,6 +625,10 @@ void main() {
             trackQuality: null,
             copyCrc: null,
             clickCount: null,
+            popCount: null,
+            clippingCount: null,
+            dropoutCount: null,
+            defectConfidence: null,
             ripLogSource: null,
             qualityCheckedAt: null,
           ),

--- a/test/unit/domain/analyse_rip_quality_usecase_test.dart
+++ b/test/unit/domain/analyse_rip_quality_usecase_test.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:audio_defect_detector/audio_defect_detector.dart' as add;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mymediascanner/core/utils/flac_decoder.dart';
@@ -296,16 +297,16 @@ End of status report
     });
 
     group(
-        'falls through to click detection when AccurateRip is unreachable',
+        'falls through to defect detection when AccurateRip is unreachable',
         () {
       test(
-          'execute_withFlacAvailable_andUnknownSampleCounts_runsClickDetection',
+          'execute_withFlacAvailable_andUnknownSampleCounts_runsDefectDetection',
           () async {
         // Arrange
         // The fake file path means _tryParseLog fails (no log) and
         // FlacReader.readMetadata returns null, which makes
         // sampleCounts.every((c) => c > 0) false, so the AR query is
-        // skipped and the pipeline falls into step 3 (click detection).
+        // skipped and the pipeline falls into step 3 (defect detection).
         final track = _track(id: 'track-1', trackNumber: 1);
         // 0.1 s of 16-bit stereo silence at 44.1 kHz: 4 bytes/frame *
         // 4410 frames = 17 640 bytes. Silence has no clicks/pops, so the
@@ -322,24 +323,133 @@ End of status report
               any(),
               arStatus: any(named: 'arStatus'),
               clickCount: any(named: 'clickCount'),
+              popCount: any(named: 'popCount'),
+              clippingCount: any(named: 'clippingCount'),
+              dropoutCount: any(named: 'dropoutCount'),
+              defectConfidence: any(named: 'defectConfidence'),
               qualityCheckedAt: any(named: 'qualityCheckedAt'),
             )).thenAnswer((_) async {});
 
         // Act
         await useCase.execute('album-1').drain<void>();
 
-        // Assert — track is marked not_found (AR could not verify) with a
-        // clickCount derived from the click-detection pass. AccurateRip
-        // must NOT be queried because sample counts were unknown.
+        // Assert — track is marked not_found (AR could not verify) with
+        // every defect-type count explicitly zeroed (silence in, no
+        // defects out). AccurateRip must NOT be queried because sample
+        // counts were unknown.
         verify(() => mockRepo.updateTrackQuality(
               'track-1',
               arStatus: 'not_found',
               clickCount: 0,
+              popCount: 0,
+              clippingCount: 0,
+              dropoutCount: 0,
+              defectConfidence: any(named: 'defectConfidence'),
               qualityCheckedAt: any(named: 'qualityCheckedAt'),
             )).called(1);
         // AccurateRip is unreachable when sample counts are unknown, so the
         // client should not be touched at all.
         verifyZeroInteractions(mockArClient);
+      });
+
+      test(
+          'execute_withInjectedDetector_partitionsDefectsByType',
+          () async {
+        // Arrange — inject a fake DefectDetector returning one defect of
+        // each DefectType plus a known aggregateConfidence so we can
+        // assert the use case partitions counts correctly and forwards
+        // the confidence verbatim.
+        final track = _track(id: 'track-1', trackNumber: 1);
+        final pcmData = Uint8List(17640);
+
+        const aggregate = 0.42;
+        const result = add.AnalysisResult(
+          defects: [
+            add.Defect(
+              offset: Duration.zero,
+              length: Duration(milliseconds: 1),
+              type: add.DefectType.click,
+              confidence: 0.9,
+              channel: 0,
+              sampleIndex: 100,
+              amplitude: 0.95,
+            ),
+            add.Defect(
+              offset: Duration(milliseconds: 50),
+              length: Duration(milliseconds: 5),
+              type: add.DefectType.pop,
+              confidence: 0.8,
+              channel: 1,
+              sampleIndex: 2205,
+              amplitude: 0.85,
+            ),
+            add.Defect(
+              offset: Duration(milliseconds: 200),
+              length: Duration(milliseconds: 1),
+              type: add.DefectType.clipping,
+              confidence: 0.95,
+              channel: 0,
+              sampleIndex: 8820,
+              amplitude: 0.99,
+            ),
+            add.Defect(
+              offset: Duration(milliseconds: 500),
+              length: Duration(milliseconds: 20),
+              type: add.DefectType.dropout,
+              confidence: 0.7,
+              channel: 1,
+              sampleIndex: 22050,
+              amplitude: 0.0,
+            ),
+          ],
+          aggregateConfidence: aggregate,
+          metadata: add.AudioMetadata(
+            sampleRate: 44100,
+            bitDepth: 16,
+            channels: 2,
+            duration: Duration(milliseconds: 100),
+          ),
+        );
+
+        when(() => mockRepo.getTracksForAlbum('album-1'))
+            .thenAnswer((_) async => [track]);
+        when(() => mockFlacDecoder.isAvailable())
+            .thenAnswer((_) async => true);
+        when(() => mockFlacDecoder.decode(any()))
+            .thenAnswer((_) async => pcmData);
+        when(() => mockRepo.updateTrackQuality(
+              any(),
+              arStatus: any(named: 'arStatus'),
+              clickCount: any(named: 'clickCount'),
+              popCount: any(named: 'popCount'),
+              clippingCount: any(named: 'clippingCount'),
+              dropoutCount: any(named: 'dropoutCount'),
+              defectConfidence: any(named: 'defectConfidence'),
+              qualityCheckedAt: any(named: 'qualityCheckedAt'),
+            )).thenAnswer((_) async {});
+
+        useCase = AnalyseRipQualityUseCase(
+          repository: mockRepo,
+          flacDecoder: mockFlacDecoder,
+          accurateRipClient: mockArClient,
+          isolateRunner: _syncIsolateRunner,
+          defectDetector: (_, {required format, required config}) => result,
+        );
+
+        // Act
+        await useCase.execute('album-1').drain<void>();
+
+        // Assert — one defect per type, aggregate confidence forwarded.
+        verify(() => mockRepo.updateTrackQuality(
+              'track-1',
+              arStatus: 'not_found',
+              clickCount: 1,
+              popCount: 1,
+              clippingCount: 1,
+              dropoutCount: 1,
+              defectConfidence: aggregate,
+              qualityCheckedAt: any(named: 'qualityCheckedAt'),
+            )).called(1);
       });
     });
 


### PR DESCRIPTION
## Summary
- Bumps `audio_defect_detector` from `^0.0.2` to `^0.2.0` and replaces the single `clickCount` write with a per-`DefectType` partition (click / pop / clipping / dropout) plus the new `aggregateConfidence`, persisted on `RipTrack`.
- Schema v20 → v21 migration adds `popCount`, `clippingCount`, `dropoutCount`, and `defectConfidence` columns. Guarded by `PRAGMA table_info` so it co-exists with the v17 drop-and-recreate branch (which already rebuilds `rip_tracks` from the current Dart definition).
- `AnalyseRipQualityUseCase` now exposes a `DefectDetector` seam so tests can supply a curated `AnalysisResult`. UI surfaces (quality icon tooltip, item detail rows, library card aggregate, rip coverage predicate, collection rip-status provider) read a new `totalDefects` extension getter on `RipTrack` and break the breakdown out per type with a confidence percentage instead of a flat "X clicks" line.

## Test plan
- [x] `flutter analyze` clean
- [x] `flutter test` — all 1451 tests pass
- [x] New use-case test injects a fake detector returning one defect of each type and asserts the per-type partition + `aggregateConfidence` are persisted verbatim
- [x] New DAO test confirms the four counts + `defectConfidence` round-trip and survive a partial AR-only `updateTrackQuality` (regression coverage for the `Value.absent()` pattern)
- [x] Existing AR-verified and AR-mismatch paths still skip the detector (no per-type counts written)
- [ ] Manual: `flutter run -d linux` on an album with no AccurateRip coverage; trigger Analyse Quality; tooltip shows non-zero per-type lines plus confidence %; item detail shows the same breakdown
- [ ] Manual: open the app on top of an existing v20 SQLite database; the four new columns are NULL on pre-existing rows and a re-run of Analyse Quality back-fills them