### PR TITLE
fix: address high-severity scan findings

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -7,6 +7,7 @@ import 'package:mymediascanner/presentation/screens/collection/statistics_screen
 import 'package:mymediascanner/presentation/screens/dashboard/dashboard_screen.dart';
 import 'package:mymediascanner/presentation/screens/disambiguation/disambiguation_screen.dart';
 import 'package:mymediascanner/presentation/screens/import/import_screen.dart';
+import 'package:mymediascanner/presentation/screens/item_detail/edit_item_screen.dart';
 import 'package:mymediascanner/presentation/screens/item_detail/item_detail_screen.dart';
 import 'package:mymediascanner/presentation/screens/manual_add/manual_add_screen.dart';
 import 'package:mymediascanner/presentation/screens/metadata_confirm/metadata_confirm_screen.dart';
@@ -127,9 +128,12 @@ final router = GoRouter(
                   routes: [
                     GoRoute(
                       path: 'edit',
-                      builder: (context, state) => Center(
-                        child: Text(
-                            'Edit item ${state.pathParameters['id']}'),
+                      parentNavigatorKey: _rootNavigatorKey,
+                      pageBuilder: (context, state) => _fadeSlideTransition(
+                        state,
+                        EditItemScreen(
+                          itemId: state.pathParameters['id']!,
+                        ),
                       ),
                     ),
                   ],

--- a/lib/core/services/camera/camera_service_provider.dart
+++ b/lib/core/services/camera/camera_service_provider.dart
@@ -5,13 +5,23 @@ import 'package:mymediascanner/core/services/camera/mobile_scanner_camera_servic
 import 'package:mymediascanner/core/services/camera/native_camera_service.dart';
 import 'package:mymediascanner/core/utils/platform_utils.dart';
 
-/// Provides the appropriate [CameraService] for the current platform.
+/// Provides a factory for the appropriate [CameraService] for the
+/// current platform.
 ///
 /// - Android/iOS/macOS: [MobileScannerCameraService] (mobile_scanner + ML Kit)
 /// - Windows/Linux: [NativeCameraService] (camera package + zxing2)
-final cameraServiceProvider = Provider<CameraService>((ref) {
-  if (PlatformCapability.canUseMobileScanner) {
-    return MobileScannerCameraService();
-  }
-  return NativeCameraService();
+///
+/// This is deliberately a factory, not a cached instance: the scan
+/// screen owns each service's lifecycle and calls `dispose()` when the
+/// webcam is toggled off, which permanently closes the service's
+/// barcode stream (and the MobileScannerController on macOS). A cached
+/// singleton would hand that dead instance back to the next session,
+/// silently dropping all detections until app restart.
+final cameraServiceFactoryProvider = Provider<CameraService Function()>((ref) {
+  return () {
+    if (PlatformCapability.canUseMobileScanner) {
+      return MobileScannerCameraService();
+    }
+    return NativeCameraService();
+  };
 });

--- a/lib/data/local/dao/media_items_dao.dart
+++ b/lib/data/local/dao/media_items_dao.dart
@@ -35,7 +35,8 @@ class MediaItemsDao extends DatabaseAccessor<AppDatabase>
             ..addColumns([mediaItemTagsTable.tagId])
             ..where(
               mediaItemTagsTable.mediaItemId.equalsExp(t.id) &
-                  mediaItemTagsTable.tagId.isIn(tagIds),
+                  mediaItemTagsTable.tagId.isIn(tagIds) &
+                  mediaItemTagsTable.deleted.equals(0),
             ),
         ),
       );

--- a/lib/data/local/dao/shelves_dao.dart
+++ b/lib/data/local/dao/shelves_dao.dart
@@ -54,55 +54,98 @@ class ShelvesDao extends DatabaseAccessor<AppDatabase>
     );
   }
 
-  Future<void> addItem(String shelfId, String mediaItemId, int position) {
-    return into(shelfItemsTable).insert(
+  /// Upsert: re-adding a previously removed item must resurrect the
+  /// soft-deleted row, clearing its tombstone.
+  Future<void> addItem(
+    String shelfId,
+    String mediaItemId,
+    int position, {
+    int? updatedAt,
+  }) {
+    return into(shelfItemsTable).insertOnConflictUpdate(
       ShelfItemsTableCompanion(
         shelfId: Value(shelfId),
         mediaItemId: Value(mediaItemId),
         position: Value(position),
+        updatedAt:
+            Value(updatedAt ?? DateTime.now().millisecondsSinceEpoch),
+        deleted: const Value(0),
       ),
-      mode: InsertMode.insertOrReplace,
     );
   }
 
-  Future<void> removeItem(String shelfId, String mediaItemId) {
-    return (delete(shelfItemsTable)
+  /// Soft delete: the tombstone row (deleted = 1) is what replicates the
+  /// removal to other devices via sync.
+  Future<void> removeItem(
+    String shelfId,
+    String mediaItemId, {
+    int? updatedAt,
+  }) {
+    return (update(shelfItemsTable)
           ..where((t) =>
               t.shelfId.equals(shelfId) &
               t.mediaItemId.equals(mediaItemId)))
-        .go();
+        .write(ShelfItemsTableCompanion(
+      deleted: const Value(1),
+      updatedAt: Value(updatedAt ?? DateTime.now().millisecondsSinceEpoch),
+    ));
   }
 
   Future<List<String>> getMediaItemIdsForShelf(String shelfId) async {
     final rows = await (select(shelfItemsTable)
-          ..where((t) => t.shelfId.equals(shelfId))
+          ..where((t) => t.shelfId.equals(shelfId) & t.deleted.equals(0))
           ..orderBy([(t) => OrderingTerm.asc(t.position)]))
         .get();
     return rows.map((r) => r.mediaItemId).toList();
   }
 
-  /// Atomically rewrite the ordering of items on [shelfId]. Deletes every
-  /// existing shelf_items row for the shelf and re-inserts them at indices
-  /// 0..N-1 so positions are dense and unique. The previous single-row
-  /// `addItem` reorder produced position collisions on any move.
+  /// Atomically rewrite the ordering of items on [shelfId]: every live
+  /// row is first tombstoned, then the surviving ids are upserted back
+  /// at dense indices 0..N-1. Items absent from [orderedMediaItemIds]
+  /// keep the tombstone, which is how their removal syncs; positions
+  /// stay dense and unique (the previous single-row `addItem` reorder
+  /// produced collisions on any move).
   Future<void> reorderItems(
     String shelfId,
-    List<String> orderedMediaItemIds,
-  ) async {
+    List<String> orderedMediaItemIds, {
+    int? updatedAt,
+  }) async {
+    final stamp = updatedAt ?? DateTime.now().millisecondsSinceEpoch;
     await transaction(() async {
-      await (delete(shelfItemsTable)
+      await (update(shelfItemsTable)
             ..where((t) => t.shelfId.equals(shelfId)))
-          .go();
-      await batch((b) {
-        b.insertAll(shelfItemsTable, [
-          for (var i = 0; i < orderedMediaItemIds.length; i++)
-            ShelfItemsTableCompanion(
-              shelfId: Value(shelfId),
-              mediaItemId: Value(orderedMediaItemIds[i]),
-              position: Value(i),
-            ),
-        ]);
-      });
+          .write(ShelfItemsTableCompanion(
+        deleted: const Value(1),
+        updatedAt: Value(stamp),
+      ));
+      for (var i = 0; i < orderedMediaItemIds.length; i++) {
+        await into(shelfItemsTable).insertOnConflictUpdate(
+          ShelfItemsTableCompanion(
+            shelfId: Value(shelfId),
+            mediaItemId: Value(orderedMediaItemIds[i]),
+            position: Value(i),
+            updatedAt: Value(stamp),
+            deleted: const Value(0),
+          ),
+        );
+      }
     });
+  }
+
+  /// Local `updated_at` for a membership, or null when no row exists.
+  /// Used by pull's last-write-wins comparison.
+  Future<int?> itemUpdatedAt(String shelfId, String mediaItemId) async {
+    final row = await (select(shelfItemsTable)
+          ..where((t) =>
+              t.shelfId.equals(shelfId) &
+              t.mediaItemId.equals(mediaItemId)))
+        .getSingleOrNull();
+    return row?.updatedAt;
+  }
+
+  /// Raw upsert used by sync pull — writes whatever the remote row says,
+  /// including tombstones.
+  Future<void> upsertItemRow(ShelfItemsTableCompanion row) {
+    return into(shelfItemsTable).insertOnConflictUpdate(row);
   }
 }

--- a/lib/data/local/dao/tags_dao.dart
+++ b/lib/data/local/dao/tags_dao.dart
@@ -50,27 +50,61 @@ class TagsDao extends DatabaseAccessor<AppDatabase> with _$TagsDaoMixin {
     );
   }
 
-  Future<void> assignToMediaItem(String tagId, String mediaItemId) {
-    return into(mediaItemTagsTable).insert(
+  /// Upsert (not insert-or-ignore): re-assigning a previously removed
+  /// tag must resurrect the soft-deleted row, clearing its tombstone.
+  Future<void> assignToMediaItem(
+    String tagId,
+    String mediaItemId, {
+    int? updatedAt,
+  }) {
+    return into(mediaItemTagsTable).insertOnConflictUpdate(
       MediaItemTagsTableCompanion(
         tagId: Value(tagId),
         mediaItemId: Value(mediaItemId),
+        updatedAt:
+            Value(updatedAt ?? DateTime.now().millisecondsSinceEpoch),
+        deleted: const Value(0),
       ),
-      mode: InsertMode.insertOrIgnore,
     );
   }
 
-  Future<void> removeFromMediaItem(String tagId, String mediaItemId) {
-    return (delete(mediaItemTagsTable)
+  /// Soft delete: the tombstone row (deleted = 1) is what replicates the
+  /// removal to other devices via sync.
+  Future<void> removeFromMediaItem(
+    String tagId,
+    String mediaItemId, {
+    int? updatedAt,
+  }) {
+    return (update(mediaItemTagsTable)
           ..where(
               (t) => t.tagId.equals(tagId) & t.mediaItemId.equals(mediaItemId)))
-        .go();
+        .write(MediaItemTagsTableCompanion(
+      deleted: const Value(1),
+      updatedAt: Value(updatedAt ?? DateTime.now().millisecondsSinceEpoch),
+    ));
   }
 
   Future<List<String>> getTagIdsForMediaItem(String mediaItemId) async {
     final rows = await (select(mediaItemTagsTable)
-          ..where((t) => t.mediaItemId.equals(mediaItemId)))
+          ..where((t) =>
+              t.mediaItemId.equals(mediaItemId) & t.deleted.equals(0)))
         .get();
     return rows.map((r) => r.tagId).toList();
+  }
+
+  /// Local `updated_at` for an assignment, or null when no row exists.
+  /// Used by pull's last-write-wins comparison.
+  Future<int?> assignmentUpdatedAt(String mediaItemId, String tagId) async {
+    final row = await (select(mediaItemTagsTable)
+          ..where((t) =>
+              t.mediaItemId.equals(mediaItemId) & t.tagId.equals(tagId)))
+        .getSingleOrNull();
+    return row?.updatedAt;
+  }
+
+  /// Raw upsert used by sync pull — writes whatever the remote row says,
+  /// including tombstones.
+  Future<void> upsertAssignmentRow(MediaItemTagsTableCompanion row) {
+    return into(mediaItemTagsTable).insertOnConflictUpdate(row);
   }
 }

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -91,7 +91,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.executor);
 
   @override
-  int get schemaVersion => 22;
+  int get schemaVersion => 23;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -324,6 +324,33 @@ class AppDatabase extends _$AppDatabase {
                   mediaItemsTable, mediaItemsTable.currentValue);
               await m.addColumn(
                   mediaItemsTable, mediaItemsTable.currentValueAsOf);
+            }
+          }
+          if (from < 23) {
+            // Join-table sync: media_item_tags and shelf_items gain
+            // `updated_at` (LWW basis) and `deleted` (removal tombstone)
+            // so tag assignments and shelf memberships replicate. They
+            // previously had no sync representation at all.
+            //
+            // Guard on table existence — synthetic migration tests seed
+            // only a subset of tables (see the v22 branch above).
+            Future<bool> tableExists(String name) async {
+              final rows = await customSelect(
+                'SELECT name FROM sqlite_master '
+                "WHERE type='table' AND name='$name'",
+              ).get();
+              return rows.isNotEmpty;
+            }
+
+            if (await tableExists('media_item_tags')) {
+              await m.addColumn(
+                  mediaItemTagsTable, mediaItemTagsTable.updatedAt);
+              await m.addColumn(
+                  mediaItemTagsTable, mediaItemTagsTable.deleted);
+            }
+            if (await tableExists('shelf_items')) {
+              await m.addColumn(shelfItemsTable, shelfItemsTable.updatedAt);
+              await m.addColumn(shelfItemsTable, shelfItemsTable.deleted);
             }
           }
         },

--- a/lib/data/local/database/app_database.g.dart
+++ b/lib/data/local/database/app_database.g.dart
@@ -2479,8 +2479,37 @@ class $MediaItemTagsTableTable extends MediaItemTagsTable
       'REFERENCES tags (id)',
     ),
   );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
   @override
-  List<GeneratedColumn> get $columns => [mediaItemId, tagId];
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _deletedMeta = const VerificationMeta(
+    'deleted',
+  );
+  @override
+  late final GeneratedColumn<int> deleted = GeneratedColumn<int>(
+    'deleted',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    mediaItemId,
+    tagId,
+    updatedAt,
+    deleted,
+  ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -2512,6 +2541,18 @@ class $MediaItemTagsTableTable extends MediaItemTagsTable
     } else if (isInserting) {
       context.missing(_tagIdMeta);
     }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    if (data.containsKey('deleted')) {
+      context.handle(
+        _deletedMeta,
+        deleted.isAcceptableOrUnknown(data['deleted']!, _deletedMeta),
+      );
+    }
     return context;
   }
 
@@ -2529,6 +2570,14 @@ class $MediaItemTagsTableTable extends MediaItemTagsTable
         DriftSqlType.string,
         data['${effectivePrefix}tag_id'],
       )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      deleted: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}deleted'],
+      )!,
     );
   }
 
@@ -2542,15 +2591,25 @@ class MediaItemTagsTableData extends DataClass
     implements Insertable<MediaItemTagsTableData> {
   final String mediaItemId;
   final String tagId;
+
+  /// Last-write-wins basis for sync (epoch millis).
+  final int updatedAt;
+
+  /// Soft-delete tombstone so removals replicate; readers filter on 0.
+  final int deleted;
   const MediaItemTagsTableData({
     required this.mediaItemId,
     required this.tagId,
+    required this.updatedAt,
+    required this.deleted,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['media_item_id'] = Variable<String>(mediaItemId);
     map['tag_id'] = Variable<String>(tagId);
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['deleted'] = Variable<int>(deleted);
     return map;
   }
 
@@ -2558,6 +2617,8 @@ class MediaItemTagsTableData extends DataClass
     return MediaItemTagsTableCompanion(
       mediaItemId: Value(mediaItemId),
       tagId: Value(tagId),
+      updatedAt: Value(updatedAt),
+      deleted: Value(deleted),
     );
   }
 
@@ -2569,6 +2630,8 @@ class MediaItemTagsTableData extends DataClass
     return MediaItemTagsTableData(
       mediaItemId: serializer.fromJson<String>(json['mediaItemId']),
       tagId: serializer.fromJson<String>(json['tagId']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deleted: serializer.fromJson<int>(json['deleted']),
     );
   }
   @override
@@ -2577,20 +2640,30 @@ class MediaItemTagsTableData extends DataClass
     return <String, dynamic>{
       'mediaItemId': serializer.toJson<String>(mediaItemId),
       'tagId': serializer.toJson<String>(tagId),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'deleted': serializer.toJson<int>(deleted),
     };
   }
 
-  MediaItemTagsTableData copyWith({String? mediaItemId, String? tagId}) =>
-      MediaItemTagsTableData(
-        mediaItemId: mediaItemId ?? this.mediaItemId,
-        tagId: tagId ?? this.tagId,
-      );
+  MediaItemTagsTableData copyWith({
+    String? mediaItemId,
+    String? tagId,
+    int? updatedAt,
+    int? deleted,
+  }) => MediaItemTagsTableData(
+    mediaItemId: mediaItemId ?? this.mediaItemId,
+    tagId: tagId ?? this.tagId,
+    updatedAt: updatedAt ?? this.updatedAt,
+    deleted: deleted ?? this.deleted,
+  );
   MediaItemTagsTableData copyWithCompanion(MediaItemTagsTableCompanion data) {
     return MediaItemTagsTableData(
       mediaItemId: data.mediaItemId.present
           ? data.mediaItemId.value
           : this.mediaItemId,
       tagId: data.tagId.present ? data.tagId.value : this.tagId,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deleted: data.deleted.present ? data.deleted.value : this.deleted,
     );
   }
 
@@ -2598,45 +2671,59 @@ class MediaItemTagsTableData extends DataClass
   String toString() {
     return (StringBuffer('MediaItemTagsTableData(')
           ..write('mediaItemId: $mediaItemId, ')
-          ..write('tagId: $tagId')
+          ..write('tagId: $tagId, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deleted: $deleted')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(mediaItemId, tagId);
+  int get hashCode => Object.hash(mediaItemId, tagId, updatedAt, deleted);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is MediaItemTagsTableData &&
           other.mediaItemId == this.mediaItemId &&
-          other.tagId == this.tagId);
+          other.tagId == this.tagId &&
+          other.updatedAt == this.updatedAt &&
+          other.deleted == this.deleted);
 }
 
 class MediaItemTagsTableCompanion
     extends UpdateCompanion<MediaItemTagsTableData> {
   final Value<String> mediaItemId;
   final Value<String> tagId;
+  final Value<int> updatedAt;
+  final Value<int> deleted;
   final Value<int> rowid;
   const MediaItemTagsTableCompanion({
     this.mediaItemId = const Value.absent(),
     this.tagId = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.deleted = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   MediaItemTagsTableCompanion.insert({
     required String mediaItemId,
     required String tagId,
+    this.updatedAt = const Value.absent(),
+    this.deleted = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : mediaItemId = Value(mediaItemId),
        tagId = Value(tagId);
   static Insertable<MediaItemTagsTableData> custom({
     Expression<String>? mediaItemId,
     Expression<String>? tagId,
+    Expression<int>? updatedAt,
+    Expression<int>? deleted,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
       if (mediaItemId != null) 'media_item_id': mediaItemId,
       if (tagId != null) 'tag_id': tagId,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (deleted != null) 'deleted': deleted,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -2644,11 +2731,15 @@ class MediaItemTagsTableCompanion
   MediaItemTagsTableCompanion copyWith({
     Value<String>? mediaItemId,
     Value<String>? tagId,
+    Value<int>? updatedAt,
+    Value<int>? deleted,
     Value<int>? rowid,
   }) {
     return MediaItemTagsTableCompanion(
       mediaItemId: mediaItemId ?? this.mediaItemId,
       tagId: tagId ?? this.tagId,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deleted: deleted ?? this.deleted,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -2662,6 +2753,12 @@ class MediaItemTagsTableCompanion
     if (tagId.present) {
       map['tag_id'] = Variable<String>(tagId.value);
     }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (deleted.present) {
+      map['deleted'] = Variable<int>(deleted.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -2673,6 +2770,8 @@ class MediaItemTagsTableCompanion
     return (StringBuffer('MediaItemTagsTableCompanion(')
           ..write('mediaItemId: $mediaItemId, ')
           ..write('tagId: $tagId, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deleted: $deleted, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -3136,8 +3235,38 @@ class $ShelfItemsTableTable extends ShelfItemsTable
     requiredDuringInsert: false,
     defaultValue: const Constant(0),
   );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
   @override
-  List<GeneratedColumn> get $columns => [shelfId, mediaItemId, position];
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _deletedMeta = const VerificationMeta(
+    'deleted',
+  );
+  @override
+  late final GeneratedColumn<int> deleted = GeneratedColumn<int>(
+    'deleted',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    shelfId,
+    mediaItemId,
+    position,
+    updatedAt,
+    deleted,
+  ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -3175,6 +3304,18 @@ class $ShelfItemsTableTable extends ShelfItemsTable
         position.isAcceptableOrUnknown(data['position']!, _positionMeta),
       );
     }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    }
+    if (data.containsKey('deleted')) {
+      context.handle(
+        _deletedMeta,
+        deleted.isAcceptableOrUnknown(data['deleted']!, _deletedMeta),
+      );
+    }
     return context;
   }
 
@@ -3196,6 +3337,14 @@ class $ShelfItemsTableTable extends ShelfItemsTable
         DriftSqlType.int,
         data['${effectivePrefix}position'],
       )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      deleted: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}deleted'],
+      )!,
     );
   }
 
@@ -3210,10 +3359,18 @@ class ShelfItemsTableData extends DataClass
   final String shelfId;
   final String mediaItemId;
   final int position;
+
+  /// Last-write-wins basis for sync (epoch millis).
+  final int updatedAt;
+
+  /// Soft-delete tombstone so removals replicate; readers filter on 0.
+  final int deleted;
   const ShelfItemsTableData({
     required this.shelfId,
     required this.mediaItemId,
     required this.position,
+    required this.updatedAt,
+    required this.deleted,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -3221,6 +3378,8 @@ class ShelfItemsTableData extends DataClass
     map['shelf_id'] = Variable<String>(shelfId);
     map['media_item_id'] = Variable<String>(mediaItemId);
     map['position'] = Variable<int>(position);
+    map['updated_at'] = Variable<int>(updatedAt);
+    map['deleted'] = Variable<int>(deleted);
     return map;
   }
 
@@ -3229,6 +3388,8 @@ class ShelfItemsTableData extends DataClass
       shelfId: Value(shelfId),
       mediaItemId: Value(mediaItemId),
       position: Value(position),
+      updatedAt: Value(updatedAt),
+      deleted: Value(deleted),
     );
   }
 
@@ -3241,6 +3402,8 @@ class ShelfItemsTableData extends DataClass
       shelfId: serializer.fromJson<String>(json['shelfId']),
       mediaItemId: serializer.fromJson<String>(json['mediaItemId']),
       position: serializer.fromJson<int>(json['position']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+      deleted: serializer.fromJson<int>(json['deleted']),
     );
   }
   @override
@@ -3250,6 +3413,8 @@ class ShelfItemsTableData extends DataClass
       'shelfId': serializer.toJson<String>(shelfId),
       'mediaItemId': serializer.toJson<String>(mediaItemId),
       'position': serializer.toJson<int>(position),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+      'deleted': serializer.toJson<int>(deleted),
     };
   }
 
@@ -3257,10 +3422,14 @@ class ShelfItemsTableData extends DataClass
     String? shelfId,
     String? mediaItemId,
     int? position,
+    int? updatedAt,
+    int? deleted,
   }) => ShelfItemsTableData(
     shelfId: shelfId ?? this.shelfId,
     mediaItemId: mediaItemId ?? this.mediaItemId,
     position: position ?? this.position,
+    updatedAt: updatedAt ?? this.updatedAt,
+    deleted: deleted ?? this.deleted,
   );
   ShelfItemsTableData copyWithCompanion(ShelfItemsTableCompanion data) {
     return ShelfItemsTableData(
@@ -3269,6 +3438,8 @@ class ShelfItemsTableData extends DataClass
           ? data.mediaItemId.value
           : this.mediaItemId,
       position: data.position.present ? data.position.value : this.position,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deleted: data.deleted.present ? data.deleted.value : this.deleted,
     );
   }
 
@@ -3277,37 +3448,48 @@ class ShelfItemsTableData extends DataClass
     return (StringBuffer('ShelfItemsTableData(')
           ..write('shelfId: $shelfId, ')
           ..write('mediaItemId: $mediaItemId, ')
-          ..write('position: $position')
+          ..write('position: $position, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deleted: $deleted')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(shelfId, mediaItemId, position);
+  int get hashCode =>
+      Object.hash(shelfId, mediaItemId, position, updatedAt, deleted);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is ShelfItemsTableData &&
           other.shelfId == this.shelfId &&
           other.mediaItemId == this.mediaItemId &&
-          other.position == this.position);
+          other.position == this.position &&
+          other.updatedAt == this.updatedAt &&
+          other.deleted == this.deleted);
 }
 
 class ShelfItemsTableCompanion extends UpdateCompanion<ShelfItemsTableData> {
   final Value<String> shelfId;
   final Value<String> mediaItemId;
   final Value<int> position;
+  final Value<int> updatedAt;
+  final Value<int> deleted;
   final Value<int> rowid;
   const ShelfItemsTableCompanion({
     this.shelfId = const Value.absent(),
     this.mediaItemId = const Value.absent(),
     this.position = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.deleted = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   ShelfItemsTableCompanion.insert({
     required String shelfId,
     required String mediaItemId,
     this.position = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.deleted = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : shelfId = Value(shelfId),
        mediaItemId = Value(mediaItemId);
@@ -3315,12 +3497,16 @@ class ShelfItemsTableCompanion extends UpdateCompanion<ShelfItemsTableData> {
     Expression<String>? shelfId,
     Expression<String>? mediaItemId,
     Expression<int>? position,
+    Expression<int>? updatedAt,
+    Expression<int>? deleted,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
       if (shelfId != null) 'shelf_id': shelfId,
       if (mediaItemId != null) 'media_item_id': mediaItemId,
       if (position != null) 'position': position,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (deleted != null) 'deleted': deleted,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -3329,12 +3515,16 @@ class ShelfItemsTableCompanion extends UpdateCompanion<ShelfItemsTableData> {
     Value<String>? shelfId,
     Value<String>? mediaItemId,
     Value<int>? position,
+    Value<int>? updatedAt,
+    Value<int>? deleted,
     Value<int>? rowid,
   }) {
     return ShelfItemsTableCompanion(
       shelfId: shelfId ?? this.shelfId,
       mediaItemId: mediaItemId ?? this.mediaItemId,
       position: position ?? this.position,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deleted: deleted ?? this.deleted,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -3351,6 +3541,12 @@ class ShelfItemsTableCompanion extends UpdateCompanion<ShelfItemsTableData> {
     if (position.present) {
       map['position'] = Variable<int>(position.value);
     }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (deleted.present) {
+      map['deleted'] = Variable<int>(deleted.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -3363,6 +3559,8 @@ class ShelfItemsTableCompanion extends UpdateCompanion<ShelfItemsTableData> {
           ..write('shelfId: $shelfId, ')
           ..write('mediaItemId: $mediaItemId, ')
           ..write('position: $position, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deleted: $deleted, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -13296,12 +13494,16 @@ typedef $$MediaItemTagsTableTableCreateCompanionBuilder =
     MediaItemTagsTableCompanion Function({
       required String mediaItemId,
       required String tagId,
+      Value<int> updatedAt,
+      Value<int> deleted,
       Value<int> rowid,
     });
 typedef $$MediaItemTagsTableTableUpdateCompanionBuilder =
     MediaItemTagsTableCompanion Function({
       Value<String> mediaItemId,
       Value<String> tagId,
+      Value<int> updatedAt,
+      Value<int> deleted,
       Value<int> rowid,
     });
 
@@ -13369,6 +13571,16 @@ class $$MediaItemTagsTableTableFilterComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get deleted => $composableBuilder(
+    column: $table.deleted,
+    builder: (column) => ColumnFilters(column),
+  );
+
   $$MediaItemsTableTableFilterComposer get mediaItemId {
     final $$MediaItemsTableTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -13425,6 +13637,16 @@ class $$MediaItemTagsTableTableOrderingComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get deleted => $composableBuilder(
+    column: $table.deleted,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$MediaItemsTableTableOrderingComposer get mediaItemId {
     final $$MediaItemsTableTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -13481,6 +13703,12 @@ class $$MediaItemTagsTableTableAnnotationComposer
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<int> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deleted =>
+      $composableBuilder(column: $table.deleted, builder: (column) => column);
+
   $$MediaItemsTableTableAnnotationComposer get mediaItemId {
     final $$MediaItemsTableTableAnnotationComposer composer = $composerBuilder(
       composer: this,
@@ -13563,20 +13791,28 @@ class $$MediaItemTagsTableTableTableManager
               ({
                 Value<String> mediaItemId = const Value.absent(),
                 Value<String> tagId = const Value.absent(),
+                Value<int> updatedAt = const Value.absent(),
+                Value<int> deleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => MediaItemTagsTableCompanion(
                 mediaItemId: mediaItemId,
                 tagId: tagId,
+                updatedAt: updatedAt,
+                deleted: deleted,
                 rowid: rowid,
               ),
           createCompanionCallback:
               ({
                 required String mediaItemId,
                 required String tagId,
+                Value<int> updatedAt = const Value.absent(),
+                Value<int> deleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => MediaItemTagsTableCompanion.insert(
                 mediaItemId: mediaItemId,
                 tagId: tagId,
+                updatedAt: updatedAt,
+                deleted: deleted,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0
@@ -13998,6 +14234,8 @@ typedef $$ShelfItemsTableTableCreateCompanionBuilder =
       required String shelfId,
       required String mediaItemId,
       Value<int> position,
+      Value<int> updatedAt,
+      Value<int> deleted,
       Value<int> rowid,
     });
 typedef $$ShelfItemsTableTableUpdateCompanionBuilder =
@@ -14005,6 +14243,8 @@ typedef $$ShelfItemsTableTableUpdateCompanionBuilder =
       Value<String> shelfId,
       Value<String> mediaItemId,
       Value<int> position,
+      Value<int> updatedAt,
+      Value<int> deleted,
       Value<int> rowid,
     });
 
@@ -14077,6 +14317,16 @@ class $$ShelfItemsTableTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get deleted => $composableBuilder(
+    column: $table.deleted,
+    builder: (column) => ColumnFilters(column),
+  );
+
   $$ShelvesTableTableFilterComposer get shelfId {
     final $$ShelvesTableTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -14138,6 +14388,16 @@ class $$ShelfItemsTableTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get deleted => $composableBuilder(
+    column: $table.deleted,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   $$ShelvesTableTableOrderingComposer get shelfId {
     final $$ShelvesTableTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -14196,6 +14456,12 @@ class $$ShelfItemsTableTableAnnotationComposer
   });
   GeneratedColumn<int> get position =>
       $composableBuilder(column: $table.position, builder: (column) => column);
+
+  GeneratedColumn<int> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<int> get deleted =>
+      $composableBuilder(column: $table.deleted, builder: (column) => column);
 
   $$ShelvesTableTableAnnotationComposer get shelfId {
     final $$ShelvesTableTableAnnotationComposer composer = $composerBuilder(
@@ -14277,11 +14543,15 @@ class $$ShelfItemsTableTableTableManager
                 Value<String> shelfId = const Value.absent(),
                 Value<String> mediaItemId = const Value.absent(),
                 Value<int> position = const Value.absent(),
+                Value<int> updatedAt = const Value.absent(),
+                Value<int> deleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ShelfItemsTableCompanion(
                 shelfId: shelfId,
                 mediaItemId: mediaItemId,
                 position: position,
+                updatedAt: updatedAt,
+                deleted: deleted,
                 rowid: rowid,
               ),
           createCompanionCallback:
@@ -14289,11 +14559,15 @@ class $$ShelfItemsTableTableTableManager
                 required String shelfId,
                 required String mediaItemId,
                 Value<int> position = const Value.absent(),
+                Value<int> updatedAt = const Value.absent(),
+                Value<int> deleted = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => ShelfItemsTableCompanion.insert(
                 shelfId: shelfId,
                 mediaItemId: mediaItemId,
                 position: position,
+                updatedAt: updatedAt,
+                deleted: deleted,
                 rowid: rowid,
               ),
           withReferenceMapper: (p0) => p0

--- a/lib/data/local/database/tables/media_item_tags_table.dart
+++ b/lib/data/local/database/tables/media_item_tags_table.dart
@@ -11,6 +11,12 @@ class MediaItemTagsTable extends Table {
   TextColumn get tagId =>
       text().references(TagsTable, #id)();
 
+  /// Last-write-wins basis for sync (epoch millis).
+  IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+
+  /// Soft-delete tombstone so removals replicate; readers filter on 0.
+  IntColumn get deleted => integer().withDefault(const Constant(0))();
+
   @override
   Set<Column> get primaryKey => {mediaItemId, tagId};
 }

--- a/lib/data/local/database/tables/shelf_items_table.dart
+++ b/lib/data/local/database/tables/shelf_items_table.dart
@@ -12,6 +12,12 @@ class ShelfItemsTable extends Table {
       text().references(MediaItemsTable, #id)();
   IntColumn get position => integer().withDefault(const Constant(0))();
 
+  /// Last-write-wins basis for sync (epoch millis).
+  IntColumn get updatedAt => integer().withDefault(const Constant(0))();
+
+  /// Soft-delete tombstone so removals replicate; readers filter on 0.
+  IntColumn get deleted => integer().withDefault(const Constant(0))();
+
   @override
   Set<Column> get primaryKey => {shelfId, mediaItemId};
 }

--- a/lib/data/remote/api/discogs/discogs_api.g.dart
+++ b/lib/data/remote/api/discogs/discogs_api.g.dart
@@ -8,7 +8,7 @@ part of 'discogs_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _DiscogsApi implements DiscogsApi {
   _DiscogsApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/api/fanart/fanart_api.g.dart
+++ b/lib/data/remote/api/fanart/fanart_api.g.dart
@@ -8,7 +8,7 @@ part of 'fanart_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _FanartApi implements FanartApi {
   _FanartApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/api/google_books/google_books_api.g.dart
+++ b/lib/data/remote/api/google_books/google_books_api.g.dart
@@ -8,7 +8,7 @@ part of 'google_books_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _GoogleBooksApi implements GoogleBooksApi {
   _GoogleBooksApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/api/pricecharting/pricecharting_api.g.dart
+++ b/lib/data/remote/api/pricecharting/pricecharting_api.g.dart
@@ -8,7 +8,7 @@ part of 'pricecharting_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _PriceChartingApi implements PriceChartingApi {
   _PriceChartingApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/api/tmdb/tmdb_account_api.g.dart
+++ b/lib/data/remote/api/tmdb/tmdb_account_api.g.dart
@@ -8,7 +8,7 @@ part of 'tmdb_account_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _TmdbAccountApi implements TmdbAccountApi {
   _TmdbAccountApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/api/tmdb/tmdb_api.g.dart
+++ b/lib/data/remote/api/tmdb/tmdb_api.g.dart
@@ -8,7 +8,7 @@ part of 'tmdb_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _TmdbApi implements TmdbApi {
   _TmdbApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/api/tvdb/tvdb_api.g.dart
+++ b/lib/data/remote/api/tvdb/tvdb_api.g.dart
@@ -8,7 +8,7 @@ part of 'tvdb_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _TvdbApi implements TvdbApi {
   _TvdbApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/api/upc/upcitemdb_api.g.dart
+++ b/lib/data/remote/api/upc/upcitemdb_api.g.dart
@@ -8,7 +8,7 @@ part of 'upcitemdb_api.dart';
 // RetrofitGenerator
 // **************************************************************************
 
-// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
 
 class _UpcitemdbApi implements UpcitemdbApi {
   _UpcitemdbApi(this._dio, {this.baseUrl, this.errorLogger});

--- a/lib/data/remote/sync/migrations/007_join_table_sync.sql
+++ b/lib/data/remote/sync/migrations/007_join_table_sync.sql
@@ -1,0 +1,27 @@
+-- Migration 007: sync columns for the join tables.
+--
+-- Tag assignments (media_item_tags) and shelf memberships (shelf_items)
+-- previously never synced: the client wrote no sync_log entries for
+-- them and the pull pipeline never read these tables, so the data was
+-- silently device-local. The client now pushes and pulls both tables;
+-- it needs `updated_at` as the last-write-wins basis and `deleted` as a
+-- removal tombstone (mirroring the soft-delete convention used by every
+-- other synced table).
+--
+-- The composite primary keys are unchanged — the client's batch upsert
+-- conflicts on (media_item_id, tag_id) / (shelf_id, media_item_id)
+-- rather than the `id` column used by the single-key tables.
+
+ALTER TABLE media_item_tags
+  ADD COLUMN IF NOT EXISTS updated_at BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS deleted INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE shelf_items
+  ADD COLUMN IF NOT EXISTS updated_at BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS deleted INTEGER NOT NULL DEFAULT 0;
+
+-- Incremental pulls filter on updated_at (`WHERE updated_at > $ts`).
+CREATE INDEX IF NOT EXISTS idx_media_item_tags_updated_at
+  ON media_item_tags(updated_at);
+CREATE INDEX IF NOT EXISTS idx_shelf_items_updated_at
+  ON shelf_items(updated_at);

--- a/lib/data/remote/sync/postgres_sync_client.dart
+++ b/lib/data/remote/sync/postgres_sync_client.dart
@@ -79,6 +79,16 @@ class PostgresSyncClient {
     return table;
   }
 
+  /// Conflict target (primary-key column list) per table for upserts.
+  /// The join tables have composite keys and no `id` column; everything
+  /// else conflicts on `id`.
+  static const _conflictTargetByTable = <String, List<String>>{
+    'shelf_items': ['shelf_id', 'media_item_id'],
+    'media_item_tags': ['media_item_id', 'tag_id'],
+  };
+
+  static const _defaultConflictTarget = ['id'];
+
   /// Matches a valid SQL identifier (column or table name).
   static final _identifierRegex = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*$');
 
@@ -136,14 +146,16 @@ class PostgresSyncClient {
       valueClauses.add('(${placeholders.join(', ')})');
     }
 
+    final conflictTarget =
+        _conflictTargetByTable[table] ?? _defaultConflictTarget;
     final updates = columns
-        .where((c) => c != 'id')
+        .where((c) => !conflictTarget.contains(c))
         .map((c) => '$c = EXCLUDED.$c')
         .join(', ');
 
     final sql = 'INSERT INTO $table (${columns.join(', ')}) '
         'VALUES ${valueClauses.join(', ')} '
-        'ON CONFLICT (id) DO UPDATE SET $updates';
+        'ON CONFLICT (${conflictTarget.join(', ')}) DO UPDATE SET $updates';
 
     return (sql: sql, params: params);
   }

--- a/lib/data/repositories/media_item_repository_impl.dart
+++ b/lib/data/repositories/media_item_repository_impl.dart
@@ -60,7 +60,7 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
     Future<Set<String>> resolveTaggedIds() async {
       if (!useFts || !hasTagFilter) return const <String>{};
       final assignments = await (_db.select(_db.mediaItemTagsTable)
-            ..where((t) => t.tagId.isIn(tagIds)))
+            ..where((t) => t.tagId.isIn(tagIds) & t.deleted.equals(0)))
           .get();
       return assignments.map((a) => a.mediaItemId).toSet();
     }

--- a/lib/data/repositories/shelf_repository_impl.dart
+++ b/lib/data/repositories/shelf_repository_impl.dart
@@ -84,20 +84,78 @@ class ShelfRepositoryImpl implements IShelfRepository {
   }
 
   @override
-  Future<void> addItem(String shelfId, String mediaItemId, int position) =>
-      _shelvesDao.addItem(shelfId, mediaItemId, position);
+  Future<void> addItem(String shelfId, String mediaItemId, int position) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    // Atomic write + sync_log: see MediaItemRepositoryImpl.save.
+    await _shelvesDao.transaction(() async {
+      await _shelvesDao.addItem(shelfId, mediaItemId, position,
+          updatedAt: now);
+      await _logItemSync(
+        shelfId: shelfId,
+        mediaItemId: mediaItemId,
+        operation: 'insert',
+        position: position,
+        updatedAt: now,
+        deleted: 0,
+      );
+    });
+  }
 
   @override
-  Future<void> removeItem(String shelfId, String mediaItemId) =>
-      _shelvesDao.removeItem(shelfId, mediaItemId);
+  Future<void> removeItem(String shelfId, String mediaItemId) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await _shelvesDao.transaction(() async {
+      await _shelvesDao.removeItem(shelfId, mediaItemId, updatedAt: now);
+      await _logItemSync(
+        shelfId: shelfId,
+        mediaItemId: mediaItemId,
+        operation: 'delete',
+        position: 0,
+        updatedAt: now,
+        deleted: 1,
+      );
+    });
+  }
 
   @override
   Future<List<String>> getMediaItemIdsForShelf(String shelfId) =>
       _shelvesDao.getMediaItemIdsForShelf(shelfId);
 
   @override
-  Future<void> reorderItems(String shelfId, List<String> orderedMediaItemIds) =>
-      _shelvesDao.reorderItems(shelfId, orderedMediaItemIds);
+  Future<void> reorderItems(
+      String shelfId, List<String> orderedMediaItemIds) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await _shelvesDao.transaction(() async {
+      // Snapshot the live membership BEFORE the rewrite so items the
+      // reorder dropped can be tombstone-logged.
+      final before = await _shelvesDao.getMediaItemIdsForShelf(shelfId);
+      await _shelvesDao.reorderItems(shelfId, orderedMediaItemIds,
+          updatedAt: now);
+
+      for (var i = 0; i < orderedMediaItemIds.length; i++) {
+        await _logItemSync(
+          shelfId: shelfId,
+          mediaItemId: orderedMediaItemIds[i],
+          operation: 'update',
+          position: i,
+          updatedAt: now,
+          deleted: 0,
+        );
+      }
+      final removed =
+          before.toSet().difference(orderedMediaItemIds.toSet());
+      for (final mediaItemId in removed) {
+        await _logItemSync(
+          shelfId: shelfId,
+          mediaItemId: mediaItemId,
+          operation: 'delete',
+          position: 0,
+          updatedAt: now,
+          deleted: 1,
+        );
+      }
+    });
+  }
 
   /// Enqueue a `sync_log` row carrying a full snake_case snapshot of
   /// [shelf]. Push uses the payload keys to derive the upsert column
@@ -117,6 +175,33 @@ class ShelfRepositoryImpl implements IShelfRepository {
         'deleted': 0,
       })),
       createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
+  /// Enqueue a `sync_log` row for a shelf membership. The composite
+  /// entity id ('shelfId|mediaItemId') mirrors the remote composite PK;
+  /// push never parses it — the payload carries the real key columns.
+  Future<void> _logItemSync({
+    required String shelfId,
+    required String mediaItemId,
+    required String operation,
+    required int position,
+    required int updatedAt,
+    required int deleted,
+  }) {
+    return _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('shelf_item'),
+      entityId: Value('$shelfId|$mediaItemId'),
+      operation: Value(operation),
+      payloadJson: Value(jsonEncode({
+        'shelf_id': shelfId,
+        'media_item_id': mediaItemId,
+        'position': position,
+        'updated_at': updatedAt,
+        'deleted': deleted,
+      })),
+      createdAt: Value(updatedAt),
     ));
   }
 

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -250,6 +250,17 @@ class SyncRepositoryImpl implements ISyncRepository {
         afterTimestamp: lastSyncedAt,
       );
 
+      // Join tables last, so their parent rows (media items, tags,
+      // shelves) have already been pulled in this same pass.
+      await _pullJoinTable(
+        tableName: 'media_item_tags',
+        afterTimestamp: lastSyncedAt,
+      );
+      await _pullJoinTable(
+        tableName: 'shelf_items',
+        afterTimestamp: lastSyncedAt,
+      );
+
       // Auto-purge old sync log entries (30 days)
       final purgeThreshold =
           DateTime.now().millisecondsSinceEpoch - _purgeThresholdMs;
@@ -321,6 +332,75 @@ class SyncRepositoryImpl implements ISyncRepository {
         continue;
       }
       await _applyRemoteRow(entityType, remote);
+    }
+  }
+
+  /// Pull a composite-key join table (`media_item_tags` / `shelf_items`)
+  /// with last-write-wins on `updated_at`. Tombstones (`deleted = 1`)
+  /// are applied as-is, soft-deleting the local row.
+  ///
+  /// Unlike [_pullLastWriteWins] this reads the local `updated_at` one
+  /// row at a time — the join tables have no single id column to bulk
+  /// key on, and incremental pulls only carry rows changed since the
+  /// watermark, so the per-row read stays small.
+  Future<void> _pullJoinTable({
+    required String tableName,
+    required int? afterTimestamp,
+  }) async {
+    final rows = await _syncClient.pullRecords(
+      tableName,
+      afterTimestamp: afterTimestamp,
+    );
+    final db = _mediaItemsDao.attachedDatabase;
+    final entityType =
+        tableName == 'media_item_tags' ? 'media_item_tag' : 'shelf_item';
+    final total = rows.length;
+    for (var i = 0; i < rows.length; i++) {
+      final remote = rows[i];
+      _progressController.add(SyncProgress(
+        phase: SyncPhase.pull,
+        current: i + 1,
+        total: total,
+        currentEntityType: entityType,
+      ));
+      final remoteUpdatedAt = (remote['updated_at'] as num?)?.toInt() ?? 0;
+      final deleted = (remote['deleted'] as num?)?.toInt() ?? 0;
+
+      switch (tableName) {
+        case 'media_item_tags':
+          final mediaItemId = remote['media_item_id'];
+          final tagId = remote['tag_id'];
+          if (mediaItemId is! String || tagId is! String) continue;
+          final localUpdatedAt =
+              await db.tagsDao.assignmentUpdatedAt(mediaItemId, tagId);
+          if (localUpdatedAt != null && remoteUpdatedAt <= localUpdatedAt) {
+            continue;
+          }
+          await db.tagsDao.upsertAssignmentRow(MediaItemTagsTableCompanion(
+            mediaItemId: Value(mediaItemId),
+            tagId: Value(tagId),
+            updatedAt: Value(remoteUpdatedAt),
+            deleted: Value(deleted),
+          ));
+        case 'shelf_items':
+          final shelfId = remote['shelf_id'];
+          final mediaItemId = remote['media_item_id'];
+          if (shelfId is! String || mediaItemId is! String) continue;
+          final localUpdatedAt =
+              await db.shelvesDao.itemUpdatedAt(shelfId, mediaItemId);
+          if (localUpdatedAt != null && remoteUpdatedAt <= localUpdatedAt) {
+            continue;
+          }
+          await db.shelvesDao.upsertItemRow(ShelfItemsTableCompanion(
+            shelfId: Value(shelfId),
+            mediaItemId: Value(mediaItemId),
+            position: Value((remote['position'] as num?)?.toInt() ?? 0),
+            updatedAt: Value(remoteUpdatedAt),
+            deleted: Value(deleted),
+          ));
+        default:
+          throw StateError('Unsupported join table for pull: $tableName');
+      }
     }
   }
 

--- a/lib/data/repositories/sync_repository_impl.dart
+++ b/lib/data/repositories/sync_repository_impl.dart
@@ -169,10 +169,18 @@ class SyncRepositoryImpl implements ISyncRepository {
         // every merged field.
         final localJson = JsonKeyCase.toSnakeCase(localRow.toJson());
 
+        // Remote rows come from SELECT *, so they carry server-managed
+        // columns the local schema doesn't have — `created_at`
+        // (TIMESTAMPTZ, decoded as a Dart DateTime) and `device_id`.
+        // Restrict the remote map to the local column set so the merge
+        // can't feed un-encodable values into jsonEncode below, or echo
+        // server-managed columns back to the server on the next push.
+        final remoteFiltered = _restrictToColumns(remote, localJson);
+
         // Detect conflicts for close-in-time edits
         final conflicts = SyncStrategy.detectConflicts(
           localJson,
-          remote,
+          remoteFiltered,
           entityType: 'media_item',
           entityId: remoteId,
         );
@@ -184,7 +192,7 @@ class SyncRepositoryImpl implements ISyncRepository {
         }
 
         // No conflicts — apply standard merge and persist
-        final merged = SyncStrategy.mergeFields(localJson, remote);
+        final merged = SyncStrategy.mergeFields(localJson, remoteFiltered);
         // Stamp synced_at on the merged row so the pulled state isn't
         // re-flagged as dirty on the next push.
         merged['synced_at'] = DateTime.now().millisecondsSinceEpoch;
@@ -500,9 +508,12 @@ class SyncRepositoryImpl implements ISyncRepository {
       );
       if (remote.isEmpty) continue;
 
+      // Strip server-managed columns (see pullChanges) before merging so
+      // the pending payload below stays JSON-encodable.
+      final localJson = JsonKeyCase.toSnakeCase(localRow.toJson());
       final merged = SyncStrategy.mergeWithResolutions(
-        JsonKeyCase.toSnakeCase(localRow.toJson()),
-        remote,
+        localJson,
+        _restrictToColumns(remote, localJson),
         entityResolutions,
       );
       merged['synced_at'] = DateTime.now().millisecondsSinceEpoch;
@@ -611,6 +622,23 @@ class SyncRepositoryImpl implements ISyncRepository {
       error: error,
       conflictCount: conflictCount,
     );
+  }
+
+  /// Restrict a remote row to the columns present on the local row.
+  ///
+  /// Remote rows are fetched with SELECT *, so they include columns the
+  /// local schema doesn't carry (`created_at`, `device_id`). Those must
+  /// not survive into merged payloads: `created_at` arrives as a Dart
+  /// [DateTime] (not JSON-encodable) and `device_id` would be pushed
+  /// back, clobbering the server's attribution of the original writer.
+  static Map<String, dynamic> _restrictToColumns(
+    Map<String, dynamic> remote,
+    Map<String, dynamic> localJson,
+  ) {
+    return {
+      for (final entry in remote.entries)
+        if (localJson.containsKey(entry.key)) entry.key: entry.value,
+    };
   }
 
   Future<int?> _getLastSyncedAt() async {

--- a/lib/data/repositories/tag_repository_impl.dart
+++ b/lib/data/repositories/tag_repository_impl.dart
@@ -76,12 +76,35 @@ class TagRepositoryImpl implements ITagRepository {
   }
 
   @override
-  Future<void> assignToMediaItem(String tagId, String mediaItemId) =>
-      _tagsDao.assignToMediaItem(tagId, mediaItemId);
+  Future<void> assignToMediaItem(String tagId, String mediaItemId) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    // Atomic write + sync_log: see MediaItemRepositoryImpl.save.
+    await _tagsDao.transaction(() async {
+      await _tagsDao.assignToMediaItem(tagId, mediaItemId, updatedAt: now);
+      await _logAssignmentSync(
+        tagId: tagId,
+        mediaItemId: mediaItemId,
+        operation: 'insert',
+        updatedAt: now,
+        deleted: 0,
+      );
+    });
+  }
 
   @override
-  Future<void> removeFromMediaItem(String tagId, String mediaItemId) =>
-      _tagsDao.removeFromMediaItem(tagId, mediaItemId);
+  Future<void> removeFromMediaItem(String tagId, String mediaItemId) async {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    await _tagsDao.transaction(() async {
+      await _tagsDao.removeFromMediaItem(tagId, mediaItemId, updatedAt: now);
+      await _logAssignmentSync(
+        tagId: tagId,
+        mediaItemId: mediaItemId,
+        operation: 'delete',
+        updatedAt: now,
+        deleted: 1,
+      );
+    });
+  }
 
   @override
   Future<List<String>> getTagIdsForMediaItem(String mediaItemId) =>
@@ -103,6 +126,31 @@ class TagRepositoryImpl implements ITagRepository {
         'deleted': 0,
       })),
       createdAt: Value(DateTime.now().millisecondsSinceEpoch),
+    ));
+  }
+
+  /// Enqueue a `sync_log` row for a tag assignment. The composite
+  /// entity id ('mediaItemId|tagId') mirrors the remote composite PK;
+  /// push never parses it — the payload carries the real key columns.
+  Future<void> _logAssignmentSync({
+    required String tagId,
+    required String mediaItemId,
+    required String operation,
+    required int updatedAt,
+    required int deleted,
+  }) {
+    return _syncLogDao.insertLog(SyncLogTableCompanion(
+      id: Value(_uuid.v7()),
+      entityType: const Value('media_item_tag'),
+      entityId: Value('$mediaItemId|$tagId'),
+      operation: Value(operation),
+      payloadJson: Value(jsonEncode({
+        'media_item_id': mediaItemId,
+        'tag_id': tagId,
+        'updated_at': updatedAt,
+        'deleted': deleted,
+      })),
+      createdAt: Value(updatedAt),
     ));
   }
 

--- a/lib/domain/usecases/edit_item_metadata_usecase.dart
+++ b/lib/domain/usecases/edit_item_metadata_usecase.dart
@@ -1,0 +1,70 @@
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/metadata_result.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+
+/// Use case backing the item edit screen: applies user-edited metadata
+/// onto an existing [MediaItem] and persists it.
+///
+/// Unlike [RefreshMetadataUseCase] (which merges API results and keeps
+/// the local value when the API returns nothing), the user's edits are
+/// authoritative — a field the user cleared in the form clears the
+/// stored value. Identity and user data (id, barcode, ownership,
+/// rating, review, progress, dates) are never touched by the form and
+/// are preserved.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+class EditItemMetadataUseCase {
+  const EditItemMetadataUseCase({
+    required IMediaItemRepository repository,
+  }) : _repo = repository;
+
+  final IMediaItemRepository _repo;
+
+  /// Map an existing item into the [MetadataResult] shape the shared
+  /// `EditableMetadataForm` takes as its initial values.
+  static MetadataResult toMetadataResult(MediaItem item) => MetadataResult(
+        barcode: item.barcode,
+        barcodeType: item.barcodeType,
+        mediaType: item.mediaType,
+        title: item.title,
+        subtitle: item.subtitle,
+        description: item.description,
+        coverUrl: item.coverUrl,
+        year: item.year,
+        publisher: item.publisher,
+        format: item.format,
+        genres: item.genres,
+        extraMetadata: item.extraMetadata,
+        sourceApis: item.sourceApis,
+        criticScore: item.criticScore,
+        criticSource: item.criticSource,
+      );
+
+  /// Apply [edited] onto [item], stamp `updatedAt`, persist, and return
+  /// the updated item.
+  Future<MediaItem> execute(MediaItem item, MetadataResult edited) async {
+    final updated = item.copyWith(
+      mediaType: edited.mediaType ?? item.mediaType,
+      // Title is the one non-nullable metadata field on MediaItem; an
+      // empty edit falls back rather than producing a blank row.
+      title: (edited.title?.trim().isNotEmpty ?? false)
+          ? edited.title!.trim()
+          : item.title,
+      subtitle: edited.subtitle,
+      description: edited.description,
+      coverUrl: edited.coverUrl,
+      year: edited.year,
+      publisher: edited.publisher,
+      format: edited.format,
+      genres: edited.genres,
+      extraMetadata: edited.extraMetadata,
+      sourceApis: edited.sourceApis,
+      criticScore: edited.criticScore,
+      criticSource: edited.criticSource,
+      updatedAt: DateTime.now().millisecondsSinceEpoch,
+    );
+    await _repo.update(updated);
+    return updated;
+  }
+}

--- a/lib/presentation/providers/batch_editor_provider.dart
+++ b/lib/presentation/providers/batch_editor_provider.dart
@@ -476,32 +476,37 @@ class BatchEditorNotifier extends AsyncNotifier<BatchEditorState> {
     // Update the live state by ID on each iteration. This preserves
     // concurrent `addScanResult` additions that land during the save loop.
     var savedCount = 0;
-    for (final item in confirmedItems) {
-      await useCase.execute(item.metadata!);
-      savedCount++;
+    try {
+      for (final item in confirmedItems) {
+        await useCase.execute(item.metadata!);
+        savedCount++;
 
-      final latest = state.requireValue;
-      final nextItems = latest.items.map((i) {
-        if (i.id == item.id) return i.copyWith(status: BatchItemStatus.saved);
-        return i;
-      }).toList();
-      state = AsyncValue.data(latest.copyWith(
-        items: nextItems,
-        saveProgress: () =>
-            BatchSaveProgress(current: savedCount, total: total),
+        final latest = state.requireValue;
+        final nextItems = latest.items.map((i) {
+          if (i.id == item.id) return i.copyWith(status: BatchItemStatus.saved);
+          return i;
+        }).toList();
+        state = AsyncValue.data(latest.copyWith(
+          items: nextItems,
+          saveProgress: () =>
+              BatchSaveProgress(current: savedCount, total: total),
+        ));
+      }
+    } finally {
+      // Runs even when a save throws mid-loop: clear the progress flag so
+      // the UI can't sit in "saving" forever, and persist the statuses of
+      // the items that DID save — otherwise a restored session would
+      // still hold them as `confirmed` and re-save them as duplicates.
+      // (Includes any concurrently added items.)
+      state = AsyncValue.data(state.requireValue.copyWith(
+        saveProgress: () => null,
       ));
+      await _persistAllItems(state.requireValue.items);
     }
 
     final finalItems = state.requireValue.items;
     final hasUnsaved =
         finalItems.any((i) => i.status != BatchItemStatus.saved);
-
-    state = AsyncValue.data(state.requireValue.copyWith(
-      saveProgress: () => null,
-    ));
-
-    // Persist all status changes (includes any concurrently added items).
-    await _persistAllItems(finalItems);
 
     // Only complete the session if it is still the live one — clearBatch
     // may have replaced it during the save loop, in which case the new

--- a/lib/presentation/providers/batch_metadata_edit_provider.dart
+++ b/lib/presentation/providers/batch_metadata_edit_provider.dart
@@ -104,10 +104,14 @@ class BatchMetadataEditNotifier extends Notifier<BatchMetadataEditState> {
 
       // Build a pre-computed lookup: trackId → RipTrack.
       // Iterates albums once up front so the per-change loop is O(1).
-      final allAlbums = ref.read(allRipAlbumsProvider).value ?? [];
+      // Query the repository directly — a synchronous `.value` read of
+      // ripTracksProvider returns null for any album whose detail view
+      // was never opened, which made existing tracks look deleted.
+      final repo = ref.read(ripLibraryRepositoryProvider);
+      final allAlbums = await repo.getAllNonDeleted();
       final trackLookup = <String, RipTrack>{};
       for (final album in allAlbums) {
-        final tracks = ref.read(ripTracksProvider(album.id)).value ?? [];
+        final tracks = await repo.getTracksForAlbum(album.id);
         for (final track in tracks) {
           trackLookup[track.id] = track;
         }
@@ -178,11 +182,14 @@ class BatchMetadataEditNotifier extends Notifier<BatchMetadataEditState> {
         writer: ref.read(metaflacWriterProvider),
       );
 
-      // Build a pre-computed lookup: trackId → RipTrack.
-      final allAlbums = ref.read(allRipAlbumsProvider).value ?? [];
+      // Build a pre-computed lookup: trackId → RipTrack. Queried from the
+      // repository for the same reason as in applyChanges — a provider
+      // `.value` read is null for albums never opened in the detail view.
+      final repo = ref.read(ripLibraryRepositoryProvider);
+      final allAlbums = await repo.getAllNonDeleted();
       final trackLookup = <String, RipTrack>{};
       for (final album in allAlbums) {
-        final tracks = ref.read(ripTracksProvider(album.id)).value ?? [];
+        final tracks = await repo.getTracksForAlbum(album.id);
         for (final track in tracks) {
           trackLookup[track.id] = track;
         }

--- a/lib/presentation/providers/disambiguation_provider.dart
+++ b/lib/presentation/providers/disambiguation_provider.dart
@@ -40,7 +40,11 @@ class DisambiguationData {
 class DisambiguationNotifier extends Notifier<DisambiguationData> {
   @override
   DisambiguationData build() {
-    final scanResult = ref.read(scannerProvider).result;
+    // Watch (not read) the scan result: `build()` only runs again when a
+    // dependency changes, so a `ref.read` snapshot here froze the FIRST
+    // multi-match scan's candidates for the life of the app — every
+    // later disambiguation showed stale data.
+    final scanResult = ref.watch(scannerProvider.select((s) => s.result));
     if (scanResult is MultiMatchScanResult) {
       return DisambiguationData(
         candidates: scanResult.candidates,

--- a/lib/presentation/screens/batch/batch_placeholder_screen.dart
+++ b/lib/presentation/screens/batch/batch_placeholder_screen.dart
@@ -391,7 +391,19 @@ class _BatchPlaceholderScreenState
         return;
       }
     }
-    await ref.read(batchEditorProvider.notifier).saveAllConfirmed();
+    try {
+      await ref.read(batchEditorProvider.notifier).saveAllConfirmed();
+    } catch (e) {
+      // The provider has already cleared its saving state and persisted
+      // the items that did save; surface the failure so the user can
+      // retry the remainder.
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Bulk save failed: $e')),
+        );
+      }
+      return;
+    }
     if (context.mounted) {
       final savedCount = ref.read(batchEditorProvider).requireValue.savedCount;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/presentation/screens/item_detail/edit_item_screen.dart
+++ b/lib/presentation/screens/item_detail/edit_item_screen.dart
@@ -1,0 +1,65 @@
+// Edit screen for an existing collection item — reuses the shared
+// EditableMetadataForm with the item's current values pre-filled.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/domain/usecases/edit_item_metadata_usecase.dart';
+import 'package:mymediascanner/presentation/providers/metadata_provider.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/screens/metadata_confirm/widgets/editable_metadata_form.dart';
+import 'package:mymediascanner/presentation/widgets/error_state.dart';
+
+class EditItemScreen extends ConsumerWidget {
+  const EditItemScreen({super.key, required this.itemId});
+
+  final String itemId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final itemAsync = ref.watch(mediaItemProvider(itemId));
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Item')),
+      body: SafeArea(
+        top: false,
+        child: itemAsync.when(
+          data: (item) {
+            if (item == null) {
+              return const ErrorState(message: 'Item not found');
+            }
+            return SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: EditableMetadataForm(
+                initial: EditItemMetadataUseCase.toMetadataResult(item),
+                primarySaveLabel: 'Save Changes',
+                enableOnlineLookup: true,
+                showFormatSuggestions: true,
+                onSave: (edited) async {
+                  final messenger = ScaffoldMessenger.of(context);
+                  final navigator = GoRouter.of(context);
+                  final useCase = EditItemMetadataUseCase(
+                    repository: ref.read(mediaItemRepositoryProvider),
+                  );
+                  await useCase.execute(item, edited);
+                  if (!context.mounted) return;
+                  ref.invalidate(mediaItemProvider(itemId));
+                  messenger.showSnackBar(
+                    const SnackBar(content: Text('Changes saved')),
+                  );
+                  navigator.pop();
+                },
+              ),
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) =>
+              ErrorState(message: 'Failed to load item: $e'),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screens/scanner/desktop_scan_screen.dart
+++ b/lib/presentation/screens/scanner/desktop_scan_screen.dart
@@ -93,7 +93,9 @@ class _DesktopScanScreenState extends ConsumerState<DesktopScanScreen> {
       _cameraError = null;
     });
 
-    final CameraService service = ref.read(cameraServiceProvider);
+    // Fresh instance per session: this screen disposes the service when
+    // the webcam is toggled off, so a cached instance must never be reused.
+    final CameraService service = ref.read(cameraServiceFactoryProvider)();
     _cameraService = service;
     try {
       await service.start();

--- a/test/unit/core/services/camera/camera_service_provider_test.dart
+++ b/test/unit/core/services/camera/camera_service_provider_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/core/services/camera/camera_service_provider.dart';
+
+/// Regression: `cameraServiceProvider` was a keep-alive
+/// `Provider<CameraService>` caching one instance for the app's
+/// lifetime, while `DesktopScanScreen` (correctly, as the owner)
+/// called `dispose()` on it when the webcam was toggled off. The next
+/// session then received the same disposed instance: its broadcast
+/// barcode controller was closed, so detections were silently dropped
+/// on Windows/Linux, and `start()` threw on macOS — scanning was dead
+/// until app restart. The provider must hand out a fresh instance per
+/// session instead of caching one.
+void main() {
+  test('each webcam session gets a fresh, usable camera service', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final createService = container.read(cameraServiceFactoryProvider);
+
+    // First session: screen creates, uses, and disposes the service.
+    final first = createService();
+    await first.dispose();
+
+    // Second session must NOT receive the disposed instance.
+    final second = createService();
+    addTearDown(second.dispose);
+    expect(identical(second, first), isFalse,
+        reason: 'a disposed service must never be handed out again');
+
+    // The fresh instance's detection stream must be live (listenable).
+    final subscription = second.onBarcodeDetected.listen((_) {});
+    await subscription.cancel();
+  });
+}

--- a/test/unit/data/local/dao/tmdb_account_sync_dao_test.dart
+++ b/test/unit/data/local/dao/tmdb_account_sync_dao_test.dart
@@ -34,8 +34,8 @@ void main() {
     );
   }
 
-  test('schemaVersion is 22', () {
-    expect(db.schemaVersion, 22);
+  test('schemaVersion is 23', () {
+    expect(db.schemaVersion, 23);
   });
 
   test('upsertByTmdbId inserts a new row when none exists', () async {

--- a/test/unit/data/local/database/migration_v23_test.dart
+++ b/test/unit/data/local/database/migration_v23_test.dart
@@ -1,0 +1,81 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+/// v23 adds `updated_at` and `deleted` to the two join tables
+/// (media_item_tags, shelf_items) so tag assignments and shelf
+/// memberships can sync: `deleted` provides removal tombstones and
+/// `updated_at` the last-write-wins basis. Without them the tables had
+/// no sync representation at all and were silently device-local.
+void main() {
+  test('v23 schema exposes updated_at and deleted on join tables', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    await db.customSelect('SELECT 1').get();
+
+    for (final table in ['media_item_tags', 'shelf_items']) {
+      final rows = await db.customSelect(
+        "SELECT name FROM pragma_table_info('$table')",
+      ).get();
+      final names = rows.map((r) => r.data['name'] as String).toSet();
+      expect(names, containsAll(['updated_at', 'deleted']),
+          reason: '$table must carry sync columns');
+    }
+  });
+
+  test('onUpgrade from v22 adds the sync columns to both join tables',
+      () async {
+    final tempDir = await Directory.systemTemp.createTemp('mms_mig_v23_');
+    final dbFile = File('${tempDir.path}/app.sqlite');
+    addTearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    // Seed the v22 join-table shapes (no updated_at / deleted).
+    final raw = sqlite3.open(dbFile.path);
+    raw.execute('''
+      CREATE TABLE media_item_tags (
+        media_item_id TEXT NOT NULL,
+        tag_id TEXT NOT NULL,
+        PRIMARY KEY (media_item_id, tag_id)
+      )
+    ''');
+    raw.execute('''
+      CREATE TABLE shelf_items (
+        shelf_id TEXT NOT NULL,
+        media_item_id TEXT NOT NULL,
+        position INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (shelf_id, media_item_id)
+      )
+    ''');
+    raw.execute("INSERT INTO media_item_tags VALUES ('m1', 't1')");
+    raw.execute("INSERT INTO shelf_items VALUES ('s1', 'm1', 0)");
+    raw.execute('PRAGMA user_version = 22');
+    raw.close();
+
+    final db = AppDatabase.forTesting(NativeDatabase(dbFile));
+    addTearDown(db.close);
+    await db.customSelect('SELECT 1').get();
+
+    for (final table in ['media_item_tags', 'shelf_items']) {
+      final rows = await db.customSelect(
+        "SELECT name FROM pragma_table_info('$table')",
+      ).get();
+      final names = rows.map((r) => r.data['name'] as String).toSet();
+      expect(names, containsAll(['updated_at', 'deleted']),
+          reason: '$table must gain sync columns on upgrade');
+    }
+
+    // Pre-existing rows survive with live defaults.
+    final tagRow = await db.customSelect(
+      'SELECT updated_at, deleted FROM media_item_tags',
+    ).getSingle();
+    expect(tagRow.data['deleted'], 0);
+    expect(tagRow.data['updated_at'], 0);
+  });
+}

--- a/test/unit/data/repositories/join_table_sync_log_test.dart
+++ b/test/unit/data/repositories/join_table_sync_log_test.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/repositories/shelf_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/tag_repository_impl.dart';
+
+/// Tag assignments (`media_item_tags`) and shelf memberships
+/// (`shelf_items`) previously never synced: the mutation paths wrote no
+/// `sync_log` entries, so the data stayed silently device-local while
+/// everything around it replicated. Every mutation must now enqueue a
+/// sync_log row (insert or tombstone) and removals must soft-delete so
+/// the tombstone has a row to represent.
+void main() {
+  late AppDatabase db;
+  late TagRepositoryImpl tagRepo;
+  late ShelfRepositoryImpl shelfRepo;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    tagRepo = TagRepositoryImpl(
+      tagsDao: db.tagsDao,
+      syncLogDao: db.syncLogDao,
+    );
+    shelfRepo = ShelfRepositoryImpl(
+      shelvesDao: db.shelvesDao,
+      syncLogDao: db.syncLogDao,
+    );
+
+    // Parent rows for the joins.
+    await db.tagsDao.insertTag(const TagsTableCompanion(
+      id: Value('t1'),
+      name: Value('Rock'),
+      updatedAt: Value(1),
+    ));
+    await db.shelvesDao.insertShelf(const ShelvesTableCompanion(
+      id: Value('s1'),
+      name: Value('Favourites'),
+      updatedAt: Value(1),
+    ));
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  Future<List<SyncLogTableData>> logsFor(String entityType, String id) async {
+    final rows = await db.syncLogDao.getPending();
+    return rows
+        .where((r) => r.entityType == entityType && r.entityId == id)
+        .toList();
+  }
+
+  group('tag assignments', () {
+    test('assignToMediaItem enqueues a media_item_tag sync_log row',
+        () async {
+      await tagRepo.assignToMediaItem('t1', 'm1');
+
+      final logs = await logsFor('media_item_tag', 'm1|t1');
+      expect(logs, hasLength(1));
+      expect(logs.single.operation, 'insert');
+      final payload =
+          jsonDecode(logs.single.payloadJson) as Map<String, dynamic>;
+      expect(payload['media_item_id'], 'm1');
+      expect(payload['tag_id'], 't1');
+      expect(payload['deleted'], 0);
+      expect(payload['updated_at'], greaterThan(0));
+    });
+
+    test('removeFromMediaItem tombstones the row and enqueues a delete log',
+        () async {
+      await tagRepo.assignToMediaItem('t1', 'm1');
+      await tagRepo.removeFromMediaItem('t1', 'm1');
+
+      expect(await tagRepo.getTagIdsForMediaItem('m1'), isEmpty,
+          reason: 'soft-deleted assignments must be filtered from reads');
+
+      final logs = await logsFor('media_item_tag', 'm1|t1');
+      expect(logs, hasLength(2));
+      final deleteLog = logs.firstWhere((l) => l.operation == 'delete');
+      final payload =
+          jsonDecode(deleteLog.payloadJson) as Map<String, dynamic>;
+      expect(payload['deleted'], 1);
+    });
+
+    test('re-assigning after removal resurrects the assignment', () async {
+      await tagRepo.assignToMediaItem('t1', 'm1');
+      await tagRepo.removeFromMediaItem('t1', 'm1');
+      await tagRepo.assignToMediaItem('t1', 'm1');
+
+      expect(await tagRepo.getTagIdsForMediaItem('m1'), ['t1']);
+    });
+  });
+
+  group('shelf memberships', () {
+    test('addItem enqueues a shelf_item sync_log row with position',
+        () async {
+      await shelfRepo.addItem('s1', 'm1', 3);
+
+      final logs = await logsFor('shelf_item', 's1|m1');
+      expect(logs, hasLength(1));
+      expect(logs.single.operation, 'insert');
+      final payload =
+          jsonDecode(logs.single.payloadJson) as Map<String, dynamic>;
+      expect(payload['shelf_id'], 's1');
+      expect(payload['media_item_id'], 'm1');
+      expect(payload['position'], 3);
+      expect(payload['deleted'], 0);
+      expect(payload['updated_at'], greaterThan(0));
+    });
+
+    test('removeItem tombstones the row and enqueues a delete log',
+        () async {
+      await shelfRepo.addItem('s1', 'm1', 0);
+      await shelfRepo.removeItem('s1', 'm1');
+
+      expect(await shelfRepo.getMediaItemIdsForShelf('s1'), isEmpty,
+          reason: 'soft-deleted memberships must be filtered from reads');
+
+      final logs = await logsFor('shelf_item', 's1|m1');
+      expect(logs, hasLength(2));
+      final deleteLog = logs.firstWhere((l) => l.operation == 'delete');
+      final payload =
+          jsonDecode(deleteLog.payloadJson) as Map<String, dynamic>;
+      expect(payload['deleted'], 1);
+    });
+
+    test('reorderItems keeps dense positions, tombstones dropped items, '
+        'and logs every change', () async {
+      await shelfRepo.addItem('s1', 'm1', 0);
+      await shelfRepo.addItem('s1', 'm2', 1);
+      await shelfRepo.addItem('s1', 'm3', 2);
+
+      // m2 removed by the reorder; m3 and m1 swap.
+      await shelfRepo.reorderItems('s1', ['m3', 'm1']);
+
+      expect(await shelfRepo.getMediaItemIdsForShelf('s1'), ['m3', 'm1']);
+
+      // Surviving items get fresh upsert logs with their new positions.
+      final m3Logs = await logsFor('shelf_item', 's1|m3');
+      final m3Latest =
+          jsonDecode(m3Logs.last.payloadJson) as Map<String, dynamic>;
+      expect(m3Latest['position'], 0);
+      expect(m3Latest['deleted'], 0);
+
+      // The dropped item gets a tombstone log.
+      final m2Logs = await logsFor('shelf_item', 's1|m2');
+      final m2Latest =
+          jsonDecode(m2Logs.last.payloadJson) as Map<String, dynamic>;
+      expect(m2Latest['deleted'], 1);
+    });
+  });
+}

--- a/test/unit/data/repositories/sync_repository_join_pull_test.dart
+++ b/test/unit/data/repositories/sync_repository_join_pull_test.dart
@@ -1,0 +1,132 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/remote/sync/postgres_sync_client.dart';
+import 'package:mymediascanner/data/repositories/sync_repository_impl.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockSyncClient extends Mock implements PostgresSyncClient {}
+
+/// Pull-side of join-table sync: remote `media_item_tags` and
+/// `shelf_items` rows must round-trip to other devices. Last-write-wins
+/// on `updated_at`; `deleted = 1` rows are tombstones that soft-delete
+/// the local assignment.
+void main() {
+  late AppDatabase db;
+  late _MockSyncClient client;
+  late SyncRepositoryImpl repo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    client = _MockSyncClient();
+    repo = SyncRepositoryImpl(
+      mediaItemsDao: db.mediaItemsDao,
+      syncLogDao: db.syncLogDao,
+      syncClient: client,
+    );
+
+    when(() => client.pullRecords(any(),
+            afterTimestamp: any(named: 'afterTimestamp')))
+        .thenAnswer((_) async => <Map<String, dynamic>>[]);
+
+    // Parent rows so the joins have something to reference.
+    await db.tagsDao.insertTag(const TagsTableCompanion(
+      id: Value('t1'),
+      name: Value('Rock'),
+      updatedAt: Value(1),
+    ));
+    await db.shelvesDao.insertShelf(const ShelvesTableCompanion(
+      id: Value('s1'),
+      name: Value('Favourites'),
+      updatedAt: Value(1),
+    ));
+  });
+
+  tearDown(() async {
+    await repo.dispose();
+    await db.close();
+  });
+
+  void stubTable(String table, List<Map<String, dynamic>> rows) {
+    when(() => client.pullRecords(table,
+        afterTimestamp: any(named: 'afterTimestamp'))).thenAnswer(
+      (_) async => rows,
+    );
+  }
+
+  test('pullChanges applies remote tag assignments locally', () async {
+    stubTable('media_item_tags', [
+      {
+        'media_item_id': 'm1',
+        'tag_id': 't1',
+        'updated_at': 5000,
+        'deleted': 0,
+      },
+    ]);
+
+    await repo.pullChanges();
+
+    expect(await db.tagsDao.getTagIdsForMediaItem('m1'), ['t1']);
+  });
+
+  test('pullChanges applies remote shelf memberships with position',
+      () async {
+    stubTable('shelf_items', [
+      {
+        'shelf_id': 's1',
+        'media_item_id': 'm2',
+        'position': 1,
+        'updated_at': 5000,
+        'deleted': 0,
+      },
+      {
+        'shelf_id': 's1',
+        'media_item_id': 'm1',
+        'position': 0,
+        'updated_at': 5000,
+        'deleted': 0,
+      },
+    ]);
+
+    await repo.pullChanges();
+
+    expect(
+        await db.shelvesDao.getMediaItemIdsForShelf('s1'), ['m1', 'm2']);
+  });
+
+  test('a remote tombstone soft-deletes the local assignment', () async {
+    await db.tagsDao.assignToMediaItem('t1', 'm1', updatedAt: 1000);
+    stubTable('media_item_tags', [
+      {
+        'media_item_id': 'm1',
+        'tag_id': 't1',
+        'updated_at': 5000,
+        'deleted': 1,
+      },
+    ]);
+
+    await repo.pullChanges();
+
+    expect(await db.tagsDao.getTagIdsForMediaItem('m1'), isEmpty);
+  });
+
+  test('an older remote row does not clobber a newer local one', () async {
+    await db.tagsDao.assignToMediaItem('t1', 'm1', updatedAt: 9000);
+    stubTable('media_item_tags', [
+      {
+        'media_item_id': 'm1',
+        'tag_id': 't1',
+        'updated_at': 5000,
+        'deleted': 1, // stale removal from a device that synced late
+      },
+    ]);
+
+    await repo.pullChanges();
+
+    expect(await db.tagsDao.getTagIdsForMediaItem('m1'), ['t1'],
+        reason: 'LWW: local updated_at 9000 beats remote 5000');
+  });
+}

--- a/test/unit/data/repositories/sync_repository_server_columns_test.dart
+++ b/test/unit/data/repositories/sync_repository_server_columns_test.dart
@@ -1,0 +1,138 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/data/local/database/app_database.dart';
+import 'package:mymediascanner/data/remote/sync/postgres_sync_client.dart';
+import 'package:mymediascanner/data/repositories/media_item_repository_impl.dart';
+import 'package:mymediascanner/data/repositories/sync_repository_impl.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/sync_conflict.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:convert';
+
+class _MockSyncClient extends Mock implements PostgresSyncClient {}
+
+/// Regression: remote `media_items` rows arrive via `SELECT *`, so they
+/// carry server-managed columns the local schema doesn't have —
+/// `created_at` (TIMESTAMPTZ, decoded by `package:postgres` as a Dart
+/// `DateTime`) and `device_id`. `SyncStrategy.mergeFields` spread every
+/// remote key into the merged map, and `jsonEncode(merged)` then threw
+/// `JsonUnsupportedObjectError` — an `Error`, so it bypassed the
+/// `on Exception` handlers and crashed the pull uncaught, leaving the
+/// status stream stuck in `isSyncing`. Even when encoding succeeded, the
+/// refreshed pending payload would push `device_id`/`created_at` back to
+/// the server, clobbering attribution.
+void main() {
+  late AppDatabase db;
+  late _MockSyncClient client;
+  late SyncRepositoryImpl repo;
+  late MediaItemRepositoryImpl mediaRepo;
+
+  MediaItem baseItem(String id) => MediaItem(
+        id: id,
+        barcode: 'bc-$id',
+        barcodeType: 'ean13',
+        mediaType: MediaType.book,
+        title: 'Local Title',
+        dateAdded: 1000,
+        dateScanned: 1000,
+        updatedAt: 1000,
+      );
+
+  /// Remote row as `pullRecords` actually delivers it: payload columns
+  /// plus the server-managed `created_at` (a `DateTime`) and `device_id`.
+  Map<String, dynamic> remoteRow(String id, {required int updatedAt}) => {
+        'id': id,
+        'title': 'Remote Title',
+        'updated_at': updatedAt,
+        'deleted': 0,
+        'created_at': DateTime.utc(2026, 1, 1),
+        'device_id': 'other-device',
+      };
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    client = _MockSyncClient();
+    repo = SyncRepositoryImpl(
+      mediaItemsDao: db.mediaItemsDao,
+      syncLogDao: db.syncLogDao,
+      syncClient: client,
+    );
+    mediaRepo = MediaItemRepositoryImpl(
+      mediaItemsDao: db.mediaItemsDao,
+      syncLogDao: db.syncLogDao,
+    );
+
+    when(() => client.pullRecords(any(),
+            afterTimestamp: any(named: 'afterTimestamp')))
+        .thenAnswer((_) async => <Map<String, dynamic>>[]);
+    when(() => client.pullRecordsByIds(any(), any()))
+        .thenAnswer((_) async => <Map<String, dynamic>>[]);
+  });
+
+  tearDown(() async {
+    await repo.dispose();
+    await db.close();
+  });
+
+  test('pullChanges merges a remote update carrying server-managed columns',
+      () async {
+    await mediaRepo.save(baseItem('m1'));
+    // updated_at far outside the 60 s conflict threshold → silent merge path.
+    when(() => client.pullRecords('media_items',
+            afterTimestamp: any(named: 'afterTimestamp')))
+        .thenAnswer((_) async => [remoteRow('m1', updatedAt: 1000 + 61000)]);
+
+    await repo.pullChanges();
+
+    final row = await db.mediaItemsDao.getById('m1');
+    expect(row!.title, 'Remote Title');
+
+    // The refreshed pending push payload must stay valid JSON and must
+    // not echo server-managed columns back to the server.
+    final pending = await db.syncLogDao.getPending();
+    final payloads = pending
+        .where((e) => e.entityType == 'media_item' && e.entityId == 'm1')
+        .map((e) => jsonDecode(e.payloadJson) as Map<String, dynamic>);
+    expect(payloads, isNotEmpty,
+        reason: 'precondition: save() must leave a pending push entry');
+    for (final payload in payloads) {
+      expect(payload.containsKey('created_at'), isFalse);
+      expect(payload.containsKey('device_id'), isFalse);
+    }
+  });
+
+  test('resolveConflicts merges a remote row carrying server-managed columns',
+      () async {
+    await mediaRepo.save(baseItem('m1'));
+    // Within the threshold → surfaces as a conflict.
+    when(() => client.pullRecords('media_items',
+            afterTimestamp: any(named: 'afterTimestamp')))
+        .thenAnswer((_) async => [remoteRow('m1', updatedAt: 2000)]);
+    when(() => client.pullRecordsByIds('media_items', any()))
+        .thenAnswer((_) async => [remoteRow('m1', updatedAt: 2000)]);
+
+    await repo.pullChanges();
+    final conflicts = await repo.getConflicts();
+    expect(conflicts, isNotEmpty,
+        reason: 'precondition: close-in-time edit must surface as conflict');
+
+    final resolutions = conflicts
+        .map((c) => c.copyWith(resolution: ConflictResolution.keepRemote))
+        .toList();
+    await repo.resolveConflicts(resolutions);
+
+    final row = await db.mediaItemsDao.getById('m1');
+    expect(row!.title, 'Remote Title');
+
+    final pending = await db.syncLogDao.getPending();
+    for (final entry in pending
+        .where((e) => e.entityType == 'media_item' && e.entityId == 'm1')) {
+      final payload = jsonDecode(entry.payloadJson) as Map<String, dynamic>;
+      expect(payload.containsKey('created_at'), isFalse);
+      expect(payload.containsKey('device_id'), isFalse);
+    }
+  });
+}

--- a/test/unit/data/sync/postgres_sync_client_test.dart
+++ b/test/unit/data/sync/postgres_sync_client_test.dart
@@ -128,6 +128,58 @@ void main() {
       expect(result.params.length, 153);
     });
 
+    group('buildBatchUpsertSql composite conflict targets', () {
+      // The join tables have no `id` column — their PKs are composite.
+      // A hard-coded `ON CONFLICT (id)` would fail at the SQL layer for
+      // every push, so the conflict target must be derived per table.
+      test('shelf_items conflicts on (shelf_id, media_item_id)', () {
+        final records = [
+          {
+            'shelf_id': 's1',
+            'media_item_id': 'm1',
+            'position': 0,
+            'updated_at': 100,
+            'deleted': 0,
+          },
+        ];
+
+        final result =
+            PostgresSyncClient.buildBatchUpsertSql('shelf_items', records);
+
+        expect(result.sql,
+            contains('ON CONFLICT (shelf_id, media_item_id) DO UPDATE'));
+        expect(result.sql, contains('position = EXCLUDED.position'));
+        expect(result.sql, contains('updated_at = EXCLUDED.updated_at'));
+        expect(result.sql, contains('deleted = EXCLUDED.deleted'));
+        // Key columns must not appear in the SET clause.
+        expect(result.sql, isNot(contains('shelf_id = EXCLUDED.shelf_id')));
+        expect(result.sql,
+            isNot(contains('media_item_id = EXCLUDED.media_item_id')));
+      });
+
+      test('media_item_tags conflicts on (media_item_id, tag_id)', () {
+        final records = [
+          {
+            'media_item_id': 'm1',
+            'tag_id': 't1',
+            'updated_at': 100,
+            'deleted': 0,
+          },
+        ];
+
+        final result = PostgresSyncClient.buildBatchUpsertSql(
+            'media_item_tags', records);
+
+        expect(result.sql,
+            contains('ON CONFLICT (media_item_id, tag_id) DO UPDATE'));
+        expect(result.sql, contains('updated_at = EXCLUDED.updated_at'));
+        expect(result.sql, contains('deleted = EXCLUDED.deleted'));
+        expect(result.sql, isNot(contains('tag_id = EXCLUDED.tag_id')));
+        expect(result.sql,
+            isNot(contains('media_item_id = EXCLUDED.media_item_id')));
+      });
+    });
+
     group('tableForEntityType (cluster-7 HIGH-1 regression)', () {
       test('regular plurals resolve correctly', () {
         expect(PostgresSyncClient.tableForEntityType('media_item'),

--- a/test/unit/domain/edit_item_metadata_usecase_test.dart
+++ b/test/unit/domain/edit_item_metadata_usecase_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/metadata_result.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/domain/usecases/edit_item_metadata_usecase.dart';
+
+class MockMediaItemRepository extends Mock implements IMediaItemRepository {}
+
+void main() {
+  late MockMediaItemRepository mockRepo;
+  late EditItemMetadataUseCase useCase;
+
+  const original = MediaItem(
+    id: 'item-1',
+    barcode: '5099902894225',
+    barcodeType: 'ean13',
+    mediaType: MediaType.music,
+    title: 'Old Title',
+    subtitle: 'Old Subtitle',
+    description: 'Old description',
+    year: 1999,
+    publisher: 'Old Label',
+    genres: ['Rock'],
+    userRating: 4.5,
+    userReview: 'Loved it',
+    ownershipStatus: OwnershipStatus.owned,
+    dateAdded: 1000,
+    dateScanned: 1000,
+    updatedAt: 1000,
+  );
+
+  setUp(() {
+    mockRepo = MockMediaItemRepository();
+    useCase = EditItemMetadataUseCase(repository: mockRepo);
+    registerFallbackValue(original);
+    when(() => mockRepo.update(any())).thenAnswer((_) async {});
+  });
+
+  group('toMetadataResult', () {
+    test('maps an item into the form-initial shape', () {
+      final result = EditItemMetadataUseCase.toMetadataResult(original);
+
+      expect(result.barcode, original.barcode);
+      expect(result.barcodeType, original.barcodeType);
+      expect(result.mediaType, MediaType.music);
+      expect(result.title, 'Old Title');
+      expect(result.subtitle, 'Old Subtitle');
+      expect(result.year, 1999);
+      expect(result.publisher, 'Old Label');
+      expect(result.genres, ['Rock']);
+    });
+  });
+
+  group('execute', () {
+    test('applies edited fields and persists via repository.update',
+        () async {
+      const edited = MetadataResult(
+        barcode: '5099902894225',
+        barcodeType: 'ean13',
+        mediaType: MediaType.music,
+        title: 'New Title',
+        subtitle: 'New Subtitle',
+        year: 2001,
+        publisher: 'New Label',
+        genres: ['Rock', 'Indie'],
+      );
+
+      final updated = await useCase.execute(original, edited);
+
+      expect(updated.title, 'New Title');
+      expect(updated.subtitle, 'New Subtitle');
+      expect(updated.year, 2001);
+      expect(updated.publisher, 'New Label');
+      expect(updated.genres, ['Rock', 'Indie']);
+      verify(() => mockRepo.update(updated)).called(1);
+    });
+
+    test('user edits are authoritative — a cleared field clears the item',
+        () async {
+      // The form omits subtitle/description → they come through null and
+      // must clear the stored values (unlike refresh-from-API merging).
+      const edited = MetadataResult(
+        barcode: '5099902894225',
+        barcodeType: 'ean13',
+        mediaType: MediaType.music,
+        title: 'New Title',
+      );
+
+      final updated = await useCase.execute(original, edited);
+
+      expect(updated.subtitle, isNull);
+      expect(updated.description, isNull);
+      expect(updated.year, isNull);
+    });
+
+    test('preserves identity and user data, bumps updatedAt', () async {
+      const edited = MetadataResult(
+        barcode: '5099902894225',
+        barcodeType: 'ean13',
+        mediaType: MediaType.music,
+        title: 'New Title',
+      );
+
+      final updated = await useCase.execute(original, edited);
+
+      expect(updated.id, 'item-1');
+      expect(updated.barcode, original.barcode);
+      expect(updated.userRating, 4.5);
+      expect(updated.userReview, 'Loved it');
+      expect(updated.ownershipStatus, OwnershipStatus.owned);
+      expect(updated.dateAdded, 1000);
+      expect(updated.updatedAt, greaterThan(original.updatedAt));
+    });
+
+    test('falls back to the original title when the edit blanks it',
+        () async {
+      const edited = MetadataResult(
+        barcode: '5099902894225',
+        barcodeType: 'ean13',
+        mediaType: MediaType.music,
+      );
+
+      final updated = await useCase.execute(original, edited);
+
+      expect(updated.title, 'Old Title');
+    });
+  });
+}

--- a/test/unit/presentation/providers/batch_editor_provider_test.dart
+++ b/test/unit/presentation/providers/batch_editor_provider_test.dart
@@ -606,6 +606,66 @@ void main() {
       expect(state.isSaving, false);
       expect(state.savedCount, 2);
     });
+
+    test('saveAllConfirmed recovers when a save fails mid-loop', () async {
+      // Regression: a mid-loop failure left saveProgress set (isSaving
+      // stuck true forever) and never persisted the statuses of items
+      // already saved — so a restored session re-saved them as
+      // duplicates after a restart.
+      var saveCalls = 0;
+      when(() => mockRepo.save(any())).thenAnswer((_) async {
+        saveCalls++;
+        if (saveCalls == 2) throw Exception('db full');
+      });
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      await readState(container);
+      final notifier = container.read(batchEditorProvider.notifier);
+
+      const meta1 = MetadataResult(
+        barcode: '1111111111',
+        barcodeType: 'EAN-13',
+        title: 'Item 1',
+      );
+      const meta2 = MetadataResult(
+        barcode: '2222222222',
+        barcodeType: 'EAN-13',
+        title: 'Item 2',
+      );
+      await notifier.addScanResult(
+          const ScanResult.single(metadata: meta1, isDuplicate: false));
+      await notifier.addScanResult(
+          const ScanResult.single(metadata: meta2, isDuplicate: false));
+
+      // The failure must surface to the caller, not vanish.
+      await expectLater(notifier.saveAllConfirmed(), throwsException);
+
+      final state = await readState(container);
+      expect(state.isSaving, false,
+          reason: 'a failed bulk save must not leave the UI stuck saving');
+      expect(
+        state.items.firstWhere((i) => i.barcode == '1111111111').status,
+        BatchItemStatus.saved,
+        reason: 'the item saved before the failure keeps its saved status',
+      );
+      expect(
+        state.items.firstWhere((i) => i.barcode == '2222222222').status,
+        BatchItemStatus.confirmed,
+        reason: 'the failed item stays confirmed for a retry',
+      );
+
+      // The persisted queue must reflect the partial result so a restored
+      // session does not re-save the first item as a duplicate.
+      final persisted =
+          await testDb.batchSessionDao.getQueueItems(state.sessionId!);
+      final statuses = {
+        for (final row in persisted) row.barcode: row.status,
+      };
+      expect(statuses['1111111111'], BatchItemStatus.saved.name);
+      expect(statuses['2222222222'], BatchItemStatus.confirmed.name);
+    });
   });
 
   group('Concurrent mutation during saves', () {

--- a/test/unit/presentation/providers/batch_metadata_edit_provider_test.dart
+++ b/test/unit/presentation/providers/batch_metadata_edit_provider_test.dart
@@ -1,6 +1,17 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/core/utils/metaflac_writer.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
+import 'package:mymediascanner/domain/repositories/i_rip_library_repository.dart';
 import 'package:mymediascanner/presentation/providers/batch_metadata_edit_provider.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+
+class MockRipLibraryRepository extends Mock implements IRipLibraryRepository {}
+
+class MockMetaflacWriter extends Mock implements MetaflacWriter {}
 
 void main() {
   ProviderContainer makeContainer() {
@@ -76,6 +87,108 @@ void main() {
       expect(state.affectedTrackCount, 0);
       expect(state.affectedAlbumCount, 0);
       expect(state.error, isNull);
+    });
+  });
+
+  group('applyChanges / undoChanges track lookup', () {
+    // Regression: apply/undo built their track lookup with a synchronous
+    // `ref.read(ripTracksProvider(id)).value ?? []`, which is null for
+    // any album whose detail view was never opened — so tracks that
+    // exist in the DB and on disk were reported as "track no longer
+    // exists in the rip library" (apply) or silently skipped (undo).
+
+    late MockRipLibraryRepository mockRepo;
+    late MockMetaflacWriter mockWriter;
+
+    const album = RipAlbum(
+      id: 'album-1',
+      libraryPath: '/music',
+      trackCount: 1,
+      totalSizeBytes: 0,
+      lastScannedAt: 0,
+      updatedAt: 0,
+    );
+    const track = RipTrack(
+      id: 'track-1',
+      ripAlbumId: 'album-1',
+      trackNumber: 1,
+      filePath: '/music/a.flac',
+      fileSizeBytes: 0,
+      updatedAt: 0,
+    );
+
+    setUp(() {
+      mockRepo = MockRipLibraryRepository();
+      mockWriter = MockMetaflacWriter();
+      when(() => mockRepo.getAllNonDeleted())
+          .thenAnswer((_) async => const [album]);
+      when(() => mockRepo.getTracksForAlbum('album-1'))
+          .thenAnswer((_) async => const [track]);
+      when(() => mockWriter.setTags(any(), any())).thenAnswer((_) async {});
+    });
+
+    ProviderContainer makeOverriddenContainer() {
+      final container = ProviderContainer(
+        overrides: [
+          ripLibraryRepositoryProvider.overrideWithValue(mockRepo),
+          metaflacWriterProvider.overrideWithValue(mockWriter),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('applyChanges finds tracks whose providers were never resolved',
+        () async {
+      final container = makeOverriddenContainer();
+      final notifier = container.read(batchMetadataEditProvider.notifier);
+
+      notifier.prepareBatchEdit(
+        pendingChanges: {
+          'track-1': {'GENRE': 'Rock'},
+        },
+        originalValues: {
+          'track-1': {'GENRE': 'Pop'},
+        },
+        affectedTrackCount: 1,
+        affectedAlbumCount: 1,
+      );
+
+      // Deliberately no prior read of allRipAlbumsProvider /
+      // ripTracksProvider — as when the album detail was never opened.
+      await notifier.applyChanges();
+
+      final state = container.read(batchMetadataEditProvider);
+      expect(state.error, isNull);
+      expect(state.status, BatchEditStatus.applied);
+      verify(() => mockWriter.setTags('/music/a.flac', {'GENRE': 'Rock'}))
+          .called(1);
+    });
+
+    test('undoChanges finds tracks whose providers were never resolved',
+        () async {
+      final container = makeOverriddenContainer();
+      final notifier = container.read(batchMetadataEditProvider.notifier);
+
+      notifier.prepareBatchEdit(
+        pendingChanges: {
+          'track-1': {'GENRE': 'Rock'},
+        },
+        originalValues: {
+          'track-1': {'GENRE': 'Pop'},
+        },
+        affectedTrackCount: 1,
+        affectedAlbumCount: 1,
+      );
+
+      await notifier.undoChanges();
+
+      final state = container.read(batchMetadataEditProvider);
+      expect(state.error, isNull);
+      expect(state.status, BatchEditStatus.idle,
+          reason: 'a successful undo resets the editor');
+      verify(() => mockWriter.setTags('/music/a.flac', {'GENRE': 'Pop'}))
+          .called(1);
     });
   });
 }

--- a/test/unit/presentation/providers/disambiguation_provider_test.dart
+++ b/test/unit/presentation/providers/disambiguation_provider_test.dart
@@ -1,25 +1,143 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/metadata_candidate.dart';
+import 'package:mymediascanner/domain/entities/scan_result.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/domain/repositories/i_metadata_repository.dart';
+import 'package:mymediascanner/presentation/providers/disambiguation_provider.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/scanner_provider.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+
+class MockMediaItemRepository extends Mock implements IMediaItemRepository {}
+
+class MockMetadataRepository extends Mock implements IMetadataRepository {}
+
+class ApiKeysNotifierStub extends ApiKeysNotifier {
+  @override
+  Future<Map<String, String?>> build() async => <String, String?>{};
+}
 
 void main() {
-  group('DisambiguationNotifier logic', () {
-    test('candidate filtering removes selected candidate on null detail', () {
-      const candidates = [
-        MetadataCandidate(sourceApi: 'discogs', sourceId: '1', title: 'A'),
-        MetadataCandidate(sourceApi: 'discogs', sourceId: '2', title: 'B'),
-        MetadataCandidate(sourceApi: 'discogs', sourceId: '3', title: 'C'),
-      ];
+  late MockMediaItemRepository mockMediaItemRepo;
+  late MockMetadataRepository mockMetadataRepo;
 
-      final filtered = candidates
-          .where((c) => c != candidates.first)
-          .toList();
+  setUp(() {
+    mockMediaItemRepo = MockMediaItemRepository();
+    mockMetadataRepo = MockMetadataRepository();
 
-      expect(filtered.length, 2);
-      expect(filtered[0].sourceId, '2');
-      expect(filtered[1].sourceId, '3');
+    registerFallbackValue(const MetadataCandidate(
+      sourceApi: '',
+      sourceId: '',
+      title: '',
+    ));
+  });
+
+  ProviderContainer createContainer() {
+    return ProviderContainer(
+      overrides: [
+        mediaItemRepositoryProvider.overrideWithValue(mockMediaItemRepo),
+        metadataRepositoryProvider.overrideWithValue(mockMetadataRepo),
+        apiKeysProvider.overrideWith(() => ApiKeysNotifierStub()),
+      ],
+    );
+  }
+
+  ScanResult multiMatch(String barcode, List<String> titles) =>
+      ScanResult.multiMatch(
+        candidates: [
+          for (final (i, title) in titles.indexed)
+            MetadataCandidate(
+              sourceApi: 'discogs',
+              sourceId: '$barcode-$i',
+              title: title,
+            ),
+        ],
+        barcode: barcode,
+        barcodeType: 'ean13',
+      );
+
+  void stubScan(String barcode, ScanResult result) {
+    when(() => mockMediaItemRepo.barcodeExists(barcode))
+        .thenAnswer((_) async => false);
+    when(() => mockMetadataRepo.lookupBarcode(barcode, typeHint: null))
+        .thenAnswer((_) async => result);
+  }
+
+  group('DisambiguationNotifier', () {
+    test('shows the candidates of the current multi-match scan', () async {
+      const barcode = '5099902894225';
+      stubScan(barcode, multiMatch(barcode, ['Album A', 'Album B']));
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+      // Keep the provider alive and rebuilding, as the screen would.
+      container.listen(disambiguationProvider, (_, _) {});
+
+      await container.read(scannerProvider.notifier).onBarcodeScanned(barcode);
+
+      final data = container.read(disambiguationProvider);
+      expect(data.barcode, barcode);
+      expect(data.candidates.map((c) => c.title), ['Album A', 'Album B']);
     });
 
+    test('shows fresh candidates for each subsequent multi-match scan',
+        () async {
+      // Regression: the notifier snapshotted the scan result with
+      // `ref.read` in a non-autoDispose `build()`, which runs once per
+      // app lifetime — so every multi-match scan after the first showed
+      // the FIRST scan's candidates and barcode.
+      const firstBarcode = '5099902894225';
+      const secondBarcode = '0602567749455';
+      stubScan(firstBarcode, multiMatch(firstBarcode, ['Album A', 'Album B']));
+      stubScan(
+          secondBarcode, multiMatch(secondBarcode, ['Film X', 'Film Y']));
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+      container.listen(disambiguationProvider, (_, _) {});
+
+      final scanner = container.read(scannerProvider.notifier);
+
+      await scanner.onBarcodeScanned(firstBarcode);
+      expect(container.read(disambiguationProvider).barcode, firstBarcode);
+
+      // User backs out and scans something else.
+      scanner.reset();
+      await scanner.onBarcodeScanned(secondBarcode);
+
+      final data = container.read(disambiguationProvider);
+      expect(data.barcode, secondBarcode);
+      expect(data.candidates.map((c) => c.title), ['Film X', 'Film Y']);
+    });
+
+    test('candidate removal on null detail survives within one scan',
+        () async {
+      const barcode = '5099902894225';
+      stubScan(barcode, multiMatch(barcode, ['Album A', 'Album B']));
+      when(() => mockMetadataRepo.fetchCandidateDetail(any(), barcode, 'ean13'))
+          .thenAnswer((_) async => null);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+      container.listen(disambiguationProvider, (_, _) {});
+
+      await container.read(scannerProvider.notifier).onBarcodeScanned(barcode);
+
+      final notifier = container.read(disambiguationProvider.notifier);
+      final first = container.read(disambiguationProvider).candidates.first;
+      final detail = await notifier.selectCandidate(first);
+
+      expect(detail, isNull);
+      expect(container.read(disambiguationProvider).candidates.map((c) => c.title),
+          ['Album B'],
+          reason: 'a failed candidate is removed from the list');
+    });
+  });
+
+  group('DisambiguationNotifier logic', () {
     test('MetadataCandidate equality works for filtering', () {
       const a = MetadataCandidate(
         sourceApi: 'discogs',
@@ -36,18 +154,6 @@ void main() {
 
       expect(a == b, isTrue);
       expect([a, b].where((c) => c != a).isEmpty, isTrue);
-    });
-
-    test('empty candidate list remains empty after filtering', () {
-      const List<MetadataCandidate> candidates = [];
-      const target = MetadataCandidate(
-        sourceApi: 'discogs',
-        sourceId: '1',
-        title: 'A',
-      );
-
-      final filtered = candidates.where((c) => c != target).toList();
-      expect(filtered, isEmpty);
     });
   });
 }

--- a/test/widget/presentation/screens/item_detail/edit_item_screen_test.dart
+++ b/test/widget/presentation/screens/item_detail/edit_item_screen_test.dart
@@ -1,0 +1,128 @@
+// Widget tests for EditItemScreen.
+//
+// Covers:
+//   1. The form is pre-populated with the item's current values.
+//   2. Saving applies the edits via repository.update and pops back.
+//   3. A missing item shows the error state instead of a form.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/screens/item_detail/edit_item_screen.dart';
+
+class _MockMediaItemRepository extends Mock implements IMediaItemRepository {}
+
+const _kItemId = 'item-1';
+
+const _item = MediaItem(
+  id: _kItemId,
+  barcode: '5099902894225',
+  barcodeType: 'ean13',
+  mediaType: MediaType.music,
+  title: 'Original Title',
+  subtitle: 'Original Subtitle',
+  publisher: 'Original Label',
+  userRating: 4.0,
+  ownershipStatus: OwnershipStatus.owned,
+  dateAdded: 1000,
+  dateScanned: 1000,
+  updatedAt: 1000,
+);
+
+Widget _wrap(IMediaItemRepository repo) {
+  final router = GoRouter(
+    initialLocation: '/collection/item/$_kItemId/edit',
+    routes: [
+      GoRoute(
+        path: '/collection/item/:id',
+        builder: (_, state) =>
+            Scaffold(body: Text('detail:${state.pathParameters['id']}')),
+        routes: [
+          GoRoute(
+            path: 'edit',
+            builder: (_, state) => EditItemScreen(
+              itemId: state.pathParameters['id']!,
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      mediaItemRepositoryProvider.overrideWithValue(repo),
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+void main() {
+  late _MockMediaItemRepository repo;
+
+  setUp(() {
+    repo = _MockMediaItemRepository();
+    registerFallbackValue(_item);
+    when(() => repo.getById(_kItemId)).thenAnswer((_) async => _item);
+    when(() => repo.update(any())).thenAnswer((_) async {});
+  });
+
+  testWidgets('pre-populates the form with the item values', (tester) async {
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Edit Item'), findsOneWidget);
+    expect(find.text('Original Title'), findsOneWidget);
+    expect(find.text('Original Subtitle'), findsOneWidget);
+    expect(find.text('Original Label'), findsOneWidget);
+  });
+
+  testWidgets('saving persists the edits and pops back to detail',
+      (tester) async {
+    // Tall viewport so the save button at the foot of the form is
+    // on-screen and tappable.
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'Original Title'), 'Edited Title');
+    await tester.tap(find.text('Save Changes'));
+    await tester.pumpAndSettle();
+
+    final updated = verify(() => repo.update(captureAny())).captured.single
+        as MediaItem;
+    expect(updated.id, _kItemId);
+    expect(updated.title, 'Edited Title');
+    expect(updated.userRating, 4.0,
+        reason: 'user data must survive a metadata edit');
+    expect(updated.updatedAt, greaterThan(1000));
+
+    expect(find.text('detail:$_kItemId'), findsOneWidget,
+        reason: 'save pops back to the detail route');
+  });
+
+  testWidgets('shows error state when the item does not exist',
+      (tester) async {
+    when(() => repo.getById(_kItemId)).thenAnswer((_) async => null);
+
+    await tester.pumpWidget(_wrap(repo));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Item not found'), findsOneWidget);
+    expect(find.text('Save Changes'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary

Addresses the high-severity findings from the scan, plus two related features that the fixes unblocked.

### Fixes
- **sync:** strip server-managed columns from pulled rows before merge, preventing them clobbering local state
- **scanner:** rebuild disambiguation candidates on each new scan (stale candidates leaked between scans)
- **scanner:** hand out a fresh camera service per webcam session (avoids reusing a disposed service)
- **batch:** recover from mid-loop failure in bulk save instead of aborting the whole batch
- **rips:** query the repository for tracks in batch metadata apply/undo

### Features
- **sync:** replicate tag assignments and shelf memberships across the join tables
- **collection:** wire the item edit route to a real edit screen (new `EditItemScreen` + `EditItemMetadataUseCase`)

### Schema / migrations
- New DB migration (schema bump) and a new sync SQL migration `007_join_table_sync.sql` for the join-table replication.

## Test plan
- `flutter test` (unit/widget suite) — substantial new coverage added across sync repository, batch providers, disambiguation, the edit-item usecase/screen, and a DB migration test.

Stats: 7 commits, +2119/-138 across 42 files.