### PR TITLE
fix: resolve mobile testing findings (cache poisoning, scanner, label wrapping)

### DIFF
--- a/lib/data/repositories/metadata_repository_impl.dart
+++ b/lib/data/repositories/metadata_repository_impl.dart
@@ -110,7 +110,7 @@ class MetadataRepositoryImpl implements IMetadataRepository {
 
     // 1. Check cache. Cached rows hold the pre-enrichment API response,
     // so re-apply enrichment for parity with fresh lookups.
-    final cached = await _checkCache(barcode);
+    final cached = await _checkCache(barcode, forceIsbn: forceIsbn);
     if (cached is SingleScanResult) {
       final enriched = await _enrichMetadata(cached.metadata);
       return ScanResult.single(
@@ -777,13 +777,58 @@ class MetadataRepositoryImpl implements IMetadataRepository {
 
   // -- Cache --
 
-  Future<ScanResult?> _checkCache(String barcode) async {
+  /// Source APIs whose results describe a book. An ISBN barcode must only
+  /// be served from one of these (or the universal UPCitemdb fallback).
+  static const _bookSources = {'google_books', 'open_library'};
+
+  /// Source APIs whose results describe a film or TV title. An IMDb ID must
+  /// only be served from one of these (or the universal UPCitemdb fallback).
+  static const _screenSources = {'tmdb', 'tvdb'};
+
+  /// Whether a cached [sourceApi] is consistent with what the barcode's own
+  /// structure demands. Prevents a poisoned row (e.g. an ISBN once cached as
+  /// `musicbrainz` while the Music chip was active) from being replayed for
+  /// every later lookup, ahead of the correct type routing.
+  ///
+  /// UPCitemdb is the universal classifier fallback and is always accepted;
+  /// only structurally-constrained barcodes (ISBN, IMDb ID) reject
+  /// mismatched specialists. EAN/UPC codes carry no such constraint.
+  bool _isCacheSourceCompatible(
+    String barcode,
+    String sourceApi, {
+    required bool forceIsbn,
+  }) {
+    if (sourceApi == 'upcitemdb') return true;
+    if (forceIsbn || BarcodeUtils.isIsbn(barcode)) {
+      return _bookSources.contains(sourceApi);
+    }
+    if (BarcodeUtils.isImdbId(barcode)) {
+      return _screenSources.contains(sourceApi);
+    }
+    return true;
+  }
+
+  Future<ScanResult?> _checkCache(
+    String barcode, {
+    bool forceIsbn = false,
+  }) async {
     final cached = await _cacheDao.getByBarcode(barcode);
     if (cached == null) return null;
 
     final age = DateTime.now().millisecondsSinceEpoch - cached.cachedAt;
     const maxAge = ApiConstants.cacheDurationDays * 24 * 60 * 60 * 1000;
     if (age > maxAge) return null;
+
+    // Reject a cached entry whose source contradicts the barcode's own
+    // structure (poisoned row) and evict it so it stops short-circuiting
+    // the correct type routing on every subsequent lookup.
+    if (!_isCacheSourceCompatible(barcode, cached.sourceApi,
+        forceIsbn: forceIsbn)) {
+      try {
+        await _cacheDao.deleteByBarcode(barcode);
+      } catch (_) {}
+      return null;
+    }
 
     // Re-map through the original mapper for full fidelity
     try {

--- a/lib/presentation/screens/collection/widgets/time_period_selector.dart
+++ b/lib/presentation/screens/collection/widgets/time_period_selector.dart
@@ -67,7 +67,14 @@ class TimePeriodSelector extends ConsumerWidget {
             segments: TimePeriod.values.map((period) {
               return ButtonSegment<TimePeriod>(
                 value: period,
-                label: Text(period.label),
+                // Cap to one line so a narrow segment truncates cleanly
+                // instead of breaking "12 months" mid-word across three
+                // lines (#98).
+                label: Text(
+                  period.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               );
             }).toList(),
             selected: {selected},

--- a/lib/presentation/screens/collection/widgets/time_period_selector.dart
+++ b/lib/presentation/screens/collection/widgets/time_period_selector.dart
@@ -67,13 +67,17 @@ class TimePeriodSelector extends ConsumerWidget {
             segments: TimePeriod.values.map((period) {
               return ButtonSegment<TimePeriod>(
                 value: period,
-                // Cap to one line so a narrow segment truncates cleanly
-                // instead of breaking "12 months" mid-word across three
-                // lines (#98).
-                label: Text(
-                  period.label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                // Scale the label down to fit a narrow segment so the full
+                // text stays readable — "12 months" shrinks rather than
+                // breaking mid-word across three lines or truncating to
+                // "1…" (#98).
+                label: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  child: Text(
+                    period.label,
+                    maxLines: 1,
+                    softWrap: false,
+                  ),
                 ),
               );
             }).toList(),

--- a/lib/presentation/screens/scanner/mobile_scan_screen.dart
+++ b/lib/presentation/screens/scanner/mobile_scan_screen.dart
@@ -25,6 +25,21 @@ import 'package:mymediascanner/core/utils/cover_ocr_helper.dart';
 import 'package:mymediascanner/core/utils/platform_utils.dart';
 import 'package:mymediascanner/domain/entities/scan_result.dart';
 
+/// Whether a camera barcode detection should be acted on.
+///
+/// Guards two failure modes: a scan already in flight ([hasScanned]), and
+/// the live preview continuing to stream **underneath** a dialog or pushed
+/// route ([routeIsCurrent] is false) — e.g. the manual-entry dialog, the
+/// confirm, disambiguation, or not-found screen. Without the route check the
+/// camera silently processes real-world barcodes in the background and can
+/// persist unconfirmed items (issue #97).
+@visibleForTesting
+bool shouldProcessCameraDetection({
+  required bool hasScanned,
+  required bool routeIsCurrent,
+}) =>
+    !hasScanned && routeIsCurrent;
+
 /// Full-screen mobile camera barcode scanner.
 class MobileScanScreen extends ConsumerStatefulWidget {
   const MobileScanScreen({super.key});
@@ -103,7 +118,18 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen>
   }
 
   Future<void> _onBarcodeDetected(BarcodeCapture capture) async {
-    if (_hasScanned) return;
+    if (!mounted) return;
+    // Ignore detections while a scan is in flight or a dialog/pushed route
+    // covers the scanner. The live preview keeps streaming underneath the
+    // manual-entry dialog and the confirm/disambiguate/not-found screens, so
+    // without this guard the camera silently processes real-world barcodes
+    // and can persist unconfirmed items (issue #97).
+    if (!shouldProcessCameraDetection(
+      hasScanned: _hasScanned,
+      routeIsCurrent: ModalRoute.of(context)?.isCurrent ?? true,
+    )) {
+      return;
+    }
 
     final barcodes = capture.barcodes;
     if (barcodes.isEmpty) return;
@@ -160,16 +186,31 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen>
   }
 
   void _showManualEntryDialog() {
+    // Pause the live camera while the dialog is up so it can't scan a
+    // real-world barcode in the background behind the text field (#97).
+    var submitted = false;
+    unawaited(_cameraController.stop());
     showDialog<void>(
       context: context,
       builder: (_) => ManualBarcodeEntryDialog(
         onSubmit: (value) {
+          submitted = true;
           _hasScanned = true;
           _cameraController.stop();
           ref.read(scannerProvider.notifier).onBarcodeScanned(value);
         },
       ),
-    );
+    ).then((_) {
+      // Dismissed without submitting — resume the live camera only if the
+      // scanner is still the active surface and no scan is in flight.
+      if (!submitted &&
+          mounted &&
+          !_externalScannerMode &&
+          !_hasScanned &&
+          (ModalRoute.of(context)?.isCurrent ?? true)) {
+        unawaited(_cameraController.start());
+      }
+    });
   }
 
   void _showDuplicateDialog() {

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -589,9 +589,17 @@ class _ThemeModeTile extends ConsumerWidget {
         };
 
     return ListTile(
+      // Drop the default 16dp side padding (matching the ReplayGain tiles
+      // below) so the three-segment brightness control doesn't starve the
+      // title column and force "Theme" to wrap character-by-character (#98).
+      contentPadding: EdgeInsets.zero,
       leading: Icon(icon(currentBrightness)),
-      title: const Text('Theme'),
-      subtitle: Text(label(currentBrightness)),
+      title: const Text('Theme', maxLines: 1, overflow: TextOverflow.ellipsis),
+      subtitle: Text(
+        label(currentBrightness),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
       trailing: SegmentedButton<ThemeBrightness>(
         segments: const [
           ButtonSegment(

--- a/test/unit/data/repositories/metadata_repository_impl_test.dart
+++ b/test/unit/data/repositories/metadata_repository_impl_test.dart
@@ -1346,4 +1346,106 @@ void main() {
       },
     );
   });
+
+  group('lookupBarcode — cache poisoning guard (#96)', () {
+    const isbn = '9780747532699';
+    late MockBarcodeCacheDao mockCache;
+    late MockGoogleBooksApi mockGoogleBooksApi;
+
+    setUp(() {
+      mockCache = MockBarcodeCacheDao();
+      mockGoogleBooksApi = MockGoogleBooksApi();
+      when(() => mockCache.upsert(any())).thenAnswer((_) async {});
+      when(() => mockCache.deleteByBarcode(any())).thenAnswer((_) async {});
+    });
+
+    BarcodeCacheTableData musicCachedFor(String barcode) => BarcodeCacheTableData(
+      barcode: barcode,
+      responseJson: jsonEncode(
+        const MusicBrainzReleaseDto(id: 'mb-x', title: 'Hard at Play').toJson(),
+      ),
+      sourceApi: 'musicbrainz',
+      cachedAt: DateTime.now().millisecondsSinceEpoch,
+    );
+
+    test(
+      'ignores a music-cached entry for an ISBN barcode and routes to book '
+      'lookup',
+      () async {
+        when(
+          () => mockCache.getByBarcode(any()),
+        ).thenAnswer((_) async => musicCachedFor(isbn));
+        when(() => mockGoogleBooksApi.searchByIsbn('isbn:$isbn')).thenAnswer(
+          (_) async => const GoogleBooksSearchResponseDto(
+            totalItems: 1,
+            items: [
+              GoogleBooksVolumeDto(
+                id: 'gb-1',
+                volumeInfo: GoogleBooksVolumeInfoDto(
+                  title: 'Harry Potter and the Philosopher\'s Stone',
+                  authors: ['J. K. Rowling'],
+                ),
+              ),
+            ],
+          ),
+        );
+
+        final repo = MetadataRepositoryImpl(
+          cacheDao: mockCache,
+          googleBooksApi: mockGoogleBooksApi,
+        );
+
+        final result = await repo.lookupBarcode(isbn);
+
+        expect(result, isA<SingleScanResult>());
+        final single = result as SingleScanResult;
+        expect(single.metadata.mediaType, MediaType.book);
+        expect(
+          single.metadata.title,
+          'Harry Potter and the Philosopher\'s Stone',
+        );
+        expect(single.metadata.sourceApis, contains('google_books'));
+      },
+    );
+
+    test(
+      'evicts the mismatched cache row so it stops poisoning future lookups',
+      () async {
+        when(
+          () => mockCache.getByBarcode(any()),
+        ).thenAnswer((_) async => musicCachedFor(isbn));
+        when(() => mockGoogleBooksApi.searchByIsbn('isbn:$isbn')).thenAnswer(
+          (_) async =>
+              const GoogleBooksSearchResponseDto(totalItems: 0, items: []),
+        );
+
+        final repo = MetadataRepositoryImpl(
+          cacheDao: mockCache,
+          googleBooksApi: mockGoogleBooksApi,
+        );
+
+        await repo.lookupBarcode(isbn);
+
+        verify(() => mockCache.deleteByBarcode(any())).called(1);
+      },
+    );
+
+    test(
+      'still serves a compatible music cache entry for an EAN barcode',
+      () async {
+        const ean = '602498746400';
+        final repo = MetadataRepositoryImpl(cacheDao: mockCache);
+        when(
+          () => mockCache.getByBarcode(any()),
+        ).thenAnswer((_) async => musicCachedFor(ean));
+
+        final result = await repo.lookupBarcode(ean, typeHint: MediaType.music);
+
+        expect(result, isA<SingleScanResult>());
+        final single = result as SingleScanResult;
+        expect(single.metadata.title, 'Hard at Play');
+        verifyNever(() => mockCache.deleteByBarcode(any()));
+      },
+    );
+  });
 }

--- a/test/unit/presentation/screens/scanner/mobile_scan_detection_guard_test.dart
+++ b/test/unit/presentation/screens/scanner/mobile_scan_detection_guard_test.dart
@@ -1,0 +1,39 @@
+// Tests for the camera detection guard that prevents the live preview from
+// silently processing real-world barcodes while a dialog or pushed route
+// (manual entry, confirm, disambiguation, not-found) covers the scanner.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/screens/scanner/mobile_scan_screen.dart';
+
+void main() {
+  group('shouldProcessCameraDetection', () {
+    test('processes a detection when the idle scanner is the current route', () {
+      expect(
+        shouldProcessCameraDetection(hasScanned: false, routeIsCurrent: true),
+        isTrue,
+      );
+    });
+
+    test('ignores a detection while a scan is already in flight', () {
+      expect(
+        shouldProcessCameraDetection(hasScanned: true, routeIsCurrent: true),
+        isFalse,
+      );
+    });
+
+    test(
+      'ignores a detection while a dialog or pushed route covers the scanner',
+      () {
+        expect(
+          shouldProcessCameraDetection(
+            hasScanned: false,
+            routeIsCurrent: false,
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+}

--- a/test/widget/presentation/screens/collection/widgets/time_period_selector_test.dart
+++ b/test/widget/presentation/screens/collection/widgets/time_period_selector_test.dart
@@ -1,0 +1,41 @@
+// Widget tests for [TimePeriodSelector].
+//
+// Guards against the label-wrapping regression where "12 months" broke
+// character-by-character across three lines inside its segmented-button cell
+// on a narrow screen (issue #98).
+//
+// Author: Paul Snow
+// Since: 0.0.0
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/screens/collection/widgets/time_period_selector.dart';
+
+void main() {
+  testWidgets(
+    'time-period labels never wrap onto multiple lines on a narrow screen',
+    (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(width: 320, child: TimePeriodSelector()),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      for (final period in TimePeriod.values) {
+        final label = tester.widget<Text>(find.text(period.label));
+        expect(
+          label.maxLines,
+          1,
+          reason: '"${period.label}" must be capped to a single line',
+        );
+      }
+      // No layout overflow should be logged while rendering constrained.
+      expect(tester.takeException(), isNull);
+    },
+  );
+}

--- a/test/widget/presentation/screens/collection/widgets/time_period_selector_test.dart
+++ b/test/widget/presentation/screens/collection/widgets/time_period_selector_test.dart
@@ -27,11 +27,24 @@ void main() {
       await tester.pumpAndSettle();
 
       for (final period in TimePeriod.values) {
-        final label = tester.widget<Text>(find.text(period.label));
+        final labelFinder = find.text(period.label);
+        final label = tester.widget<Text>(labelFinder);
         expect(
           label.maxLines,
           1,
           reason: '"${period.label}" must be capped to a single line',
+        );
+        // Each label scales down to fit its segment so the full text stays
+        // readable ("12 months" shrinks instead of truncating to "1…").
+        expect(
+          find.ancestor(
+            of: labelFinder,
+            matching: find.byWidgetPredicate(
+              (w) => w is FittedBox && w.fit == BoxFit.scaleDown,
+            ),
+          ),
+          findsOneWidget,
+          reason: '"${period.label}" should scale down, not ellipsise',
         );
       }
       // No layout overflow should be logged while rendering constrained.

--- a/test/widget/presentation/screens/settings/settings_screen_test.dart
+++ b/test/widget/presentation/screens/settings/settings_screen_test.dart
@@ -318,6 +318,21 @@ void main() {
     expect(capturedFamilies, contains(ThemeFamily.cobalt));
   });
 
+  testWidgets('Theme tile title stays on a single line (#98)', (tester) async {
+    await tester.pumpWidget(_buildSettings());
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byType(SegmentedButton<ThemeBrightness>),
+      200,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+
+    final title = tester.widget<Text>(find.text('Theme'));
+    expect(title.maxLines, 1);
+  });
+
   // -------------------------------------------------------------------------
   // Test 4 — sync section shows not-configured state when no postgres config
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Fixes found during on-device (Android) testing of the scanner, settings, and insights flows. All changes are test-driven; `flutter analyze` is clean and the full suite (1681 tests) passes. Fixes #96–#98 and #99 were also confirmed on a physical device after a fresh dev-flavour install.

## Fixes

- **#96 — barcode cache poisoning.** `_checkCache` now rejects and evicts a cached row whose source contradicts the barcode's structure (e.g. an ISBN once cached as `musicbrainz`), so a poisoned entry no longer short-circuits the correct type routing on every subsequent lookup.
- **#97 — camera scanning behind dialogs.** Detections are ignored while a dialog or pushed route covers the live preview, and the camera is paused while the manual-entry dialog is open — preventing silent, unconfirmed saves from background scans.
- **#98 — label wrapping.** The "Theme" settings tile and the Insights time-period segment labels are capped to a single line; time-period labels scale down to fit so "12 months" stays fully readable instead of breaking mid-word or truncating.
- **#99 — palette picker.** Verified all five palette families (Classic, Popcorn, Kinetic, Vault, Index) render and select via an existing widget test; the device previously showing only two was a stale build, not a code defect. Confirmed on-device after reinstall.

## Tests

- New: cache-poisoning guard tests, camera detection-guard tests, time-period label tests, Theme-tile single-line test.
- Existing "palette cards render and switch family" continues to pass (all five families).

Closes #96
Closes #97
Closes #98
Closes #99
