### PR TITLE
chore(deps): upgrade Dart libraries

### DIFF
--- a/lib/core/services/audio/audio_player_service.dart
+++ b/lib/core/services/audio/audio_player_service.dart
@@ -19,8 +19,7 @@ class AudioPlayerService {
   /// Creates an [AudioPlayerService].
   ///
   /// If [player] is null, a real [AudioPlayer] is created.
-  AudioPlayerService({AudioPlayer? player})
-      : _player = player ?? AudioPlayer();
+  AudioPlayerService({AudioPlayer? player}) : _player = player ?? AudioPlayer();
 
   final AudioPlayer _player;
 
@@ -50,20 +49,17 @@ class AudioPlayerService {
   Stream<int?> get currentIndexStream => _player.currentIndexStream;
 
   /// Stream of the current sequence state (track, index, list, etc.).
-  Stream<SequenceState?> get sequenceStateStream =>
-      _player.sequenceStateStream;
+  Stream<SequenceState?> get sequenceStateStream => _player.sequenceStateStream;
 
   /// Stream of playback events, useful for monitoring errors.
-  /// Individual track load failures in a [ConcatenatingAudioSource] will
+  /// Individual track load failures in a playlist will
   /// emit errors here; the player auto-advances to the next track.
-  Stream<PlaybackEvent> get playbackEventStream =>
-      _player.playbackEventStream;
+  Stream<PlaybackEvent> get playbackEventStream => _player.playbackEventStream;
 
   /// Loads and plays an album from the given [tracks], starting at
   /// [startIndex].
   ///
-  /// Builds a [ConcatenatingAudioSource] from the track file paths for
-  /// gapless playback.
+  /// Builds audio sources from the track file paths for gapless playback.
   Future<void> playAlbum({
     required RipAlbum album,
     required List<RipTrack> tracks,
@@ -72,14 +68,11 @@ class AudioPlayerService {
     _currentAlbum = album;
     _currentTracks = List<RipTrack>.from(tracks);
 
-    final source = ConcatenatingAudioSource(
-      useLazyPreparation: true,
-      children: tracks
-          .map((track) => AudioSource.file(track.filePath, tag: track.title))
-          .toList(),
-    );
+    final sources = tracks
+        .map((track) => AudioSource.file(track.filePath, tag: track.title))
+        .toList();
 
-    await _player.setAudioSource(source, initialIndex: startIndex);
+    await _player.setAudioSources(sources, initialIndex: startIndex);
     await _player.play();
   }
 
@@ -96,14 +89,11 @@ class AudioPlayerService {
     _currentAlbum = album;
     _currentTracks = List<RipTrack>.from(tracks);
 
-    final source = ConcatenatingAudioSource(
-      useLazyPreparation: true,
-      children: tracks
-          .map((track) => AudioSource.file(track.filePath, tag: track.title))
-          .toList(),
-    );
+    final sources = tracks
+        .map((track) => AudioSource.file(track.filePath, tag: track.title))
+        .toList();
 
-    await _player.setAudioSource(source, initialIndex: startIndex);
+    await _player.setAudioSources(sources, initialIndex: startIndex);
     await _player.play();
   }
 

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -9,7 +9,7 @@ class NotificationService {
   NotificationService() : _plugin = FlutterLocalNotificationsPlugin();
 
   NotificationService.withPlugin(FlutterLocalNotificationsPlugin plugin)
-      : _plugin = plugin;
+    : _plugin = plugin;
 
   final FlutterLocalNotificationsPlugin _plugin;
   bool _initialised = false;
@@ -18,8 +18,9 @@ class NotificationService {
   Future<void> initialise() async {
     if (_initialised) return;
 
-    const androidSettings =
-        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const androidSettings = AndroidInitializationSettings(
+      '@mipmap/ic_launcher',
+    );
     const darwinSettings = DarwinInitializationSettings(
       requestAlertPermission: true,
       requestBadgePermission: true,
@@ -32,14 +33,15 @@ class NotificationService {
     );
 
     try {
-      await _plugin.initialize(settings);
+      await _plugin.initialize(settings: settings);
       _initialised = true;
       // Android 13+ requires a runtime permission before notifications
       // are displayed; Darwin permissions are requested via the
       // initialization settings above.
       await _plugin
           .resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin>()
+            AndroidFlutterLocalNotificationsPlugin
+          >()
           ?.requestNotificationsPermission();
     } catch (_) {
       // Gracefully degrade on unsupported platforms.
@@ -70,7 +72,12 @@ class NotificationService {
     );
 
     try {
-      await _plugin.show(id, title, body, details);
+      await _plugin.show(
+        id: id,
+        title: title,
+        body: body,
+        notificationDetails: details,
+      );
     } catch (_) {
       // Gracefully degrade.
     }
@@ -80,7 +87,7 @@ class NotificationService {
   Future<void> cancelNotification(int id) async {
     if (!_initialised) return;
     try {
-      await _plugin.cancel(id);
+      await _plugin.cancel(id: id);
     } catch (_) {
       // Gracefully degrade.
     }

--- a/lib/data/importers/discogs_csv_parser.dart
+++ b/lib/data/importers/discogs_csv_parser.dart
@@ -11,17 +11,14 @@ import 'package:mymediascanner/domain/entities/media_type.dart';
 class DiscogsCsvParser implements ImportParser {
   const DiscogsCsvParser();
 
-  static const _converter = CsvToListConverter(
-    shouldParseNumbers: false,
-    eol: '\n',
-  );
+  static final _converter = Csv(autoDetect: false);
 
   @override
   List<ImportRow> parse(String content) {
     final trimmed = content.trim();
     if (trimmed.isEmpty) return const [];
 
-    final table = _converter.convert(trimmed);
+    final table = _converter.decode(trimmed);
     if (table.length < 2) return const [];
 
     final header = table.first.map((c) => c.toString()).toList();
@@ -58,16 +55,18 @@ class DiscogsCsvParser implements ImportParser {
       if (releaseId != null) fields['discogs_release_id'] = releaseId;
       if (label != null) fields['label'] = label;
       if (format != null) fields['format'] = format;
-      rows.add(ImportRow(
-        sourceRowId: releaseId ?? 'discogs-$i',
-        source: ImportSource.discogs,
-        mediaType: MediaType.music,
-        rawTitle: title,
-        rawAuthor: cell(artistCol),
-        rawYear: int.tryParse(cell(yearCol) ?? ''),
-        discogsCatalog: catalog,
-        rawFields: fields,
-      ));
+      rows.add(
+        ImportRow(
+          sourceRowId: releaseId ?? 'discogs-$i',
+          source: ImportSource.discogs,
+          mediaType: MediaType.music,
+          rawTitle: title,
+          rawAuthor: cell(artistCol),
+          rawYear: int.tryParse(cell(yearCol) ?? ''),
+          discogsCatalog: catalog,
+          rawFields: fields,
+        ),
+      );
     }
     return rows;
   }

--- a/lib/data/importers/goodreads_csv_parser.dart
+++ b/lib/data/importers/goodreads_csv_parser.dart
@@ -12,17 +12,14 @@ import 'package:mymediascanner/domain/entities/media_type.dart';
 class GoodreadsCsvParser implements ImportParser {
   const GoodreadsCsvParser();
 
-  static const _converter = CsvToListConverter(
-    shouldParseNumbers: false,
-    eol: '\n',
-  );
+  static final _converter = Csv(autoDetect: false);
 
   @override
   List<ImportRow> parse(String content) {
     final trimmed = content.trim();
     if (trimmed.isEmpty) return const [];
 
-    final table = _converter.convert(trimmed);
+    final table = _converter.decode(trimmed);
     if (table.length < 2) return const [];
 
     final header = table.first.map((c) => c.toString()).toList();
@@ -58,16 +55,18 @@ class GoodreadsCsvParser implements ImportParser {
       final fields = <String, String>{};
       if (publisher != null) fields['publisher'] = publisher;
 
-      rows.add(ImportRow(
-        sourceRowId: cell(bookIdCol) ?? 'goodreads-$i',
-        source: ImportSource.goodreads,
-        mediaType: MediaType.book,
-        rawTitle: title,
-        rawAuthor: cell(authorCol),
-        rawYear: _parseYear(cell(origYearCol) ?? cell(yearCol)),
-        isbn: isbn,
-        rawFields: fields,
-      ));
+      rows.add(
+        ImportRow(
+          sourceRowId: cell(bookIdCol) ?? 'goodreads-$i',
+          source: ImportSource.goodreads,
+          mediaType: MediaType.book,
+          rawTitle: title,
+          rawAuthor: cell(authorCol),
+          rawYear: _parseYear(cell(origYearCol) ?? cell(yearCol)),
+          isbn: isbn,
+          rawFields: fields,
+        ),
+      );
     }
     return rows;
   }

--- a/lib/data/importers/letterboxd_csv_parser.dart
+++ b/lib/data/importers/letterboxd_csv_parser.dart
@@ -11,17 +11,14 @@ import 'package:mymediascanner/domain/entities/media_type.dart';
 class LetterboxdCsvParser implements ImportParser {
   const LetterboxdCsvParser();
 
-  static const _converter = CsvToListConverter(
-    shouldParseNumbers: false,
-    eol: '\n',
-  );
+  static final _converter = Csv(autoDetect: false);
 
   @override
   List<ImportRow> parse(String content) {
     final trimmed = content.trim();
     if (trimmed.isEmpty) return const [];
 
-    final table = _converter.convert(trimmed);
+    final table = _converter.decode(trimmed);
     if (table.length < 2) return const [];
 
     final header = table.first.map((c) => c.toString()).toList();
@@ -51,14 +48,16 @@ class LetterboxdCsvParser implements ImportParser {
       final fields = <String, String>{};
       if (uri != null) fields['letterboxd_uri'] = uri;
       if (date != null) fields['watched_date'] = date;
-      rows.add(ImportRow(
-        sourceRowId: uri ?? 'letterboxd-$i',
-        source: ImportSource.letterboxd,
-        mediaType: MediaType.film,
-        rawTitle: name,
-        rawYear: int.tryParse(cell(yearCol) ?? ''),
-        rawFields: fields,
-      ));
+      rows.add(
+        ImportRow(
+          sourceRowId: uri ?? 'letterboxd-$i',
+          source: ImportSource.letterboxd,
+          mediaType: MediaType.film,
+          rawTitle: name,
+          rawYear: int.tryParse(cell(yearCol) ?? ''),
+          rawFields: fields,
+        ),
+      );
     }
     return rows;
   }

--- a/lib/data/local/database/app_database.g.dart
+++ b/lib/data/local/database/app_database.g.dart
@@ -11977,10 +11977,7 @@ final class $$MediaItemsTableTableReferences
   _mediaItemTagsTableRefsTable(_$AppDatabase db) =>
       MultiTypedResultKey.fromTable(
         db.mediaItemTagsTable,
-        aliasName: $_aliasNameGenerator(
-          db.mediaItemsTable.id,
-          db.mediaItemTagsTable.mediaItemId,
-        ),
+        aliasName: 'media_items__id__media_item_tags__media_item_id',
       );
 
   $$MediaItemTagsTableTableProcessedTableManager get mediaItemTagsTableRefs {
@@ -12000,10 +11997,7 @@ final class $$MediaItemsTableTableReferences
   static MultiTypedResultKey<$ShelfItemsTableTable, List<ShelfItemsTableData>>
   _shelfItemsTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.shelfItemsTable,
-    aliasName: $_aliasNameGenerator(
-      db.mediaItemsTable.id,
-      db.shelfItemsTable.mediaItemId,
-    ),
+    aliasName: 'media_items__id__shelf_items__media_item_id',
   );
 
   $$ShelfItemsTableTableProcessedTableManager get shelfItemsTableRefs {
@@ -12023,10 +12017,7 @@ final class $$MediaItemsTableTableReferences
   static MultiTypedResultKey<$LoansTableTable, List<LoansTableData>>
   _loansTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.loansTable,
-    aliasName: $_aliasNameGenerator(
-      db.mediaItemsTable.id,
-      db.loansTable.mediaItemId,
-    ),
+    aliasName: 'media_items__id__loans__media_item_id',
   );
 
   $$LoansTableTableProcessedTableManager get loansTableRefs {
@@ -12044,10 +12035,7 @@ final class $$MediaItemsTableTableReferences
   static MultiTypedResultKey<$RipAlbumsTableTable, List<RipAlbumsTableData>>
   _ripAlbumsTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.ripAlbumsTable,
-    aliasName: $_aliasNameGenerator(
-      db.mediaItemsTable.id,
-      db.ripAlbumsTable.mediaItemId,
-    ),
+    aliasName: 'media_items__id__rip_albums__media_item_id',
   );
 
   $$RipAlbumsTableTableProcessedTableManager get ripAlbumsTableRefs {
@@ -13207,10 +13195,7 @@ final class $$TagsTableTableReferences
   _mediaItemTagsTableRefsTable(_$AppDatabase db) =>
       MultiTypedResultKey.fromTable(
         db.mediaItemTagsTable,
-        aliasName: $_aliasNameGenerator(
-          db.tagsTable.id,
-          db.mediaItemTagsTable.tagId,
-        ),
+        aliasName: 'tags__id__media_item_tags__tag_id',
       );
 
   $$MediaItemTagsTableTableProcessedTableManager get mediaItemTagsTableRefs {
@@ -13520,13 +13505,9 @@ final class $$MediaItemTagsTableTableReferences
     super.$_typedResult,
   );
 
-  static $MediaItemsTableTable _mediaItemIdTable(_$AppDatabase db) =>
-      db.mediaItemsTable.createAlias(
-        $_aliasNameGenerator(
-          db.mediaItemTagsTable.mediaItemId,
-          db.mediaItemsTable.id,
-        ),
-      );
+  static $MediaItemsTableTable _mediaItemIdTable(_$AppDatabase db) => db
+      .mediaItemsTable
+      .createAlias('media_item_tags__media_item_id__media_items__id');
 
   $$MediaItemsTableTableProcessedTableManager get mediaItemId {
     final $_column = $_itemColumn<String>('media_item_id')!;
@@ -13543,9 +13524,7 @@ final class $$MediaItemTagsTableTableReferences
   }
 
   static $TagsTableTable _tagIdTable(_$AppDatabase db) =>
-      db.tagsTable.createAlias(
-        $_aliasNameGenerator(db.mediaItemTagsTable.tagId, db.tagsTable.id),
-      );
+      db.tagsTable.createAlias('media_item_tags__tag_id__tags__id');
 
   $$TagsTableTableProcessedTableManager get tagId {
     final $_column = $_itemColumn<String>('tag_id')!;
@@ -13928,10 +13907,7 @@ final class $$ShelvesTableTableReferences
   static MultiTypedResultKey<$ShelfItemsTableTable, List<ShelfItemsTableData>>
   _shelfItemsTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.shelfItemsTable,
-    aliasName: $_aliasNameGenerator(
-      db.shelvesTable.id,
-      db.shelfItemsTable.shelfId,
-    ),
+    aliasName: 'shelves__id__shelf_items__shelf_id',
   );
 
   $$ShelfItemsTableTableProcessedTableManager get shelfItemsTableRefs {
@@ -14262,9 +14238,7 @@ final class $$ShelfItemsTableTableReferences
   );
 
   static $ShelvesTableTable _shelfIdTable(_$AppDatabase db) =>
-      db.shelvesTable.createAlias(
-        $_aliasNameGenerator(db.shelfItemsTable.shelfId, db.shelvesTable.id),
-      );
+      db.shelvesTable.createAlias('shelf_items__shelf_id__shelves__id');
 
   $$ShelvesTableTableProcessedTableManager get shelfId {
     final $_column = $_itemColumn<String>('shelf_id')!;
@@ -14280,13 +14254,9 @@ final class $$ShelfItemsTableTableReferences
     );
   }
 
-  static $MediaItemsTableTable _mediaItemIdTable(_$AppDatabase db) =>
-      db.mediaItemsTable.createAlias(
-        $_aliasNameGenerator(
-          db.shelfItemsTable.mediaItemId,
-          db.mediaItemsTable.id,
-        ),
-      );
+  static $MediaItemsTableTable _mediaItemIdTable(_$AppDatabase db) => db
+      .mediaItemsTable
+      .createAlias('shelf_items__media_item_id__media_items__id');
 
   $$MediaItemsTableTableProcessedTableManager get mediaItemId {
     final $_column = $_itemColumn<String>('media_item_id')!;
@@ -15255,10 +15225,7 @@ final class $$BorrowersTableTableReferences
   static MultiTypedResultKey<$LoansTableTable, List<LoansTableData>>
   _loansTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.loansTable,
-    aliasName: $_aliasNameGenerator(
-      db.borrowersTable.id,
-      db.loansTable.borrowerId,
-    ),
+    aliasName: 'borrowers__id__loans__borrower_id',
   );
 
   $$LoansTableTableProcessedTableManager get loansTableRefs {
@@ -15601,9 +15568,7 @@ final class $$LoansTableTableReferences
   $$LoansTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static $MediaItemsTableTable _mediaItemIdTable(_$AppDatabase db) =>
-      db.mediaItemsTable.createAlias(
-        $_aliasNameGenerator(db.loansTable.mediaItemId, db.mediaItemsTable.id),
-      );
+      db.mediaItemsTable.createAlias('loans__media_item_id__media_items__id');
 
   $$MediaItemsTableTableProcessedTableManager get mediaItemId {
     final $_column = $_itemColumn<String>('media_item_id')!;
@@ -15620,9 +15585,7 @@ final class $$LoansTableTableReferences
   }
 
   static $BorrowersTableTable _borrowerIdTable(_$AppDatabase db) =>
-      db.borrowersTable.createAlias(
-        $_aliasNameGenerator(db.loansTable.borrowerId, db.borrowersTable.id),
-      );
+      db.borrowersTable.createAlias('loans__borrower_id__borrowers__id');
 
   $$BorrowersTableTableProcessedTableManager get borrowerId {
     final $_column = $_itemColumn<String>('borrower_id')!;
@@ -16104,13 +16067,9 @@ final class $$RipAlbumsTableTableReferences
     super.$_typedResult,
   );
 
-  static $MediaItemsTableTable _mediaItemIdTable(_$AppDatabase db) =>
-      db.mediaItemsTable.createAlias(
-        $_aliasNameGenerator(
-          db.ripAlbumsTable.mediaItemId,
-          db.mediaItemsTable.id,
-        ),
-      );
+  static $MediaItemsTableTable _mediaItemIdTable(_$AppDatabase db) => db
+      .mediaItemsTable
+      .createAlias('rip_albums__media_item_id__media_items__id');
 
   $$MediaItemsTableTableProcessedTableManager? get mediaItemId {
     final $_column = $_itemColumn<String>('media_item_id');
@@ -16129,10 +16088,7 @@ final class $$RipAlbumsTableTableReferences
   static MultiTypedResultKey<$RipTracksTableTable, List<RipTracksTableData>>
   _ripTracksTableRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
     db.ripTracksTable,
-    aliasName: $_aliasNameGenerator(
-      db.ripAlbumsTable.id,
-      db.ripTracksTable.ripAlbumId,
-    ),
+    aliasName: 'rip_albums__id__rip_tracks__rip_album_id',
   );
 
   $$RipTracksTableTableProcessedTableManager get ripTracksTableRefs {
@@ -16739,12 +16695,7 @@ final class $$RipTracksTableTableReferences
   );
 
   static $RipAlbumsTableTable _ripAlbumIdTable(_$AppDatabase db) =>
-      db.ripAlbumsTable.createAlias(
-        $_aliasNameGenerator(
-          db.ripTracksTable.ripAlbumId,
-          db.ripAlbumsTable.id,
-        ),
-      );
+      db.ripAlbumsTable.createAlias('rip_tracks__rip_album_id__rip_albums__id');
 
   $$RipAlbumsTableTableProcessedTableManager get ripAlbumId {
     final $_column = $_itemColumn<String>('rip_album_id')!;
@@ -16767,10 +16718,7 @@ final class $$RipTracksTableTableReferences
   _playlistTracksTableRefsTable(_$AppDatabase db) =>
       MultiTypedResultKey.fromTable(
         db.playlistTracksTable,
-        aliasName: $_aliasNameGenerator(
-          db.ripTracksTable.id,
-          db.playlistTracksTable.ripTrackId,
-        ),
+        aliasName: 'rip_tracks__id__playlist_tracks__rip_track_id',
       );
 
   $$PlaylistTracksTableTableProcessedTableManager get playlistTracksTableRefs {
@@ -18039,10 +17987,7 @@ final class $$PlaylistsTableTableReferences
   _playlistTracksTableRefsTable(_$AppDatabase db) =>
       MultiTypedResultKey.fromTable(
         db.playlistTracksTable,
-        aliasName: $_aliasNameGenerator(
-          db.playlistsTable.id,
-          db.playlistTracksTable.playlistId,
-        ),
+        aliasName: 'playlists__id__playlist_tracks__playlist_id',
       );
 
   $$PlaylistTracksTableTableProcessedTableManager get playlistTracksTableRefs {
@@ -18394,13 +18339,9 @@ final class $$PlaylistTracksTableTableReferences
     super.$_typedResult,
   );
 
-  static $PlaylistsTableTable _playlistIdTable(_$AppDatabase db) =>
-      db.playlistsTable.createAlias(
-        $_aliasNameGenerator(
-          db.playlistTracksTable.playlistId,
-          db.playlistsTable.id,
-        ),
-      );
+  static $PlaylistsTableTable _playlistIdTable(_$AppDatabase db) => db
+      .playlistsTable
+      .createAlias('playlist_tracks__playlist_id__playlists__id');
 
   $$PlaylistsTableTableProcessedTableManager get playlistId {
     final $_column = $_itemColumn<String>('playlist_id')!;
@@ -18416,13 +18357,9 @@ final class $$PlaylistTracksTableTableReferences
     );
   }
 
-  static $RipTracksTableTable _ripTrackIdTable(_$AppDatabase db) =>
-      db.ripTracksTable.createAlias(
-        $_aliasNameGenerator(
-          db.playlistTracksTable.ripTrackId,
-          db.ripTracksTable.id,
-        ),
-      );
+  static $RipTracksTableTable _ripTrackIdTable(_$AppDatabase db) => db
+      .ripTracksTable
+      .createAlias('playlist_tracks__rip_track_id__rip_tracks__id');
 
   $$RipTracksTableTableProcessedTableManager get ripTrackId {
     final $_column = $_itemColumn<String>('rip_track_id')!;

--- a/lib/domain/services/label_pdf_generator.dart
+++ b/lib/domain/services/label_pdf_generator.dart
@@ -39,21 +39,23 @@ class LabelPdfGenerator {
       final end = (start + perPage).clamp(0, targets.length);
       final pageTargets = targets.sublist(start, end);
 
-      doc.addPage(pw.Page(
-        pageFormat: pageSize,
-        build: (context) => pw.Stack(
-          children: [
-            for (var i = 0; i < pageTargets.length; i++)
-              _positionCell(
-                preset: preset,
-                index: i,
-                cellW: cellW,
-                cellH: cellH,
-                child: _LabelCell(target: pageTargets[i]),
-              ),
-          ],
+      doc.addPage(
+        pw.Page(
+          pageFormat: pageSize,
+          build: (context) => pw.Stack(
+            children: [
+              for (var i = 0; i < pageTargets.length; i++)
+                _positionCell(
+                  preset: preset,
+                  index: i,
+                  cellW: cellW,
+                  cellH: cellH,
+                  child: _LabelCell(target: pageTargets[i]),
+                ),
+            ],
+          ),
         ),
-      ));
+      );
     }
 
     return doc.save();
@@ -74,11 +76,7 @@ class LabelPdfGenerator {
     return pw.Positioned(
       left: x,
       top: y,
-      child: pw.SizedBox(
-        width: cellW,
-        height: cellH,
-        child: child,
-      ),
+      child: pw.SizedBox(width: cellW, height: cellH, child: child),
     );
   }
 }
@@ -115,7 +113,7 @@ class _LabelCell extends pw.StatelessWidget {
               children: [
                 pw.Text(
                   target.title,
-                  style: pw.TextStyle(
+                  style: const pw.TextStyle(
                     fontSize: 10,
                     fontWeight: pw.FontWeight.bold,
                   ),

--- a/lib/presentation/screens/export/static_export_screen.dart
+++ b/lib/presentation/screens/export/static_export_screen.dart
@@ -20,8 +20,7 @@ class StaticExportScreen extends ConsumerStatefulWidget {
   const StaticExportScreen({super.key});
 
   @override
-  ConsumerState<StaticExportScreen> createState() =>
-      _StaticExportScreenState();
+  ConsumerState<StaticExportScreen> createState() => _StaticExportScreenState();
 }
 
 class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
@@ -47,8 +46,7 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
     final theme = Theme.of(context);
 
     return Scaffold(
-      appBar:
-          isDesktop ? null : AppBar(title: const Text('Export collection')),
+      appBar: isDesktop ? null : AppBar(title: const Text('Export collection')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -58,10 +56,7 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
               // This screen is pushed on the root navigator, so there is no
               // sidebar and no AppBar on desktop — provide an explicit back
               // affordance (mobile gets one from the AppBar).
-              const Align(
-                alignment: Alignment.centerLeft,
-                child: BackButton(),
-              ),
+              const Align(alignment: Alignment.centerLeft, child: BackButton()),
               const ScreenHeader(
                 title: 'Export collection',
                 subtitle:
@@ -78,9 +73,7 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
                 children: [
                   TextField(
                     controller: _titleController,
-                    decoration: const InputDecoration(
-                      labelText: 'Site title',
-                    ),
+                    decoration: const InputDecoration(labelText: 'Site title'),
                   ),
                   const SizedBox(height: 12),
                   TextField(
@@ -94,8 +87,9 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
                     contentPadding: EdgeInsets.zero,
                     title: const Text('Download and bundle cover art'),
                     subtitle: const Text(
-                        'Fetches every cover URL. Without this the export '
-                        'references the original hosts, which may 404 later.'),
+                      'Fetches every cover URL. Without this the export '
+                      'references the original hosts, which may 404 later.',
+                    ),
                     value: _bundleCovers,
                     onChanged: _running
                         ? null
@@ -104,9 +98,9 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
                   const SizedBox(height: 16),
                   FilledButton.icon(
                     icon: const Icon(Icons.download),
-                    label: Text(_running
-                        ? 'Exporting…'
-                        : 'Choose folder and export'),
+                    label: Text(
+                      _running ? 'Exporting…' : 'Choose folder and export',
+                    ),
                     onPressed: _running ? null : _export,
                   ),
                   if (_running || _progressTotal > 0) ...[
@@ -117,14 +111,17 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
                           : _progressDone / _progressTotal,
                     ),
                     const SizedBox(height: 4),
-                    Text('$_progressDone / $_progressTotal',
-                        style: theme.textTheme.bodySmall),
+                    Text(
+                      '$_progressDone / $_progressTotal',
+                      style: theme.textTheme.bodySmall,
+                    ),
                   ],
                   if (_errorMessage != null) ...[
                     const SizedBox(height: 16),
-                    Text(_errorMessage!,
-                        style: TextStyle(
-                            color: theme.colorScheme.error)),
+                    Text(
+                      _errorMessage!,
+                      style: TextStyle(color: theme.colorScheme.error),
+                    ),
                   ],
                   if (_resultPath != null) ...[
                     const SizedBox(height: 16),
@@ -135,18 +132,22 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text('Export complete',
-                                style: theme.textTheme.titleMedium),
+                            Text(
+                              'Export complete',
+                              style: theme.textTheme.titleMedium,
+                            ),
                             const SizedBox(height: 4),
                             SelectableText(_resultPath!),
                             const SizedBox(height: 12),
-                            Row(children: [
-                              FilledButton.tonalIcon(
-                                icon: const Icon(Icons.open_in_browser),
-                                label: const Text('Open index.html'),
-                                onPressed: () => _launch(_resultPath!),
-                              ),
-                            ]),
+                            Row(
+                              children: [
+                                FilledButton.tonalIcon(
+                                  icon: const Icon(Icons.open_in_browser),
+                                  label: const Text('Open index.html'),
+                                  onPressed: () => _launch(_resultPath!),
+                                ),
+                              ],
+                            ),
                           ],
                         ),
                       ),
@@ -162,7 +163,7 @@ class _StaticExportScreenState extends ConsumerState<StaticExportScreen> {
   }
 
   Future<void> _export() async {
-    final dirPath = await FilePicker.platform.getDirectoryPath(
+    final dirPath = await FilePicker.getDirectoryPath(
       dialogTitle: 'Choose export folder',
     );
     if (dirPath == null) return;

--- a/lib/presentation/screens/import/import_screen.dart
+++ b/lib/presentation/screens/import/import_screen.dart
@@ -4,8 +4,6 @@
 // Author: Paul Snow
 // Since: 0.0.0
 
-import 'dart:io';
-
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -131,22 +129,13 @@ class _ImportScreenState extends ConsumerState<ImportScreen> {
   };
 
   Future<void> _pickFile() async {
-    final result = await FilePicker.platform.pickFiles(
+    final file = await FilePicker.pickFile(
       allowedExtensions: [_source.fileExtension],
       type: FileType.custom,
-      withData: true,
     );
-    if (result == null) return;
+    if (file == null) return;
 
-    final file = result.files.single;
-    String content;
-    if (file.bytes != null) {
-      content = String.fromCharCodes(file.bytes!);
-    } else if (file.path != null) {
-      content = await File(file.path!).readAsString();
-    } else {
-      return;
-    }
+    final content = String.fromCharCodes(await file.readAsBytes());
 
     if (!mounted) return;
     await ref

--- a/lib/presentation/screens/settings/backup_screen.dart
+++ b/lib/presentation/screens/settings/backup_screen.dart
@@ -91,7 +91,7 @@ class _BackupScreenState extends ConsumerState<BackupScreen> {
       _errorMessage = null;
     });
     try {
-      final destination = await FilePicker.platform.getDirectoryPath(
+      final destination = await FilePicker.getDirectoryPath(
         dialogTitle: 'Choose backup destination folder',
       );
       if (destination == null) return;
@@ -135,15 +135,17 @@ class _BackupScreenState extends ConsumerState<BackupScreen> {
       _errorMessage = null;
     });
     try {
-      final result = await FilePicker.platform.pickFiles(
+      final result = await FilePicker.pickFiles(
         dialogTitle: 'Choose backup `.db` file',
       );
       final path = result?.files.single.path;
       if (path == null) return;
       await ref.read(_backupServiceProvider).restoreFromBackup(path);
       if (mounted) {
-        setState(() => _statusMessage =
-            'Restore complete. Restart the app for the changes to take effect.');
+        setState(
+          () => _statusMessage =
+              'Restore complete. Restart the app for the changes to take effect.',
+        );
       }
     } catch (e) {
       if (mounted) setState(() => _errorMessage = e.toString());

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -29,9 +29,7 @@ class SettingsScreen extends ConsumerWidget {
     final isDesktop = PlatformCapability.isDesktop;
 
     return Scaffold(
-      appBar: isDesktop
-          ? null
-          : AppBar(title: const Text('Settings')),
+      appBar: isDesktop ? null : AppBar(title: const Text('Settings')),
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
@@ -98,8 +96,7 @@ class SettingsScreen extends ConsumerWidget {
               ListTile(
                 leading: const Icon(Icons.upload_file),
                 title: const Text('Import from external collection'),
-                subtitle:
-                    const Text('Goodreads, Discogs, Letterboxd or Trakt'),
+                subtitle: const Text('Goodreads, Discogs, Letterboxd or Trakt'),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => context.go('/settings/import'),
               ),
@@ -117,7 +114,8 @@ class SettingsScreen extends ConsumerWidget {
                 leading: const Icon(Icons.print_outlined),
                 title: const Text('Print labels'),
                 subtitle: const Text(
-                    'QR labels for locations or items, preview and export as PDF'),
+                  'QR labels for locations or items, preview and export as PDF',
+                ),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => context.go('/settings/labels'),
               ),
@@ -135,8 +133,9 @@ class SettingsScreen extends ConsumerWidget {
                 leading: const Icon(Icons.public_outlined),
                 title: const Text('Static HTML export'),
                 subtitle: const Text(
-                    'Portable website bundle with filter controls; drop '
-                    'into any static host or open locally'),
+                  'Portable website bundle with filter controls; drop '
+                  'into any static host or open locally',
+                ),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => context.go('/settings/export'),
               ),
@@ -153,8 +152,9 @@ class SettingsScreen extends ConsumerWidget {
                 leading: const Icon(Icons.delete_outline),
                 title: const Text('Trash'),
                 subtitle: const Text(
-                    'Restore or permanently delete items you removed '
-                    'from the collection'),
+                  'Restore or permanently delete items you removed '
+                  'from the collection',
+                ),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => context.go('/settings/trash'),
               ),
@@ -162,8 +162,9 @@ class SettingsScreen extends ConsumerWidget {
                 leading: const Icon(Icons.merge_type),
                 title: const Text('Find duplicates'),
                 subtitle: const Text(
-                    'Scan the library for items with the same barcode '
-                    'or a near-identical title and year'),
+                  'Scan the library for items with the same barcode '
+                  'or a near-identical title and year',
+                ),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => context.go('/settings/dedupe'),
               ),
@@ -171,8 +172,9 @@ class SettingsScreen extends ConsumerWidget {
                 leading: const Icon(Icons.backup_outlined),
                 title: const Text('Backup & restore'),
                 subtitle: const Text(
-                    'Copy the local database to a portable file, or '
-                    'restore from a previously-saved backup'),
+                  'Copy the local database to a portable file, or '
+                  'restore from a previously-saved backup',
+                ),
                 trailing: const Icon(Icons.chevron_right),
                 onTap: () => context.go('/settings/backup'),
               ),
@@ -213,10 +215,7 @@ class SettingsScreen extends ConsumerWidget {
             title: 'Preferences',
             colors: colors,
             theme: theme,
-            children: [
-              _PaletteTile(),
-              _ThemeModeTile(),
-            ],
+            children: [_PaletteTile(), _ThemeModeTile()],
           ),
           const SizedBox(height: 16),
 
@@ -226,9 +225,7 @@ class SettingsScreen extends ConsumerWidget {
             color: colors.errorContainer.withValues(alpha: 0.1),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
-              side: BorderSide(
-                color: colors.error.withValues(alpha: 0.2),
-              ),
+              side: BorderSide(color: colors.error.withValues(alpha: 0.2)),
             ),
             clipBehavior: Clip.antiAlias,
             child: Padding(
@@ -236,16 +233,17 @@ class SettingsScreen extends ConsumerWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text('Danger Zone',
-                      style: theme.textTheme.titleSmall?.copyWith(
-                        color: colors.error,
-                      )),
+                  Text(
+                    'Danger Zone',
+                    style: theme.textTheme.titleSmall?.copyWith(
+                      color: colors.error,
+                    ),
+                  ),
                   const SizedBox(height: 8),
                   ListTile(
                     leading: Icon(Icons.warning, color: colors.error),
                     title: const Text('Reset & Re-sync'),
-                    subtitle:
-                        const Text('Replace local data with remote'),
+                    subtitle: const Text('Replace local data with remote'),
                     onTap: () => _confirmReset(context, ref),
                   ),
                 ],
@@ -283,7 +281,8 @@ class SettingsScreen extends ConsumerWidget {
       builder: (ctx) => AlertDialog(
         title: const Text('Reset local database?'),
         content: const Text(
-            'This will replace all local data with data from your PostgreSQL server. This cannot be undone.'),
+          'This will replace all local data with data from your PostgreSQL server. This cannot be undone.',
+        ),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(ctx),
@@ -298,10 +297,11 @@ class SettingsScreen extends ConsumerWidget {
               final messenger = ScaffoldMessenger.of(context);
               final repo = ref.read(syncRepositoryProvider);
               if (repo == null) {
-                messenger.showSnackBar(const SnackBar(
-                  content:
-                      Text('Configure PostgreSQL first to reset.'),
-                ));
+                messenger.showSnackBar(
+                  const SnackBar(
+                    content: Text('Configure PostgreSQL first to reset.'),
+                  ),
+                );
                 return;
               }
               try {
@@ -312,14 +312,16 @@ class SettingsScreen extends ConsumerWidget {
                 // context — `messenger` is captured pre-await but we
                 // still check `context.mounted` as the canonical guard.
                 if (!context.mounted) return;
-                messenger.showSnackBar(const SnackBar(
-                  content: Text('Local data replaced with remote.'),
-                ));
+                messenger.showSnackBar(
+                  const SnackBar(
+                    content: Text('Local data replaced with remote.'),
+                  ),
+                );
               } on Exception catch (e) {
                 if (!context.mounted) return;
-                messenger.showSnackBar(SnackBar(
-                  content: Text('Reset failed: $e'),
-                ));
+                messenger.showSnackBar(
+                  SnackBar(content: Text('Reset failed: $e')),
+                );
               }
             },
             child: const Text('Reset'),
@@ -336,8 +338,9 @@ class SettingsScreen extends ConsumerWidget {
 class _PaletteTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentFamily =
-        ref.watch(themeChoiceProvider.select((c) => c.family));
+    final currentFamily = ref.watch(
+      themeChoiceProvider.select((c) => c.family),
+    );
     final theme = Theme.of(context);
 
     Widget card({
@@ -358,8 +361,7 @@ class _PaletteTile extends ConsumerWidget {
           container: container,
           mediaDots: mediaDots,
           labelColor: labelColor,
-          onTap: () =>
-              ref.read(themeChoiceProvider.notifier).setFamily(family),
+          onTap: () => ref.read(themeChoiceProvider.notifier).setFamily(family),
         ),
       );
     }
@@ -488,8 +490,9 @@ class _PaletteCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final ringColor =
-        selected ? theme.colorScheme.primary : theme.colorScheme.outlineVariant;
+    final ringColor = selected
+        ? theme.colorScheme.primary
+        : theme.colorScheme.outlineVariant;
 
     return Semantics(
       button: true,
@@ -504,10 +507,7 @@ class _PaletteCard extends StatelessWidget {
           decoration: BoxDecoration(
             color: surface,
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(
-              color: ringColor,
-              width: selected ? 2 : 1,
-            ),
+            border: Border.all(color: ringColor, width: selected ? 2 : 1),
           ),
           child: Row(
             children: [
@@ -573,20 +573,21 @@ class _PaletteCard extends StatelessWidget {
 class _ThemeModeTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final currentBrightness =
-        ref.watch(themeChoiceProvider.select((c) => c.brightness));
+    final currentBrightness = ref.watch(
+      themeChoiceProvider.select((c) => c.brightness),
+    );
 
     String label(ThemeBrightness b) => switch (b) {
-          ThemeBrightness.system => 'System default',
-          ThemeBrightness.light => 'Light',
-          ThemeBrightness.dark => 'Dark',
-        };
+      ThemeBrightness.system => 'System default',
+      ThemeBrightness.light => 'Light',
+      ThemeBrightness.dark => 'Dark',
+    };
 
     IconData icon(ThemeBrightness b) => switch (b) {
-          ThemeBrightness.system => Icons.brightness_auto,
-          ThemeBrightness.light => Icons.light_mode,
-          ThemeBrightness.dark => Icons.dark_mode,
-        };
+      ThemeBrightness.system => Icons.brightness_auto,
+      ThemeBrightness.light => Icons.light_mode,
+      ThemeBrightness.dark => Icons.dark_mode,
+    };
 
     return ListTile(
       // Drop the default 16dp side padding (matching the ReplayGain tiles
@@ -617,9 +618,7 @@ class _ThemeModeTile extends ConsumerWidget {
         ],
         selected: {currentBrightness},
         onSelectionChanged: (selection) {
-          ref
-              .read(themeChoiceProvider.notifier)
-              .setBrightness(selection.first);
+          ref.read(themeChoiceProvider.notifier).setBrightness(selection.first);
         },
         showSelectedIcon: false,
       ),
@@ -650,18 +649,9 @@ class _ReplayGainSection extends ConsumerWidget {
           subtitle: const Text('Normalise track loudness'),
           trailing: SegmentedButton<ReplayGainMode>(
             segments: const [
-              ButtonSegment(
-                value: ReplayGainMode.off,
-                label: Text('Off'),
-              ),
-              ButtonSegment(
-                value: ReplayGainMode.track,
-                label: Text('Track'),
-              ),
-              ButtonSegment(
-                value: ReplayGainMode.album,
-                label: Text('Album'),
-              ),
+              ButtonSegment(value: ReplayGainMode.off, label: Text('Off')),
+              ButtonSegment(value: ReplayGainMode.track, label: Text('Track')),
+              ButtonSegment(value: ReplayGainMode.album, label: Text('Album')),
             ],
             selected: {mode},
             onSelectionChanged: (selection) {
@@ -676,7 +666,9 @@ class _ReplayGainSection extends ConsumerWidget {
         // Pre-amp
         ListTile(
           contentPadding: EdgeInsets.zero,
-          title: Text('Pre-amp: ${preamp >= 0 ? '+' : ''}${preamp.toStringAsFixed(1)} dB'),
+          title: Text(
+            'Pre-amp: ${preamp >= 0 ? '+' : ''}${preamp.toStringAsFixed(1)} dB',
+          ),
           subtitle: Slider(
             value: preamp,
             min: -6.0,
@@ -827,8 +819,7 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
               icon: const Icon(Icons.folder_open),
               tooltip: 'Browse\u2026',
               onPressed: () async {
-                final path =
-                    await FilePicker.platform.getDirectoryPath();
+                final path = await FilePicker.getDirectoryPath();
                 if (path != null) {
                   _pathController.text = path;
                   await ref.read(ripLibraryPathProvider.notifier).setPath(path);
@@ -846,9 +837,7 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
                   : () {
                       final path = _pathController.text.trim();
                       if (path.isNotEmpty) {
-                        ref
-                            .read(ripLibraryPathProvider.notifier)
-                            .setPath(path);
+                        ref.read(ripLibraryPathProvider.notifier).setPath(path);
                         ref
                             .read(ripScanNotifierProvider.notifier)
                             .startScan(path);
@@ -881,8 +870,8 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
               Text(
                 'Error: ${scanState.error}',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.error,
-                    ),
+                  color: Theme.of(context).colorScheme.error,
+                ),
               ),
           ],
         ),
@@ -911,7 +900,7 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
               icon: const Icon(Icons.folder_open),
               tooltip: 'Browse\u2026',
               onPressed: () async {
-                final result = await FilePicker.platform.pickFiles(
+                final result = await FilePicker.pickFiles(
                   dialogTitle: 'Select flac binary',
                 );
                 if (result != null && result.files.single.path != null) {
@@ -927,8 +916,10 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
         ),
         const SizedBox(height: 16),
         // Click detection sensitivity
-        Text('Click detection sensitivity',
-            style: Theme.of(context).textTheme.bodyMedium),
+        Text(
+          'Click detection sensitivity',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
         const SizedBox(height: 4),
         clickSensitivityAsync.when(
           loading: () => const SizedBox.shrink(),
@@ -936,8 +927,7 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
           data: (sensitivity) => SegmentedButton<Sensitivity>(
             segments: const [
               ButtonSegment(value: Sensitivity.low, label: Text('Low')),
-              ButtonSegment(
-                  value: Sensitivity.medium, label: Text('Medium')),
+              ButtonSegment(value: Sensitivity.medium, label: Text('Medium')),
               ButtonSegment(value: Sensitivity.high, label: Text('High')),
             ],
             selected: {sensitivity},
@@ -952,8 +942,8 @@ class _FlacLibrarySectionState extends ConsumerState<_FlacLibrarySection> {
         Text(
           'Higher sensitivity catches more defects but may flag legitimate transients.',
           style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                color: Theme.of(context).colorScheme.outline,
-              ),
+            color: Theme.of(context).colorScheme.outline,
+          ),
         ),
       ],
     );
@@ -980,8 +970,9 @@ class _TextScaleSection extends ConsumerWidget {
           Text(
             'Stacks on top of the platform text-size setting so the whole '
             'app scales together with the rest of your device.',
-            style: theme.textTheme.bodySmall
-                ?.copyWith(color: colors.onSurfaceVariant),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colors.onSurfaceVariant,
+            ),
           ),
           const SizedBox(height: 8),
           scaleAsync.when(
@@ -993,9 +984,7 @@ class _TextScaleSection extends ConsumerWidget {
                 for (final option in const [1.0, 1.15, 1.3, 1.5])
                   ChoiceChip(
                     label: Text(
-                      option == 1.0
-                          ? 'Default'
-                          : '${(option * 100).round()}%',
+                      option == 1.0 ? 'Default' : '${(option * 100).round()}%',
                     ),
                     selected: factor == option,
                     onSelected: (_) => notifier.setFactor(option),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: "direct main"
     description:
       name: app_links
-      sha256: "5f88447519add627fe1cbcab4fd1da3d4fed15b9baf29f28b22535c95ecee3e8"
+      sha256: f8db46d2ea9ff6f3a37191a7fd5b7813da1253ace8c32c1b9eadace41d1188ea
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "7.2.1"
   app_links_linux:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: app_links_platform_interface
-      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      sha256: "7546f09a6e93f4a2df2fe2bd40a5c6c64310ac461b036d82b43033be7a59f809"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.4"
   app_links_web:
     dependency: transitive
     description:
@@ -85,18 +85,18 @@ packages:
     dependency: "direct main"
     description:
       name: audio_defect_detector
-      sha256: "4097162d046b519ab0149ae8e5e522eb36dc96a1f4a683afd6541d30b6aab27f"
+      sha256: f88e1e7c2196e7fd4e0760446bfe5a8ceea010b98d859e8dee81aa4a3667f52d
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0"
   audio_session:
     dependency: transitive
     description:
       name: audio_session
-      sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"
+      sha256: f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.25"
+    version: "0.2.4"
   barcode:
     dependency: transitive
     description:
@@ -133,34 +133,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -205,50 +205,50 @@ packages:
     dependency: "direct main"
     description:
       name: camera
-      sha256: "4142a19a38e388d3bab444227636610ba88982e36dff4552d5191a86f65dc437"
+      sha256: "034c38cb8014d29698dcae6d20276688a1bf74e6487dfeb274d70ea05d5f7777"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.4"
+    version: "0.12.0+1"
   camera_android_camerax:
     dependency: transitive
     description:
       name: camera_android_camerax
-      sha256: "8516fe308bc341a5067fb1a48edff0ddfa57c0d3cdcc9dbe7ceca3ba119e2577"
+      sha256: cf6c248ef3d3c4846e99e488de9487d95927437e083c396e5fed2c1ece7f93a7
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.30"
+    version: "0.7.4+1"
   camera_avfoundation:
     dependency: transitive
     description:
       name: camera_avfoundation
-      sha256: "11b4aee2f5e5e038982e152b4a342c749b414aa27857899d20f4323e94cb5f0b"
+      sha256: "866e9cd8370f8055d005c0413937a52dc1d7a472687f0ee3ce02392955aababa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.23+2"
+    version: "0.10.2"
   camera_desktop:
     dependency: "direct main"
     description:
       name: camera_desktop
-      sha256: bf5709484dc3ec4607ff93c497d86f76c0c10ee41705b10ae20060b409ee1d47
+      sha256: bea6ba51ecfa1afa24c543f26a66f10ca9f43ce8525207de7675ebcb4402d66f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.7"
+    version: "1.2.1"
   camera_platform_interface:
     dependency: transitive
     description:
       name: camera_platform_interface
-      sha256: "7ac852d77699acee79f0d438b793feee26721841e50973576419ff5c6d95e9b7"
+      sha256: "4524ca6eb4176b066864036ad4fe02c3e4863e63b77eadc21a5bf56824f43498"
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   camera_web:
     dependency: transitive
     description:
       name: camera_web
-      sha256: "57f49a635c8bf249d07fb95eb693d7e4dda6796dedb3777f9127fb54847beba7"
+      sha256: "1245a480a113437f8d46d19c0fb90cea9db921436d9cf2ba5fb11854a1312693"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+3"
+    version: "0.3.5+4"
   characters:
     dependency: transitive
     description:
@@ -341,18 +341,18 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -373,10 +373,10 @@ packages:
     dependency: "direct main"
     description:
       name: csv
-      sha256: c6aa2679b2a18cb57652920f674488d89712efaf4d3fdf2e537215b35fc19d6c
+      sha256: "2e0a52fb729f2faacd19c9c0c954ff450bba37aa8ab999410309e2342e7013a2"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -397,18 +397,18 @@ packages:
     dependency: "direct main"
     description:
       name: dart_cue
-      sha256: b34e7d5265e841b246595ad198ca9fe6817dfc2ea5c4431150bee1b9e26a38af
+      sha256: cafb38674022ff830f076f7b436901838e0f9dd730bca563d3074bad8ec1ec40
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.6"
+    version: "0.1.1"
   dart_flac:
     dependency: "direct main"
     description:
       name: dart_flac
-      sha256: "46ccf29b91f070a7c5a39ca41c28fc4b14e975442ab0f2fbb70eec9b040a3fd7"
+      sha256: ae9bbc4e1ecaae1a16cffd676a3656264c08491e47385962f31629f8777c793b
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.6"
+    version: "0.0.7"
   dart_metaflac:
     dependency: "direct main"
     description:
@@ -421,10 +421,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_rip_log
-      sha256: a13953ad961e0c4286786192129ed42261bf38cf885e8797187532176b2501ed
+      sha256: "71195e3b24aa853f47f7bb614859d920b98ecf5531e2dfba2b2a2b11484d4f10"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.5"
+    version: "0.1.0"
   dart_style:
     dependency: transitive
     description:
@@ -445,58 +445,58 @@ packages:
     dependency: transitive
     description:
       name: dbus
-      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.14"
+    version: "0.7.13"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      sha256: ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.2"
+    version: "5.10.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      sha256: dd58dc3861eb36edb13b217efc006a1c21e5bbc341de8c229b85634fa5e362e4
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   drift:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "8033500116b24398fba0cca0369cc31678cd627c01e41753a61186911cea743e"
+      sha256: c21b9af62e78f86837638dda6c33506bd9444ca8a32cad2b99c07369cf9e2462
       url: "https://pub.dev"
     source: hosted
-    version: "2.33.0"
+    version: "2.34.1"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: b3dd5b75e30522a91da8abda9f5bb17230cb038097f6d15fa75d42bb563428aa
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.33.0"
+    version: "2.34.0"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: "887fdec622174dc7eaefd0048403e34ee07cc18626ac8a7544cc3b8a4a172166"
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   equatable:
     dependency: transitive
     description:
       name: equatable
-      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -513,6 +513,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  ffi_leak_tracker:
+    dependency: transitive
+    description:
+      name: ffi_leak_tracker
+      sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
   file:
     dependency: transitive
     description:
@@ -525,10 +533,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: "57d9a1dd5063f85fa3107fb42d1faffda52fdc948cefd5fe5ea85267a5fc7343"
+      sha256: fdc6a37f715d19f35b131decf1ce39242eeed5ddae18c0818c3eccb731ab76be
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.10"
+    version: "12.0.0-beta.7"
   file_selector_linux:
     dependency: transitive
     description:
@@ -573,10 +581,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: "5276944c6ffc975ae796569a826c38a62d2abcf264e26b88fa6f482e107f4237"
+      sha256: b938f77d042cbcd822936a7a359a7235bad8bd72070de1f827efc2cc297ac888
       url: "https://pub.dev"
     source: hosted
-    version: "0.70.2"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -615,34 +623,42 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
       url: "https://pub.dev"
     source: hosted
-    version: "19.5.0"
+    version: "22.0.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: "9ca97e63776f29ab1b955725c09999fc2c150523269db150c39274f2a43c5a8b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "12.0.0"
+  flutter_local_notifications_web:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_web
+      sha256: "516afaf97a2d1e67a036c6617321b00d205d72f7a67b6eccf936cd565f985878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "6f43bdd03b171b7a90f22647506fea33e2bb12294b7c7c7a3d690e960a382945"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.1.1"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -668,10 +684,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -716,10 +732,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "3b7c8e068875dfd46719ff57c90d8c459c87f2302ed6b00ff006b3c9fcad1613"
+      sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -795,18 +811,18 @@ packages:
     dependency: transitive
     description:
       name: google_mlkit_commons
-      sha256: "3e69fea4211727732cc385104e675ad1e40b29f12edd492ee52fa108423a6124"
+      sha256: c7fc384bdb66c3b83e24e3a41818e61d7a378d900f65f5e775344fbca95a0917
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.12.0"
   google_mlkit_text_recognition:
     dependency: "direct main"
     description:
       name: google_mlkit_text_recognition
-      sha256: "10a8d1a64fa21efda89514f6df88bbb7885be3ae1bfb7a6d229132d802a20d22"
+      sha256: "8324fdc2628ebeb63568ad06437b984b716d938d87e4ce63ab24dfd3eeebf08a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.15.1"
+    version: "0.16.0"
   graphs:
     dependency: transitive
     description:
@@ -867,18 +883,18 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.1"
   image_picker:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   image_picker_android:
     dependency: transitive
     description:
@@ -992,10 +1008,10 @@ packages:
     dependency: "direct main"
     description:
       name: just_audio
-      sha256: f978d5b4ccea08f267dae0232ec5405c1b05d3f3cd63f82097ea46c015d5c09e
+      sha256: e60aa97b233ddea025e13dfac59195207f528fa5e9e4a4a49a8c0766701e5fe6
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.46"
+    version: "0.10.6"
   just_audio_media_kit:
     dependency: "direct main"
     description:
@@ -1120,18 +1136,18 @@ packages:
     dependency: "direct dev"
     description:
       name: msix
-      sha256: b6b08e7a7b5d1845f2b1d31216d5b1fb558e98251efefe54eb79ed00d27bc2ac
+      sha256: "61415c352e8aea084332b8a5514e6408c961c8cdeca202804fff1040eb555ac7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.16.13"
+    version: "3.18.0"
   native_toolchain_c:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: f59351d28f49520cd3a74eb1f41c5f19ae15e53c65a3231d14af672e46510a96
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.1"
+    version: "0.19.2"
   node_preamble:
     dependency: transitive
     description:
@@ -1168,18 +1184,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      sha256: f5c435dc0e0d461e5b32471a870f769b6a1cc46930637efe24fbc535314e78ad
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.1"
+    version: "10.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      sha256: db762cb2f4f25ee60fb6359773861b0f199e00b90d237bd85a76a1e806b46ef4
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "4.1.0"
   path:
     dependency: "direct main"
     description:
@@ -1200,10 +1216,10 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.6"
   path_provider_android:
     dependency: transitive
     description:
@@ -1224,18 +1240,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   path_provider_windows:
     dependency: transitive
     description:
@@ -1248,10 +1264,10 @@ packages:
     dependency: "direct main"
     description:
       name: pdf
-      sha256: e47a275b267873d5944ad5f5ff0dcc7ac2e36c02b3046a0ffac9b72fd362c44b
+      sha256: "517df47af468734a23c8b513c0c6a8a62357403ab1b8ab7fad1606576a9dbdd0"
       url: "https://pub.dev"
     source: hosted
-    version: "3.12.0"
+    version: "3.13.0"
   pdf_widget_wrapper:
     dependency: transitive
     description:
@@ -1304,18 +1320,18 @@ packages:
     dependency: "direct main"
     description:
       name: postgres
-      sha256: fe4a19a69fad564efa8ced72d58b14e86d12a548f5f0a511b377089bf3b592ed
+      sha256: "123de5cbadc56a7e8d9fa485c780b6b56940b4081f4c74f3a5578682757c299b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.11"
+    version: "3.5.12"
   printing:
     dependency: "direct main"
     description:
       name: printing
-      sha256: "689170c9ddb1bda85826466ba80378aa8993486d3c959a71cd7d2d80cb606692"
+      sha256: f6cd14c768c1352dd37a958a3ee351aa9ce305b398218d3acd86389d5f7ecad1
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.3"
+    version: "5.15.0"
   process:
     dependency: transitive
     description:
@@ -1384,26 +1400,26 @@ packages:
     dependency: "direct dev"
     description:
       name: retrofit_generator
-      sha256: "7b7a7bbd61da2f2cac0646fc852515886c958cafad3c7f01f25b5b2bc451405b"
+      sha256: "0c6468f776e449de3886b0d68fa668943e005d884e618487fdf8b1323becdf88"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.6"
+    version: "10.2.7"
   riverpod:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "8c22216be8ad3ef2b44af3a329693558c98eca7b8bd4ef495c92db0bba279f83"
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.1"
+    version: "3.3.2"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "16471a1260b94e939394d78f1c63a9350936ac4a68c9fbdab40be47268c0b04f"
+      sha256: "674dbb26e2db3d9253166faf4758c796af14146b8fbcf5e7102bc8a04cd359b8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.0.3"
   rxdart:
     dependency: transitive
     description:
@@ -1416,50 +1432,50 @@ packages:
     dependency: transitive
     description:
       name: safe_local_storage
-      sha256: "287ea1f667c0b93cdc127dccc707158e2d81ee59fba0459c31a0c7da4d09c755"
+      sha256: "7483b3d5e8976f0bd263647c03b96131ee8e43f48b56fa8a8ec459e8515d74b0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   screen_retriever:
     dependency: transitive
     description:
       name: screen_retriever
-      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      sha256: ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_linux:
     dependency: transitive
     description:
       name: screen_retriever_linux
-      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      sha256: "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_macos:
     dependency: transitive
     description:
       name: screen_retriever_macos
-      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      sha256: a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_platform_interface:
     dependency: transitive
     description:
       name: screen_retriever_platform_interface
-      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      sha256: "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   screen_retriever_windows:
     dependency: transitive
     description:
       name: screen_retriever_windows
-      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      sha256: dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1472,10 +1488,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: a2c49fc1fed7140cadd892d765bd47edbe4ac0b9c7e7e3c493dcb58126f99cf0
+      sha256: "93ae5884a9df5d3bb696825bceb3a17590754548b5d740eba51500afc8d088f5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.25"
+    version: "2.4.26"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1613,18 +1629,18 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: cce558075afe2a83f3fd7fc123acd6b090683e4f23910d44fbb31ecd7800b014
+      sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
       url: "https://pub.dev"
     source: hosted
-    version: "2.5.9"
+    version: "2.5.11"
   sqflite_darwin:
     dependency: transitive
     description:
       name: sqflite_darwin
-      sha256: "164a5d73ab87a134566057219988bafde837029a64264e61f1f04376ef3cfcd2"
+      sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.3+1"
   sqflite_platform_interface:
     dependency: transitive
     description:
@@ -1645,10 +1661,10 @@ packages:
     dependency: "direct dev"
     description:
       name: sqlite3
-      sha256: "9488c7d2cdb1091c91cacf7e207cff81b28bff8e366f042bad3afe7d34afe189"
+      sha256: "752d9d746052359a2022f588bb979f2e7c4e0f9e4b6a1c3121f7626a1574974b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.2"
+    version: "3.3.4"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1661,10 +1677,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: ecdc06d4a7d79dcbc928d99afd2f7f5b0f98a637c46f89be83d911617f759978
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.44.4"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:
@@ -1757,10 +1773,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:
@@ -1933,18 +1949,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
       url: "https://pub.dev"
     source: hosted
-    version: "5.15.0"
+    version: "6.3.0"
   window_manager:
     dependency: "direct main"
     description:
       name: window_manager
-      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      sha256: "05c231fd7b23d2380f14c5cc10b7b93d60d4fa4a2fb4e0f032de27e44b5560e9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -1957,10 +1973,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.6.1"
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,37 +49,37 @@ dependencies:
   flutter_secure_storage: ^10.0.0
   cached_network_image: ^3.4.1
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.11.0
+  json_annotation: ^4.12.0
   uuid: ^4.5.3
   intl: ^0.20.2
   path_provider: ^2.1.5
   path: ^1.9.0
   window_manager: ^0.5.1
-  file_picker: ">=10.3.10 <11.0.0"
-  flutter_local_notifications: ^19.0.0
-  fl_chart: ^0.70.2
+  file_picker: ^12.0.0-beta.7
+  flutter_local_notifications: ^22.0.1
+  fl_chart: ^1.2.0
   shared_preferences: ^2.5.4
   data_table_2: ^2.7.2
-  package_info_plus: ^9.0.1
+  package_info_plus: ^10.2.0
   url_launcher: ^6.3.1
-  google_mlkit_text_recognition: ^0.15.1
+  google_mlkit_text_recognition: ^0.16.0
   image_picker: ^1.2.1
-  camera: ^0.11.4
+  camera: ^0.12.0+1
   camera_desktop: ^1.1.2
   flutter_zxing: ^2.2.1
-  just_audio: ^0.9.43
+  just_audio: ^0.10.6
   just_audio_media_kit: ^2.1.0
   ffi: ^2.2.0
   dart_metaflac: ^0.0.1
   dart_flac: ^0.0.1
   dart_accuraterip: ^0.0.3
-  audio_defect_detector: ^0.2.0
-  app_links: ^6.4.0
-  dart_rip_log: ^0.0.1
-  dart_cue: ^0.0.1
-  csv: ^6.0.0
-  pdf: ^3.11.0
-  printing: ^5.14.0
+  audio_defect_detector: ^0.3.0
+  app_links: ^7.2.1
+  dart_rip_log: ^0.1.0
+  dart_cue: ^0.1.1
+  csv: ^8.0.0
+  pdf: ^3.13.0
+  printing: ^5.15.0
 
 dev_dependencies:
   flutter_test:

--- a/test/_fakes/fake_file_picker.dart
+++ b/test/_fakes/fake_file_picker.dart
@@ -1,9 +1,9 @@
-/// Test fake for the [FilePicker] platform interface.
+/// Test fake for the [FilePickerPlatform] interface.
 ///
-/// `FilePicker.platform` is a static field on a platform-interface class,
+/// `FilePickerPlatform.instance` is a static platform singleton,
 /// which means tests cannot stub it via the usual mocktail / method-channel
 /// patterns — but the package does allow swapping the singleton. This
-/// helper extends [FilePicker], captures the arguments passed to
+/// helper extends [FilePickerPlatform], captures the arguments passed to
 /// [pickFiles], and returns whatever [FilePickerResult] the test seeds.
 ///
 /// Typical usage in a `testWidgets` body:
@@ -51,7 +51,7 @@ class FilePickerCall {
 /// [UnimplementedError] — fail-fast is intentional, so a screen reaching
 /// for a method other than [pickFiles] surfaces immediately rather than
 /// silently no-oping.
-class FakeFilePicker extends FilePicker {
+class FakeFilePicker extends FilePickerPlatform {
   FakeFilePicker({this.result});
 
   /// The canned result returned from [pickFiles]. `null` simulates the
@@ -69,13 +69,14 @@ class FakeFilePicker extends FilePicker {
     FileType type = FileType.any,
     List<String>? allowedExtensions,
     Function(FilePickerStatus)? onFileLoading,
-    bool allowCompression = false,
     int compressionQuality = 0,
     bool allowMultiple = false,
     bool withData = false,
     bool withReadStream = false,
     bool lockParentWindow = false,
     bool readSequential = false,
+    bool cancelUploadOnWindowBlur = true,
+    AndroidSAFOptions? androidSafOptions,
   }) async {
     lastCall = FilePickerCall(
       type: type,
@@ -89,45 +90,36 @@ class FakeFilePicker extends FilePicker {
 
 /// Builds a single-file [FilePickerResult] with the given in-memory bytes.
 ///
-/// Mirrors the shape `FilePicker.platform.pickFiles(withData: true)`
-/// returns on the platforms the app uses (web/desktop), where
-/// [PlatformFile.bytes] is populated.
+/// Builds the shape returned by a platform picker with in-memory data.
 FilePickerResult buildBytesResult({
   required String name,
   required List<int> bytes,
 }) {
   return FilePickerResult([
-    PlatformFile(
-      name: name,
-      size: bytes.length,
-      bytes: Uint8List.fromList(bytes),
-    ),
+    PlatformFile.fromMap({
+      'name': name,
+      'size': bytes.length,
+      'bytes': Uint8List.fromList(bytes),
+      'path': null,
+      'identifier': null,
+    }),
   ]);
 }
 
-/// Installs [FakeFilePicker] as `FilePicker.platform` for the duration of
+/// Installs [FakeFilePicker] as `FilePickerPlatform.instance` for the duration of
 /// the current widget test, then restores the previous instance during
 /// tearDown. Always reach for this helper rather than swapping
-/// `FilePicker.platform` by hand so tests do not leak overrides between
+/// `FilePickerPlatform.instance` by hand so tests do not leak overrides between
 /// each other.
 FakeFilePicker installFakeFilePicker(
   WidgetTester tester, {
   FilePickerResult? result,
 }) {
-  // FilePicker.platform is a `late` field so the very first read may
-  // throw; defer the restore through a captured reference.
-  FilePicker? previous;
-  try {
-    previous = FilePicker.platform;
-  } catch (_) {
-    previous = null;
-  }
+  final previous = FilePickerPlatform.instance;
   final fake = FakeFilePicker(result: result);
-  FilePicker.platform = fake;
+  FilePickerPlatform.instance = fake;
   addTearDown(() {
-    if (previous != null) {
-      FilePicker.platform = previous;
-    }
+    FilePickerPlatform.instance = previous;
   });
   return fake;
 }

--- a/test/_fakes/fake_printing_platform.dart
+++ b/test/_fakes/fake_printing_platform.dart
@@ -79,27 +79,26 @@ class FakePrintingPlatform extends PrintingPlatform {
     bool usePrinterSettings,
     OutputType outputType,
     bool forceCustomPrintPaper,
+    bool windowsModernDialog,
   ) async {
     final bytes = await onLayout(format);
-    layoutPdfCalls.add(LayoutPdfCall(
-      name: name,
-      bytes: bytes,
-      format: format,
-    ));
+    layoutPdfCalls.add(LayoutPdfCall(name: name, bytes: bytes, format: format));
     return layoutResult;
   }
 
   @override
-  Future<PrintingInfo> info() async => throw UnimplementedError(
-      'FakePrintingPlatform.info is not stubbed.');
+  Future<PrintingInfo> info() async =>
+      throw UnimplementedError('FakePrintingPlatform.info is not stubbed.');
 
   @override
   Future<List<Printer>> listPrinters() async => throw UnimplementedError(
-      'FakePrintingPlatform.listPrinters is not stubbed.');
+    'FakePrintingPlatform.listPrinters is not stubbed.',
+  );
 
   @override
   Future<Printer?> pickPrinter(Rect bounds) async => throw UnimplementedError(
-      'FakePrintingPlatform.pickPrinter is not stubbed.');
+    'FakePrintingPlatform.pickPrinter is not stubbed.',
+  );
 
   @override
   Future<bool> sharePdf(
@@ -110,26 +109,22 @@ class FakePrintingPlatform extends PrintingPlatform {
     String? body,
     List<String>? emails,
   ) async =>
-      throw UnimplementedError(
-          'FakePrintingPlatform.sharePdf is not stubbed.');
+      throw UnimplementedError('FakePrintingPlatform.sharePdf is not stubbed.');
 
   @override
   Future<Uint8List> convertHtml(
     String html,
     String? baseUrl,
     PdfPageFormat format,
-  ) async =>
-      throw UnimplementedError(
-          'FakePrintingPlatform.convertHtml is not stubbed.');
+  ) async => throw UnimplementedError(
+    'FakePrintingPlatform.convertHtml is not stubbed.',
+  );
 
   @override
-  Stream<PdfRaster> raster(
-    Uint8List document,
-    List<int>? pages,
-    double dpi,
-  ) =>
-      Stream.error(UnimplementedError(
-          'FakePrintingPlatform.raster is not stubbed.'));
+  Stream<PdfRaster> raster(Uint8List document, List<int>? pages, double dpi) =>
+      Stream.error(
+        UnimplementedError('FakePrintingPlatform.raster is not stubbed.'),
+      );
 }
 
 /// Installs a [FakePrintingPlatform] as `PrintingPlatform.instance` for

--- a/test/unit/core/services/audio/audio_player_service_test.dart
+++ b/test/unit/core/services/audio/audio_player_service_test.dart
@@ -61,6 +61,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakeAudioSource());
+    registerFallbackValue(<AudioSource>[FakeAudioSource()]);
     registerFallbackValue(LoopMode.off);
     registerFallbackValue(Duration.zero);
   });
@@ -69,16 +70,21 @@ void main() {
     mockPlayer = MockAudioPlayer();
 
     // Default stubs for stream getters
-    when(() => mockPlayer.positionStream)
-        .thenAnswer((_) => const Stream<Duration>.empty());
-    when(() => mockPlayer.durationStream)
-        .thenAnswer((_) => const Stream<Duration?>.empty());
-    when(() => mockPlayer.playerStateStream)
-        .thenAnswer((_) => const Stream<PlayerState>.empty());
-    when(() => mockPlayer.currentIndexStream)
-        .thenAnswer((_) => const Stream<int?>.empty());
-    when(() => mockPlayer.sequenceStateStream)
-        .thenAnswer((_) => const Stream<SequenceState?>.empty());
+    when(
+      () => mockPlayer.positionStream,
+    ).thenAnswer((_) => const Stream<Duration>.empty());
+    when(
+      () => mockPlayer.durationStream,
+    ).thenAnswer((_) => const Stream<Duration?>.empty());
+    when(
+      () => mockPlayer.playerStateStream,
+    ).thenAnswer((_) => const Stream<PlayerState>.empty());
+    when(
+      () => mockPlayer.currentIndexStream,
+    ).thenAnswer((_) => const Stream<int?>.empty());
+    when(
+      () => mockPlayer.sequenceStateStream,
+    ).thenAnswer((_) => const Stream<SequenceState>.empty());
     when(() => mockPlayer.playing).thenReturn(false);
 
     service = AudioPlayerService(player: mockPlayer);
@@ -106,8 +112,9 @@ void main() {
     group('stream delegation', () {
       test('positionStream delegates to player', () {
         final controller = StreamController<Duration>.broadcast();
-        when(() => mockPlayer.positionStream)
-            .thenAnswer((_) => controller.stream);
+        when(
+          () => mockPlayer.positionStream,
+        ).thenAnswer((_) => controller.stream);
 
         final stream = service.positionStream;
         expect(stream, isA<Stream<Duration>>());
@@ -117,8 +124,9 @@ void main() {
 
       test('durationStream delegates to player', () {
         final controller = StreamController<Duration?>.broadcast();
-        when(() => mockPlayer.durationStream)
-            .thenAnswer((_) => controller.stream);
+        when(
+          () => mockPlayer.durationStream,
+        ).thenAnswer((_) => controller.stream);
 
         final stream = service.durationStream;
         expect(stream, isA<Stream<Duration?>>());
@@ -128,8 +136,9 @@ void main() {
 
       test('playerStateStream delegates to player', () {
         final controller = StreamController<PlayerState>.broadcast();
-        when(() => mockPlayer.playerStateStream)
-            .thenAnswer((_) => controller.stream);
+        when(
+          () => mockPlayer.playerStateStream,
+        ).thenAnswer((_) => controller.stream);
 
         final stream = service.playerStateStream;
         expect(stream, isA<Stream<PlayerState>>());
@@ -139,8 +148,9 @@ void main() {
 
       test('currentIndexStream delegates to player', () {
         final controller = StreamController<int?>.broadcast();
-        when(() => mockPlayer.currentIndexStream)
-            .thenAnswer((_) => controller.stream);
+        when(
+          () => mockPlayer.currentIndexStream,
+        ).thenAnswer((_) => controller.stream);
 
         final stream = service.currentIndexStream;
         expect(stream, isA<Stream<int?>>());
@@ -149,9 +159,10 @@ void main() {
       });
 
       test('sequenceStateStream delegates to player', () {
-        final controller = StreamController<SequenceState?>.broadcast();
-        when(() => mockPlayer.sequenceStateStream)
-            .thenAnswer((_) => controller.stream);
+        final controller = StreamController<SequenceState>.broadcast();
+        when(
+          () => mockPlayer.sequenceStateStream,
+        ).thenAnswer((_) => controller.stream);
 
         final stream = service.sequenceStateStream;
         expect(stream, isA<Stream<SequenceState?>>());
@@ -162,43 +173,53 @@ void main() {
 
     group('playAlbum', () {
       test('sets currentAlbum and currentTracks', () async {
-        when(() => mockPlayer.setAudioSource(any(), initialIndex: any(named: 'initialIndex')))
-            .thenAnswer((_) async => const Duration(seconds: 600));
+        when(
+          () => mockPlayer.setAudioSources(
+            any(),
+            initialIndex: any(named: 'initialIndex'),
+          ),
+        ).thenAnswer((_) async => const Duration(seconds: 600));
         when(() => mockPlayer.play()).thenAnswer((_) async {});
 
-        await service.playAlbum(
-          album: testAlbum,
-          tracks: testTracks,
-        );
+        await service.playAlbum(album: testAlbum, tracks: testTracks);
 
         expect(service.currentAlbum, testAlbum);
         expect(service.currentTracks, testTracks);
         expect(service.currentTracks, isA<List<RipTrack>>());
       });
 
-      test('calls setAudioSource with ConcatenatingAudioSource', () async {
-        when(() => mockPlayer.setAudioSource(any(), initialIndex: any(named: 'initialIndex')))
-            .thenAnswer((_) async => const Duration(seconds: 600));
+      test('calls setAudioSources with every track source', () async {
+        when(
+          () => mockPlayer.setAudioSources(
+            any(),
+            initialIndex: any(named: 'initialIndex'),
+          ),
+        ).thenAnswer((_) async => const Duration(seconds: 600));
         when(() => mockPlayer.play()).thenAnswer((_) async {});
 
-        await service.playAlbum(
-          album: testAlbum,
-          tracks: testTracks,
-        );
+        await service.playAlbum(album: testAlbum, tracks: testTracks);
 
         final captured = verify(
-          () => mockPlayer.setAudioSource(
+          () => mockPlayer.setAudioSources(
             captureAny(),
             initialIndex: any(named: 'initialIndex'),
           ),
         ).captured;
 
-        expect(captured.first, isA<ConcatenatingAudioSource>());
+        expect(captured.single, isA<List<AudioSource>>());
+        expect(
+          captured.single as List<AudioSource>,
+          hasLength(testTracks.length),
+        );
       });
 
-      test('passes startIndex to setAudioSource', () async {
-        when(() => mockPlayer.setAudioSource(any(), initialIndex: any(named: 'initialIndex')))
-            .thenAnswer((_) async => const Duration(seconds: 600));
+      test('passes startIndex to setAudioSources', () async {
+        when(
+          () => mockPlayer.setAudioSources(
+            any(),
+            initialIndex: any(named: 'initialIndex'),
+          ),
+        ).thenAnswer((_) async => const Duration(seconds: 600));
         when(() => mockPlayer.play()).thenAnswer((_) async {});
 
         await service.playAlbum(
@@ -208,35 +229,34 @@ void main() {
         );
 
         verify(
-          () => mockPlayer.setAudioSource(
-            any(),
-            initialIndex: 2,
-          ),
+          () => mockPlayer.setAudioSources(any(), initialIndex: 2),
         ).called(1);
       });
 
       test('calls play after setting audio source', () async {
-        when(() => mockPlayer.setAudioSource(any(), initialIndex: any(named: 'initialIndex')))
-            .thenAnswer((_) async => const Duration(seconds: 600));
+        when(
+          () => mockPlayer.setAudioSources(
+            any(),
+            initialIndex: any(named: 'initialIndex'),
+          ),
+        ).thenAnswer((_) async => const Duration(seconds: 600));
         when(() => mockPlayer.play()).thenAnswer((_) async {});
 
-        await service.playAlbum(
-          album: testAlbum,
-          tracks: testTracks,
-        );
+        await service.playAlbum(album: testAlbum, tracks: testTracks);
 
         verify(() => mockPlayer.play()).called(1);
       });
 
       test('currentTracks is unmodifiable', () async {
-        when(() => mockPlayer.setAudioSource(any(), initialIndex: any(named: 'initialIndex')))
-            .thenAnswer((_) async => const Duration(seconds: 600));
+        when(
+          () => mockPlayer.setAudioSources(
+            any(),
+            initialIndex: any(named: 'initialIndex'),
+          ),
+        ).thenAnswer((_) async => const Duration(seconds: 600));
         when(() => mockPlayer.play()).thenAnswer((_) async {});
 
-        await service.playAlbum(
-          album: testAlbum,
-          tracks: testTracks,
-        );
+        await service.playAlbum(album: testAlbum, tracks: testTracks);
 
         expect(
           () => (service.currentTracks as List).add(testTracks.first),
@@ -276,15 +296,16 @@ void main() {
 
       test('clears currentAlbum and currentTracks', () async {
         // First play an album
-        when(() => mockPlayer.setAudioSource(any(), initialIndex: any(named: 'initialIndex')))
-            .thenAnswer((_) async => const Duration(seconds: 600));
+        when(
+          () => mockPlayer.setAudioSources(
+            any(),
+            initialIndex: any(named: 'initialIndex'),
+          ),
+        ).thenAnswer((_) async => const Duration(seconds: 600));
         when(() => mockPlayer.play()).thenAnswer((_) async {});
         when(() => mockPlayer.stop()).thenAnswer((_) async {});
 
-        await service.playAlbum(
-          album: testAlbum,
-          tracks: testTracks,
-        );
+        await service.playAlbum(album: testAlbum, tracks: testTracks);
 
         expect(service.currentAlbum, isNotNull);
         expect(service.currentTracks, isNotEmpty);
@@ -349,8 +370,9 @@ void main() {
 
     group('setShuffleEnabled', () {
       test('calls setShuffleModeEnabled on the underlying player', () async {
-        when(() => mockPlayer.setShuffleModeEnabled(any()))
-            .thenAnswer((_) async {});
+        when(
+          () => mockPlayer.setShuffleModeEnabled(any()),
+        ).thenAnswer((_) async {});
 
         await service.setShuffleEnabled(true);
 

--- a/test/widget/presentation/screens/import/import_screen_test.dart
+++ b/test/widget/presentation/screens/import/import_screen_test.dart
@@ -7,7 +7,7 @@
 //      phase.
 //   3. A result summary ("Imported N items") is shown after import completes.
 //   4. An error message is surfaced when the phase is error.
-//   5. The Choose-file… button drives FilePicker.platform.pickFiles with the
+//   5. The Choose-file… button drives FilePicker.pickFiles with the
 //      source's expected extension and forwards the picked bytes to the
 //      ImportNotifier (uses the fake_file_picker scaffolding under
 //      test/_fakes/).
@@ -71,33 +71,27 @@ class _StubImportNotifier extends ImportNotifier {
 /// Builds a [GoRouter] that knows about the collection route so that
 /// "View collection" navigation doesn't throw.
 GoRouter _router({String initialLocation = '/import'}) => GoRouter(
-      initialLocation: initialLocation,
-      routes: [
-        GoRoute(
-          path: '/import',
-          builder: (_, _) => const ImportScreen(),
-        ),
-        GoRoute(
-          path: '/collection',
-          builder: (_, _) => const Scaffold(body: Text('collection')),
-        ),
-      ],
-    );
+  initialLocation: initialLocation,
+  routes: [
+    GoRoute(path: '/import', builder: (_, _) => const ImportScreen()),
+    GoRoute(
+      path: '/collection',
+      builder: (_, _) => const Scaffold(body: Text('collection')),
+    ),
+  ],
+);
 
 /// Wraps [ImportScreen] with a ProviderScope that overrides
 /// [importNotifierProvider] using [notifier].
 Widget _wrap(_StubImportNotifier notifier, {GoRouter? router}) {
   return ProviderScope(
-    overrides: [
-      importNotifierProvider.overrideWith(() => notifier),
-    ],
+    overrides: [importNotifierProvider.overrideWith(() => notifier)],
     child: MaterialApp.router(routerConfig: router ?? _router()),
   );
 }
 
 /// Creates a stub notifier pre-set to [state].
-_StubImportNotifier _notifier(ImportState state) =>
-    _StubImportNotifier(state);
+_StubImportNotifier _notifier(ImportState state) => _StubImportNotifier(state);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -105,9 +99,9 @@ _StubImportNotifier _notifier(ImportState state) =>
 
 void main() {
   group('ImportScreen — idle state', () {
-    testWidgets(
-        'renders the format selector showing all four import sources',
-        (tester) async {
+    testWidgets('renders the format selector showing all four import sources', (
+      tester,
+    ) async {
       final stub = _notifier(const ImportState());
 
       await tester.pumpWidget(_wrap(stub));
@@ -129,9 +123,9 @@ void main() {
       expect(find.text('Trakt (.json)'), findsOneWidget);
     });
 
-    testWidgets(
-        'shows the "Choose file…" button in idle phase',
-        (tester) async {
+    testWidgets('shows the "Choose file…" button in idle phase', (
+      tester,
+    ) async {
       final stub = _notifier(const ImportState());
 
       await tester.pumpWidget(_wrap(stub));
@@ -142,9 +136,9 @@ void main() {
   });
 
   group('ImportScreen — enriching phase', () {
-    testWidgets(
-        'displays a progress indicator while the use case is running',
-        (tester) async {
+    testWidgets('displays a progress indicator while the use case is running', (
+      tester,
+    ) async {
       // Build rows that simulate an in-progress enrichment (3 of 5 done).
       final rows = List.generate(
         5,
@@ -174,13 +168,10 @@ void main() {
   });
 
   group('ImportScreen — done phase', () {
-    testWidgets(
-        'shows a result summary after import completes',
-        (tester) async {
-      const doneState = ImportState(
-        phase: ImportPhase.done,
-        savedCount: 8,
-      );
+    testWidgets('shows a result summary after import completes', (
+      tester,
+    ) async {
+      const doneState = ImportState(phase: ImportPhase.done, savedCount: 8);
 
       final stub = _notifier(doneState);
 
@@ -192,13 +183,10 @@ void main() {
       expect(find.text('View collection'), findsOneWidget);
     });
 
-    testWidgets(
-        'singular grammar when exactly one item is imported',
-        (tester) async {
-      const doneState = ImportState(
-        phase: ImportPhase.done,
-        savedCount: 1,
-      );
+    testWidgets('singular grammar when exactly one item is imported', (
+      tester,
+    ) async {
+      const doneState = ImportState(phase: ImportPhase.done, savedCount: 1);
 
       final stub = _notifier(doneState);
 
@@ -210,9 +198,9 @@ void main() {
   });
 
   group('ImportScreen — error phase', () {
-    testWidgets(
-        'shows an error message when the import throws',
-        (tester) async {
+    testWidgets('shows an error message when the import throws', (
+      tester,
+    ) async {
       const errorState = ImportState(
         phase: ImportPhase.error,
         errorMessage: 'Could not parse file: unexpected column header',
@@ -231,26 +219,27 @@ void main() {
     });
 
     testWidgets(
-        'shows "Unknown error" when errorMessage is null in error phase',
-        (tester) async {
-      const errorState = ImportState(
-        phase: ImportPhase.error,
-        // errorMessage intentionally null.
-      );
+      'shows "Unknown error" when errorMessage is null in error phase',
+      (tester) async {
+        const errorState = ImportState(
+          phase: ImportPhase.error,
+          // errorMessage intentionally null.
+        );
 
-      final stub = _notifier(errorState);
+        final stub = _notifier(errorState);
 
-      await tester.pumpWidget(_wrap(stub));
-      await tester.pumpAndSettle();
+        await tester.pumpWidget(_wrap(stub));
+        await tester.pumpAndSettle();
 
-      expect(find.text('Unknown error'), findsOneWidget);
-    });
+        expect(find.text('Unknown error'), findsOneWidget);
+      },
+    );
   });
 
   group('ImportScreen — parsing phase', () {
-    testWidgets(
-        'shows a spinner and "Parsing file…" label during parsing',
-        (tester) async {
+    testWidgets('shows a spinner and "Parsing file…" label during parsing', (
+      tester,
+    ) async {
       const parsingState = ImportState(
         phase: ImportPhase.parsing,
         source: ImportSource.discogs,
@@ -270,9 +259,9 @@ void main() {
   });
 
   group('ImportScreen — saving phase', () {
-    testWidgets(
-        'shows a spinner and "Saving items…" label during save',
-        (tester) async {
+    testWidgets('shows a spinner and "Saving items…" label during save', (
+      tester,
+    ) async {
       const savingState = ImportState(
         phase: ImportPhase.saving,
         source: ImportSource.letterboxd,
@@ -291,10 +280,8 @@ void main() {
   });
 
   group('ImportScreen — Choose-file flow', () {
-    testWidgets(
-        'pickFiles is called with the source extension and the picked '
-        'bytes are forwarded to startImport',
-        (tester) async {
+    testWidgets('pickFiles is called with the source extension and the picked '
+        'bytes are forwarded to startImport', (tester) async {
       const csv = 'Title,Author\nNeuromancer,William Gibson\n';
       final fake = installFakeFilePicker(
         tester,
@@ -312,10 +299,10 @@ void main() {
       await tester.tap(find.text('Choose file…'));
       await tester.pumpAndSettle();
 
-      // The screen requested CSV files with bytes inlined.
+      // The screen requested one CSV file and read its bytes on demand.
       expect(fake.lastCall, isNotNull);
       expect(fake.lastCall!.allowedExtensions, ['csv']);
-      expect(fake.lastCall!.withData, isTrue);
+      expect(fake.lastCall!.withData, isFalse);
       expect(fake.lastCall!.allowMultiple, isFalse);
 
       // The notifier received the file's bytes and the active source.
@@ -323,9 +310,9 @@ void main() {
       expect(stub.lastImportContent, csv);
     });
 
-    testWidgets(
-        'no startImport call when the user cancels the picker',
-        (tester) async {
+    testWidgets('no startImport call when the user cancels the picker', (
+      tester,
+    ) async {
       installFakeFilePicker(tester); // result: null → user cancelled
 
       final stub = _notifier(const ImportState());


### PR DESCRIPTION
## Summary

- upgrade Dart and Flutter dependencies to their latest mutually compatible versions
- migrate notification, CSV, file-picker, audio playlist, PDF, and printing APIs for breaking releases
- regenerate Drift output and update affected test fakes and assertions

## Impact

The application now uses the current compatible dependency graph, including `pdf` 3.13.0 and `printing` 5.15.0. Existing import, playback, notification, database, and label-printing behavior is preserved through the required API migrations.

`drift_dev` remains at 2.34.0 because newer releases require analyzer 13, while the latest stable Freezed release requires analyzer below 11.

## Validation

- `flutter analyze`
- `flutter test` (1,681 tests passed)
- `git diff --check`
