### PR TITLE
fix: guard TMDB account-sync StateError and add desktop back/cancel affordances

### DIFF
--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -210,7 +210,18 @@ class ApiKeysNotifier extends AsyncNotifier<Map<String, String?>> {
     ref.invalidateSelf();
   }
 
-  Future<void> setTmdbKey(String key) => _writeOrDelete(_tmdbKey, key);
+  Future<void> setTmdbKey(String key) async {
+    await _writeOrDelete(_tmdbKey, key);
+    // Clearing the TMDB key makes account sync impossible (the repository
+    // throws without a token). Disable it at the source so dependent
+    // scan/save paths and the desktop sidebar can't be left pointing at an
+    // unavailable repository while the `enabled` flag stays true.
+    if (key.trim().isEmpty) {
+      await ref
+          .read(tmdbAccountSyncSettingsProvider.notifier)
+          .disableForMissingKey();
+    }
+  }
 
   Future<void> setDiscogsKey(String key) => _writeOrDelete(_discogsKey, key);
 
@@ -376,6 +387,13 @@ class TmdbAccountSyncSettingsNotifier
     final p = await _instance;
     await p.setBool(_kEnabled, v);
   }
+
+  /// Disables account sync because the TMDB API key was removed. Without
+  /// a key every account-sync repository call throws, so `enabled` — the
+  /// master gate every scan/save/detail consumer checks — must be cleared
+  /// to keep those paths from reaching the unavailable repository. Called
+  /// from [ApiKeysNotifier.setTmdbKey] when the key is cleared.
+  Future<void> disableForMissingKey() => setEnabled(false);
 
   Future<void> setEnrichScans(bool v) async {
     state = state.copyWith(enrichScans: v);

--- a/lib/presentation/screens/collection/collection_screen.dart
+++ b/lib/presentation/screens/collection/collection_screen.dart
@@ -300,6 +300,10 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
         content: const Text('Choose a format to export your collection.'),
         actions: [
           TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
             onPressed: () {
               Navigator.of(dialogContext).pop();
               _exportCollection(context, ref, ExportFormat.csv);

--- a/lib/presentation/screens/export/static_export_screen.dart
+++ b/lib/presentation/screens/export/static_export_screen.dart
@@ -54,7 +54,14 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (isDesktop)
+            if (isDesktop) ...[
+              // This screen is pushed on the root navigator, so there is no
+              // sidebar and no AppBar on desktop — provide an explicit back
+              // affordance (mobile gets one from the AppBar).
+              const Align(
+                alignment: Alignment.centerLeft,
+                child: BackButton(),
+              ),
               const ScreenHeader(
                 title: 'Export collection',
                 subtitle:
@@ -62,6 +69,7 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
                     'searchable grid and per-item pages. Private items '
                     '(tagged) are excluded.',
               ),
+            ],
             const SizedBox(height: 8),
             ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 560),

--- a/lib/presentation/screens/import/import_screen.dart
+++ b/lib/presentation/screens/import/import_screen.dart
@@ -41,13 +41,21 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              if (isDesktop)
+              if (isDesktop) ...[
+                // Pushed on the root navigator, so there is no sidebar or
+                // AppBar on desktop — provide an explicit back affordance
+                // (mobile gets one from the AppBar).
+                const Align(
+                  alignment: Alignment.centerLeft,
+                  child: BackButton(),
+                ),
                 const ScreenHeader(
                   title: 'Import collection',
                   subtitle:
                       'Bulk-import items from a Goodreads, Discogs, '
                       'Letterboxd or Trakt export.',
                 ),
+              ],
               Expanded(child: _buildBody(state)),
             ],
           ),

--- a/lib/presentation/screens/labels/label_print_screen.dart
+++ b/lib/presentation/screens/labels/label_print_screen.dart
@@ -44,13 +44,21 @@ class _LabelPrintScreenState extends ConsumerState<LabelPrintScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (isDesktop)
+            if (isDesktop) ...[
+              // Pushed on the root navigator, so there is no sidebar or
+              // AppBar on desktop — provide an explicit back affordance
+              // (mobile gets one from the AppBar).
+              const Align(
+                alignment: Alignment.centerLeft,
+                child: BackButton(),
+              ),
               const ScreenHeader(
                 title: 'Print labels',
                 subtitle:
                     'Generate a printable sheet of QR labels for your '
                     'locations or items.',
               ),
+            ],
             _Toolbar(
               source: _source,
               preset: _preset,

--- a/lib/presentation/screens/metadata_confirm/metadata_confirm_screen.dart
+++ b/lib/presentation/screens/metadata_confirm/metadata_confirm_screen.dart
@@ -44,9 +44,17 @@ class _MetadataConfirmScreenState extends ConsumerState<MetadataConfirmScreen> {
       final tmdbId = _resolveTmdbId();
       final mediaType = _resolveApiMediaType();
       if (tmdbId != null && TmdbMediaType.isTmdbMovieOrTv(mediaType)) {
-        ref
-            .read(enrichScanWithTmdbAccountUseCaseProvider)
-            .call(tmdbId: tmdbId, mediaType: mediaType!);
+        // Fire-and-forget enrichment. Guard the read because
+        // enrichScanWithTmdbAccountUseCaseProvider throws if the TMDB API
+        // key was removed while account sync stayed enabled — a missing
+        // key should silently skip enrichment, not crash the scan confirm.
+        try {
+          ref
+              .read(enrichScanWithTmdbAccountUseCaseProvider)
+              .call(tmdbId: tmdbId, mediaType: mediaType!);
+        } catch (_) {
+          // No-op — enrichment is best-effort.
+        }
       }
     });
   }

--- a/lib/presentation/widgets/app_scaffold.dart
+++ b/lib/presentation/widgets/app_scaffold.dart
@@ -280,26 +280,37 @@ class _DesktopSidebar extends ConsumerWidget {
     final colors = theme.colorScheme;
     final design = theme.extension<AppDesignExtension>();
 
-    final connectionAsync = ref.watch(tmdbAccountConnectionProvider);
-    final isTmdbConnected =
+    // Short-circuit when no TMDB token is configured — watching the
+    // account-sync providers in that state surfaces the
+    // `StateError: TMDB API key not configured` from
+    // `tmdbAccountSyncRepositoryProvider`. Mirrors the guard used by the
+    // settings sections.
+    final tmdbKey = (ref.watch(apiKeysProvider).value ?? {})['tmdb'] ?? '';
+    final hasTmdbKey = tmdbKey.trim().isNotEmpty;
+
+    final isTmdbConnected = hasTmdbKey &&
         PlatformCapability.isDesktop &&
-        connectionAsync.value is TmdbConnected;
+        ref.watch(tmdbAccountConnectionProvider).value is TmdbConnected;
 
     final settings = ref.watch(tmdbAccountSyncSettingsProvider);
-    final conflictsCount = ref.watch(tmdbConflictedRowsProvider).maybeWhen(
-          data: (rows) => rows.length,
-          orElse: () => 0,
-        );
+    final conflictsCount = hasTmdbKey
+        ? ref.watch(tmdbConflictedRowsProvider).maybeWhen(
+              data: (rows) => rows.length,
+              orElse: () => 0,
+            )
+        : 0;
     final showConflicts = isTmdbConnected &&
         settings.conflictPolicy == TmdbConflictPolicy.askUser &&
         conflictsCount > 0;
 
-    final savedCount = ref
-        .watch(tmdbBridgeBucketProvider(TmdbBridgeBucket.saved))
-        .maybeWhen(
-          data: (rows) => rows.length,
-          orElse: () => 0,
-        );
+    final savedCount = hasTmdbKey
+        ? ref
+            .watch(tmdbBridgeBucketProvider(TmdbBridgeBucket.saved))
+            .maybeWhen(
+              data: (rows) => rows.length,
+              orElse: () => 0,
+            )
+        : 0;
 
     // Build label with count so the user can see how many need resolving.
     final conflictsItem = _SidebarDestination(

--- a/test/unit/presentation/providers/settings_provider_test.dart
+++ b/test/unit/presentation/providers/settings_provider_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/presentation/providers/settings_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+ProviderContainer _makeContainer(MockFlutterSecureStorage storage) {
+  final container = ProviderContainer(
+    overrides: [secureStorageProvider.overrideWithValue(storage)],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  MockFlutterSecureStorage stubbedStorage() {
+    final storage = MockFlutterSecureStorage();
+    when(() => storage.read(key: any(named: 'key')))
+        .thenAnswer((_) async => null);
+    when(() => storage.write(
+            key: any(named: 'key'), value: any(named: 'value')))
+        .thenAnswer((_) async {});
+    when(() => storage.delete(key: any(named: 'key')))
+        .thenAnswer((_) async {});
+    return storage;
+  }
+
+  group('ApiKeysNotifier.setTmdbKey clears dependent account sync', () {
+    test('clearing the TMDB key disables account sync', () async {
+      final storage = stubbedStorage();
+      final container = _makeContainer(storage);
+
+      // Enable account sync (as if the user had connected with a key).
+      await container
+          .read(tmdbAccountSyncSettingsProvider.notifier)
+          .setEnabled(true);
+      expect(
+          container.read(tmdbAccountSyncSettingsProvider).enabled, isTrue);
+
+      // Clearing the key must disable account sync so dependent scan/save
+      // paths and the sidebar never reach the now-unavailable repository.
+      await container.read(apiKeysProvider.notifier).setTmdbKey('');
+
+      expect(
+          container.read(tmdbAccountSyncSettingsProvider).enabled, isFalse);
+      verify(() => storage.delete(key: 'api_key_tmdb')).called(1);
+    });
+
+    test('whitespace-only key is treated as cleared and disables sync',
+        () async {
+      final storage = stubbedStorage();
+      final container = _makeContainer(storage);
+
+      await container
+          .read(tmdbAccountSyncSettingsProvider.notifier)
+          .setEnabled(true);
+
+      await container.read(apiKeysProvider.notifier).setTmdbKey('   ');
+
+      expect(
+          container.read(tmdbAccountSyncSettingsProvider).enabled, isFalse);
+    });
+
+    test('setting a non-empty key leaves account sync untouched', () async {
+      final storage = stubbedStorage();
+      final container = _makeContainer(storage);
+
+      await container
+          .read(tmdbAccountSyncSettingsProvider.notifier)
+          .setEnabled(true);
+
+      await container
+          .read(apiKeysProvider.notifier)
+          .setTmdbKey('abc123token');
+
+      expect(
+          container.read(tmdbAccountSyncSettingsProvider).enabled, isTrue);
+      verify(() => storage.write(key: 'api_key_tmdb', value: 'abc123token'))
+          .called(1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Two related robustness/UX fixes uncovered while investigating a `StateError` thrown from the TMDB settings section.

### TMDB account-sync `StateError` safeguards
`tmdbAccountSyncRepositoryProvider` deliberately throws `StateError` when no TMDB key is configured, and consumers are expected to guard on the key first. A few paths did not:

- **Desktop sidebar** (`app_scaffold`) watched the account-sync providers unconditionally, surfacing the `StateError` whenever no key was set. Now short-circuits when the key is absent, mirroring the settings sections' guard.
- **Post-scan enrich** (`metadata_confirm`) read the enrich use case as a fire-and-forget side effect with no `try/catch`; now wrapped so a missing key silently skips enrichment.
- **Source-level fix:** clearing the TMDB key now disables account sync (`ApiKeysNotifier.setTmdbKey` → `disableForMissingKey`), so the master `enabled` gate can't stay `true` without a key. Closes the "flag true but no key" edge case at its root.

Adds `settings_provider_test` covering the clear / whitespace / non-empty key cases (TDD red→green).

### Export / navigation back affordances
- **Export Collection dialog** offered only CSV/JSON with no way to dismiss — added a **Cancel** action.
- **Static export, Import, and Print-labels screens** are pushed on the root navigator and render a `ScreenHeader` (no AppBar) on desktop, leaving no visible way back. Added a desktop **BackButton** to each (mobile already gets one from its AppBar).

## Testing
- `flutter analyze` clean on all touched files
- New `settings_provider_test` (3 tests) pass
- Existing settings / collection / manual-add / import / label-print widget tests pass