### PR TITLE
Rips: align Coverage & Playlists tabs with themed design

### DIFF
--- a/lib/domain/entities/rip_coverage.dart
+++ b/lib/domain/entities/rip_coverage.dart
@@ -1,0 +1,106 @@
+// Author: Paul Snow
+
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
+
+/// Rip coverage status for a physical music item, comparing the collection
+/// against the linked FLAC rip album.
+enum CoverageStatus { notRipped, partiallyRipped, fullyRipped, qualityIssues }
+
+/// One music item paired with its linked rip album (if any) and derived
+/// coverage status.
+class RipCoverageEntry {
+  const RipCoverageEntry({
+    required this.item,
+    required this.album,
+    required this.status,
+  });
+
+  final MediaItem item;
+  final RipAlbum? album;
+  final CoverageStatus status;
+}
+
+/// Categorise each music item's rip coverage.
+///
+/// `tracksByAlbum` supplies analysed tracks (keyed by rip album ID) used to
+/// escalate a fully-ripped album to [CoverageStatus.qualityIssues] when a
+/// track has an AccurateRip mismatch or recorded defects. Quality is only
+/// considered once analysis has run (`qualityCheckedAt` set). Entries are
+/// returned sorted by status index (notRipped first).
+List<RipCoverageEntry> categoriseRipCoverage({
+  required List<MediaItem> items,
+  required List<RipAlbum> albums,
+  required Map<String, List<RipTrack>> tracksByAlbum,
+}) {
+  final albumByMediaId = <String, RipAlbum>{};
+  for (final album in albums) {
+    if (album.mediaItemId != null) {
+      albumByMediaId[album.mediaItemId!] = album;
+    }
+  }
+
+  return items.map((item) {
+    final linked = albumByMediaId[item.id];
+    if (linked == null) {
+      return RipCoverageEntry(
+        item: item,
+        album: null,
+        status: CoverageStatus.notRipped,
+      );
+    }
+
+    final trackListing = item.extraMetadata['track_listing'];
+    final expectedTracks = trackListing is List ? trackListing.length : 0;
+    final fullyRipped =
+        expectedTracks == 0 || linked.trackCount >= expectedTracks;
+    if (!fullyRipped) {
+      return RipCoverageEntry(
+        item: item,
+        album: linked,
+        status: CoverageStatus.partiallyRipped,
+      );
+    }
+
+    final tracks = tracksByAlbum[linked.id] ?? const <RipTrack>[];
+    final anyChecked = tracks.any((t) => t.qualityCheckedAt != null);
+    final hasQualityIssues = anyChecked &&
+        tracks.any((t) =>
+            t.accurateRipStatus == 'mismatch' || t.totalDefects > 0);
+    return RipCoverageEntry(
+      item: item,
+      album: linked,
+      status: hasQualityIssues
+          ? CoverageStatus.qualityIssues
+          : CoverageStatus.fullyRipped,
+    );
+  }).toList()
+    ..sort((a, b) => a.status.index.compareTo(b.status.index));
+}
+
+/// Library-wide aggregate of rip coverage for the header stat cards.
+class RipCoverageStats {
+  const RipCoverageStats({required this.counts, required this.total});
+
+  final Map<CoverageStatus, int> counts;
+  final int total;
+
+  int countOf(CoverageStatus status) => counts[status] ?? 0;
+
+  /// Items with a complete rip (fully ripped, with or without quality issues).
+  int get rippedCount =>
+      countOf(CoverageStatus.fullyRipped) +
+      countOf(CoverageStatus.qualityIssues);
+
+  int get coveragePercent =>
+      total == 0 ? 0 : (rippedCount * 100 / total).round();
+}
+
+RipCoverageStats computeRipCoverageStats(List<RipCoverageEntry> entries) {
+  final counts = {for (final s in CoverageStatus.values) s: 0};
+  for (final entry in entries) {
+    counts[entry.status] = counts[entry.status]! + 1;
+  }
+  return RipCoverageStats(counts: counts, total: entries.length);
+}

--- a/lib/presentation/providers/rip_coverage_provider.dart
+++ b/lib/presentation/providers/rip_coverage_provider.dart
@@ -1,0 +1,35 @@
+// Author: Paul Snow
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/rip_coverage.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/providers/rip_health_provider.dart';
+import 'package:mymediascanner/presentation/providers/rip_provider.dart';
+
+/// All music items in the collection — the denominator for rip coverage.
+final ripCoverageMusicItemsProvider = StreamProvider<List<MediaItem>>((ref) {
+  return ref
+      .watch(mediaItemRepositoryProvider)
+      .watchAll(mediaType: MediaType.music);
+});
+
+/// Music items categorised by rip coverage, reusing the library-wide
+/// all-tracks stream so quality-issue escalation stays in sync with analysis.
+final ripCoverageEntriesProvider = Provider<List<RipCoverageEntry>>((ref) {
+  final items = ref.watch(ripCoverageMusicItemsProvider).value ?? const [];
+  final albums = ref.watch(allRipAlbumsProvider).value ?? const [];
+  final tracksByAlbum =
+      ref.watch(ripAllTracksByAlbumProvider).value ?? const {};
+  return categoriseRipCoverage(
+    items: items,
+    albums: albums,
+    tracksByAlbum: tracksByAlbum,
+  );
+});
+
+/// Aggregate coverage stats for the Coverage tab header cards.
+final ripCoverageStatsProvider = Provider<RipCoverageStats>((ref) {
+  return computeRipCoverageStats(ref.watch(ripCoverageEntriesProvider));
+});

--- a/lib/presentation/screens/rips/rips_screen.dart
+++ b/lib/presentation/screens/rips/rips_screen.dart
@@ -27,13 +27,21 @@ class _RipsScreenState extends ConsumerState<RipsScreen> {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const ScreenHeader(
-            title: 'Rip Library',
+          ScreenHeader(
+            title: switch (_selected) {
+              _RipsSegment.library => 'Rip Library',
+              _RipsSegment.coverage => 'Rip Coverage',
+              _RipsSegment.playlists => 'Playlists',
+            },
             eyebrow: 'FLAC RIP COLLECTION',
             subtitle:
                 'Manage your FLAC rip collection and compare coverage '
                 'against physical media.',
-            actions: [RipHealthStatCards()],
+            actions: switch (_selected) {
+              _RipsSegment.library => const [RipHealthStatCards()],
+              _RipsSegment.coverage => const [RipCoverageStatCards()],
+              _RipsSegment.playlists => const [],
+            },
           ),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/presentation/screens/rips/widgets/playlist_view.dart
+++ b/lib/presentation/screens/rips/widgets/playlist_view.dart
@@ -9,6 +9,7 @@ library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mymediascanner/app/theme/app_typography.dart';
 import 'package:mymediascanner/data/local/database/app_database.dart';
 import 'package:mymediascanner/presentation/providers/playlist_provider.dart';
 import 'package:mymediascanner/presentation/screens/rips/widgets/playback_widgets.dart';
@@ -73,9 +74,11 @@ class _PlaylistGrid extends ConsumerWidget {
             child: Row(
               children: [
                 Text(
-                  'My Playlists',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
+                  'MY PLAYLISTS',
+                  style: AppTypography.monoLabel(
+                    color: colors.onSurfaceVariant,
+                    fontSize: 11,
+                    letterSpacing: 1.5,
                   ),
                 ),
                 const Spacer(),
@@ -268,31 +271,33 @@ class _PlaylistCard extends ConsumerWidget {
                     playlist.name,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                      color: isSelected ? colors.primary : null,
+                    style: AppTypography.displayTitle(
+                      color: isSelected ? colors.primary : colors.onSurface,
+                      fontSize: 14,
                     ),
                   ),
-                  const SizedBox(height: 2),
+                  const SizedBox(height: 4),
                   Row(
                     children: [
                       Expanded(
                         child: Text(
-                          trackCountStr,
-                          style: theme.textTheme.bodySmall?.copyWith(
-                            color:
-                                colors.onSurfaceVariant.withValues(alpha: 0.7),
-                            fontSize: 11,
+                          trackCountStr.toUpperCase(),
+                          style: AppTypography.monoLabel(
+                            color: colors.onSurfaceVariant,
+                            fontSize: 9.5,
+                            letterSpacing: 0.4,
+                            fontWeight: FontWeight.w600,
                           ),
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),
                       Text(
                         dateStr,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color:
-                              colors.onSurfaceVariant.withValues(alpha: 0.5),
-                          fontSize: 10,
+                        style: AppTypography.monoLabel(
+                          color: colors.onSurfaceVariant.withValues(alpha: 0.6),
+                          fontSize: 9.5,
+                          letterSpacing: 0.2,
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
                     ],

--- a/lib/presentation/screens/rips/widgets/rip_coverage_view.dart
+++ b/lib/presentation/screens/rips/widgets/rip_coverage_view.dart
@@ -1,27 +1,17 @@
+// Author: Paul Snow
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:mymediascanner/app/theme/app_media_colors.dart';
-import 'package:mymediascanner/domain/entities/media_item.dart';
-import 'package:mymediascanner/domain/entities/media_type.dart';
-import 'package:mymediascanner/domain/entities/rip_album.dart';
-import 'package:mymediascanner/domain/entities/rip_track.dart';
-import 'package:mymediascanner/presentation/providers/repository_providers.dart';
-import 'package:mymediascanner/presentation/providers/rip_provider.dart';
-import 'package:mymediascanner/presentation/widgets/error_state.dart';
-import 'package:mymediascanner/presentation/widgets/loading_indicator.dart';
+import 'package:mymediascanner/app/theme/app_typography.dart';
+import 'package:mymediascanner/domain/entities/rip_coverage.dart';
+import 'package:mymediascanner/presentation/providers/rip_coverage_provider.dart';
+import 'package:mymediascanner/presentation/screens/rips/widgets/rip_cover_thumb.dart';
+import 'package:mymediascanner/presentation/screens/rips/widgets/rip_health_widgets.dart';
 
-/// Coverage status for a music item.
-enum CoverageStatus { notRipped, partiallyRipped, fullyRipped, qualityIssues }
-
-/// Provider that watches all music items from the collection.
-final _musicItemsProvider = StreamProvider<List<MediaItem>>((ref) {
-  return ref
-      .watch(mediaItemRepositoryProvider)
-      .watchAll(mediaType: MediaType.music);
-});
-
-/// Displays rip coverage across the music collection.
+/// Displays rip coverage across the music collection: how much of the
+/// physical CD collection has been ripped to FLAC, and the quality of those
+/// rips. Aggregate counts live in the screen header ([RipCoverageStatCards]).
 class RipCoverageView extends ConsumerStatefulWidget {
   const RipCoverageView({super.key});
 
@@ -34,279 +24,212 @@ class _RipCoverageViewState extends ConsumerState<RipCoverageView> {
 
   @override
   Widget build(BuildContext context) {
-    final musicAsync = ref.watch(_musicItemsProvider);
-    final albumsAsync = ref.watch(allRipAlbumsProvider);
+    final entries = ref.watch(ripCoverageEntriesProvider);
+    final stats = ref.watch(ripCoverageStatsProvider);
 
-    return musicAsync.when(
-      loading: () => const LoadingIndicator(),
-      error: (e, _) => ErrorState(
-        message: e.toString(),
-        onRetry: () => ref.invalidate(_musicItemsProvider),
-      ),
-      data: (musicItems) {
-        return albumsAsync.when(
-          loading: () => const LoadingIndicator(),
-          error: (e, _) => ErrorState(
-            message: e.toString(),
-            onRetry: () => ref.invalidate(allRipAlbumsProvider),
-          ),
-          data: (ripAlbums) {
-            final categorised = _categorise(musicItems, ripAlbums);
-            final filtered = _activeFilters.isEmpty
-                ? categorised
-                : categorised
-                    .where((e) => _activeFilters.contains(e.status))
-                    .toList();
+    final filtered = _activeFilters.isEmpty
+        ? entries
+        : entries.where((e) => _activeFilters.contains(e.status)).toList();
 
-            final rippedCount = categorised
-                .where((e) =>
-                    e.status == CoverageStatus.fullyRipped ||
-                    e.status == CoverageStatus.qualityIssues)
-                .length;
-
-            final pct = musicItems.isEmpty
-                ? 0
-                : (rippedCount * 100 / musicItems.length).round();
-
-            return Column(
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
               children: [
-                _SummaryBar(
-                  rippedCount: rippedCount,
-                  totalCount: musicItems.length,
-                  percentage: pct,
-                ),
-                Padding(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                  child: Wrap(
-                    spacing: 8,
-                    children: CoverageStatus.values.map((status) {
-                      return FilterChip(
-                        label: Text(_statusLabel(status)),
-                        avatar: Icon(_statusIcon(status),
-                            size: 16, color: _statusColour(context, status)),
-                        selected: _activeFilters.contains(status),
-                        onSelected: (selected) {
-                          setState(() {
-                            if (selected) {
-                              _activeFilters = {..._activeFilters, status};
-                            } else {
-                              _activeFilters = {..._activeFilters}
-                                ..remove(status);
-                            }
-                          });
-                        },
-                      );
-                    }).toList(),
+                for (final status in CoverageStatus.values) ...[
+                  _CoverageFilterChip(
+                    status: status,
+                    count: stats.countOf(status),
+                    selected: _activeFilters.contains(status),
+                    onSelected: (selected) {
+                      setState(() {
+                        _activeFilters = {..._activeFilters};
+                        if (selected) {
+                          _activeFilters.add(status);
+                        } else {
+                          _activeFilters.remove(status);
+                        }
+                      });
+                    },
                   ),
-                ),
-                Expanded(
-                  child: filtered.isEmpty
-                      ? const Center(
-                          child: Text('No items match the current filters.'))
-                      : ListView.builder(
-                          padding: const EdgeInsets.all(16),
-                          itemCount: filtered.length,
-                          itemBuilder: (context, index) {
-                            final entry = filtered[index];
-                            return _CoverageItemTile(entry: entry);
-                          },
-                        ),
-                ),
+                  const SizedBox(width: 8),
+                ],
               ],
-            );
-          },
-        );
-      },
+            ),
+          ),
+        ),
+        Expanded(
+          child: filtered.isEmpty
+              ? Center(
+                  child: Text(
+                    entries.isEmpty
+                        ? 'No music items in the collection yet.'
+                        : 'No items match the current filters.',
+                  ),
+                )
+              : ListView.separated(
+                  padding: const EdgeInsets.all(16),
+                  itemCount: filtered.length,
+                  separatorBuilder: (_, _) => const SizedBox(height: 10),
+                  itemBuilder: (context, index) =>
+                      _CoverageRow(entry: filtered[index]),
+                ),
+        ),
+      ],
     );
   }
-
-  List<_CoverageEntry> _categorise(
-    List<MediaItem> items,
-    List<RipAlbum> albums,
-  ) {
-    final albumByMediaId = <String, RipAlbum>{};
-    for (final album in albums) {
-      if (album.mediaItemId != null) {
-        albumByMediaId[album.mediaItemId!] = album;
-      }
-    }
-
-    return items.map((item) {
-      final linked = albumByMediaId[item.id];
-      if (linked == null) {
-        return _CoverageEntry(
-          item: item,
-          ripAlbum: null,
-          status: CoverageStatus.notRipped,
-        );
-      }
-
-      // Check track count from extraMetadata
-      final trackListing = item.extraMetadata['track_listing'];
-      final expectedTracks = trackListing is List ? trackListing.length : 0;
-      final actualTracks = linked.trackCount;
-
-      final fullyRipped =
-          expectedTracks == 0 || actualTracks >= expectedTracks;
-
-      if (!fullyRipped) {
-        return _CoverageEntry(
-          item: item,
-          ripAlbum: linked,
-          status: CoverageStatus.partiallyRipped,
-        );
-      }
-
-      // Check for quality issues (we'll refine this with track data later)
-      return _CoverageEntry(
-        item: item,
-        ripAlbum: linked,
-        status: CoverageStatus.fullyRipped,
-      );
-    }).toList()
-      ..sort((a, b) => a.status.index.compareTo(b.status.index));
-  }
 }
 
-class _CoverageEntry {
-  const _CoverageEntry({
-    required this.item,
-    required this.ripAlbum,
+String coverageStatusLabel(CoverageStatus status) => switch (status) {
+      CoverageStatus.notRipped => 'Not ripped',
+      CoverageStatus.partiallyRipped => 'Partially ripped',
+      CoverageStatus.fullyRipped => 'Fully ripped',
+      CoverageStatus.qualityIssues => 'Quality issues',
+    };
+
+IconData coverageStatusIcon(CoverageStatus status) => switch (status) {
+      CoverageStatus.notRipped => Icons.cancel,
+      CoverageStatus.partiallyRipped => Icons.timelapse,
+      CoverageStatus.fullyRipped => Icons.check_circle,
+      CoverageStatus.qualityIssues => Icons.warning,
+    };
+
+/// Pill-style filter chip mirroring the Library tab's health chips.
+class _CoverageFilterChip extends StatelessWidget {
+  const _CoverageFilterChip({
     required this.status,
+    required this.count,
+    required this.selected,
+    required this.onSelected,
   });
 
-  final MediaItem item;
-  final RipAlbum? ripAlbum;
   final CoverageStatus status;
-}
+  final int count;
+  final bool selected;
+  final ValueChanged<bool> onSelected;
 
-String _statusLabel(CoverageStatus status) {
-  switch (status) {
-    case CoverageStatus.notRipped:
-      return 'Not ripped';
-    case CoverageStatus.partiallyRipped:
-      return 'Partially ripped';
-    case CoverageStatus.fullyRipped:
-      return 'Fully ripped';
-    case CoverageStatus.qualityIssues:
-      return 'Quality issues';
+  @override
+  Widget build(BuildContext context) {
+    final colour = coverageStatusColour(context, status);
+    return ChoiceChip(
+      selected: selected,
+      showCheckmark: false,
+      shape: const StadiumBorder(),
+      avatar: Container(
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(
+          color: colour,
+          borderRadius: BorderRadius.circular(2),
+        ),
+      ),
+      label: Text('${coverageStatusLabel(status)} $count'),
+      onSelected: onSelected,
+    );
   }
 }
 
-IconData _statusIcon(CoverageStatus status) {
-  switch (status) {
-    case CoverageStatus.notRipped:
-      return Icons.cancel;
-    case CoverageStatus.partiallyRipped:
-      return Icons.timelapse;
-    case CoverageStatus.fullyRipped:
-      return Icons.check_circle;
-    case CoverageStatus.qualityIssues:
-      return Icons.warning;
-  }
-}
+/// A single coverage row: cover, title/artist, status pill and track count.
+class _CoverageRow extends StatelessWidget {
+  const _CoverageRow({required this.entry});
 
-Color _statusColour(BuildContext context, CoverageStatus status) {
-  final mediaColors = context.mediaColors;
-  switch (status) {
-    case CoverageStatus.notRipped:
-      return mediaColors.film;
-    case CoverageStatus.partiallyRipped:
-      return mediaColors.tv;
-    case CoverageStatus.fullyRipped:
-      return mediaColors.book;
-    case CoverageStatus.qualityIssues:
-      return mediaColors.tv;
-  }
-}
-
-class _SummaryBar extends StatelessWidget {
-  const _SummaryBar({
-    required this.rippedCount,
-    required this.totalCount,
-    required this.percentage,
-  });
-
-  final int rippedCount;
-  final int totalCount;
-  final int percentage;
+  final RipCoverageEntry entry;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.all(16),
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceContainerHighest,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          Icon(Icons.album, size: 32, color: theme.colorScheme.primary),
-          const SizedBox(width: 12),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    final colors = theme.colorScheme;
+    final colour = coverageStatusColour(context, entry.status);
+
+    return Material(
+      color: colors.surfaceContainerLow,
+      borderRadius: BorderRadius.circular(14),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: () => context.go('/collection/item/${entry.item.id}'),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Row(
             children: [
-              Text(
-                '$rippedCount of $totalCount CDs ripped ($percentage%)',
-                style: theme.textTheme.titleMedium,
-              ),
-              const SizedBox(height: 4),
-              SizedBox(
-                width: 200,
-                child: LinearProgressIndicator(
-                  value: totalCount > 0 ? rippedCount / totalCount : 0,
+              RipCoverThumb(coverPath: entry.album?.coverPath, size: 48),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      entry.item.title,
+                      style: AppTypography.displayTitle(
+                        color: colors.onSurface,
+                        fontSize: 15,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if ((entry.item.subtitle ?? '').isNotEmpty) ...[
+                      const SizedBox(height: 3),
+                      Text(
+                        entry.item.subtitle!,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colors.onSurfaceVariant,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ],
                 ),
               ),
+              const SizedBox(width: 12),
+              _CoveragePill(status: entry.status, colour: colour),
+              if (entry.album != null) ...[
+                const SizedBox(width: 12),
+                Text(
+                  '${entry.album!.trackCount} tracks',
+                  style: AppTypography.monoLabel(
+                    color: colors.onSurfaceVariant,
+                    fontSize: 10,
+                    letterSpacing: 0.2,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
             ],
           ),
-        ],
+        ),
       ),
     );
   }
 }
 
-class _CoverageItemTile extends ConsumerWidget {
-  const _CoverageItemTile({required this.entry});
+class _CoveragePill extends StatelessWidget {
+  const _CoveragePill({required this.status, required this.colour});
 
-  final _CoverageEntry entry;
+  final CoverageStatus status;
+  final Color colour;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    // Check track quality for linked albums
-    final hasQualityIssues = _checkQualityIssues(ref);
-    final effectiveStatus =
-        hasQualityIssues ? CoverageStatus.qualityIssues : entry.status;
-
-    return ListTile(
-      leading: Icon(
-        _statusIcon(effectiveStatus),
-        color: _statusColour(context, effectiveStatus),
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: colour.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(999),
       ),
-      title: Text(entry.item.title),
-      subtitle: Text(entry.item.subtitle ?? ''),
-      trailing: entry.ripAlbum != null
-          ? Text('${entry.ripAlbum!.trackCount} tracks')
-          : null,
-      onTap: () => context.go('/collection/item/${entry.item.id}'),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(coverageStatusIcon(status), size: 12, color: colour),
+          const SizedBox(width: 5),
+          Text(
+            coverageStatusLabel(status).toUpperCase(),
+            style: AppTypography.monoLabel(color: colour),
+          ),
+        ],
+      ),
     );
-  }
-
-  bool _checkQualityIssues(WidgetRef ref) {
-    if (entry.ripAlbum == null) return false;
-    if (entry.status != CoverageStatus.fullyRipped) return false;
-
-    final tracksAsync = ref.watch(ripTracksProvider(entry.ripAlbum!.id));
-    final tracks = tracksAsync.whenOrNull(data: (t) => t) ?? [];
-    if (tracks.isEmpty) return false;
-
-    // Only flag quality issues if analysis has been run
-    final anyChecked = tracks.any((t) => t.qualityCheckedAt != null);
-    if (!anyChecked) return false;
-
-    return tracks.any((t) =>
-        t.accurateRipStatus == 'mismatch' || t.totalDefects > 0);
   }
 }

--- a/lib/presentation/screens/rips/widgets/rip_health_widgets.dart
+++ b/lib/presentation/screens/rips/widgets/rip_health_widgets.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mymediascanner/app/theme/app_media_colors.dart';
 import 'package:mymediascanner/app/theme/app_typography.dart';
 import 'package:mymediascanner/domain/entities/rip_album_health.dart';
+import 'package:mymediascanner/domain/entities/rip_coverage.dart';
+import 'package:mymediascanner/presentation/providers/rip_coverage_provider.dart';
 import 'package:mymediascanner/presentation/providers/rip_health_provider.dart';
 
 Color ripHealthColour(BuildContext context, RipAlbumHealth health) {
@@ -113,6 +115,62 @@ class RipHealthStatCards extends ConsumerWidget {
           label: 'TOTAL SIZE',
           value: formatSize(stats.totalSizeBytes),
           valueColour: theme.colorScheme.primary,
+        ),
+      ],
+    );
+  }
+}
+
+/// Colour for a coverage status, mapped through the media-type palette.
+Color coverageStatusColour(BuildContext context, CoverageStatus status) {
+  final mediaColors = context.mediaColors;
+  final colors = Theme.of(context).colorScheme;
+  return switch (status) {
+    CoverageStatus.notRipped => colors.outline,
+    CoverageStatus.partiallyRipped => mediaColors.tv,
+    CoverageStatus.fullyRipped => mediaColors.book,
+    CoverageStatus.qualityIssues => mediaColors.tv,
+  };
+}
+
+/// Four compact header stat cards for the Coverage tab: ripped / total CDs /
+/// coverage percent / quality issues. Reads [ripCoverageStatsProvider].
+class RipCoverageStatCards extends ConsumerWidget {
+  const RipCoverageStatCards({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final stats = ref.watch(ripCoverageStatsProvider);
+    final theme = Theme.of(context);
+    final mediaColors = context.mediaColors;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _StatCard(
+          label: 'RIPPED',
+          value: '${stats.rippedCount}',
+          dotColour: mediaColors.book,
+        ),
+        const SizedBox(width: 10),
+        _StatCard(
+          label: 'TOTAL CDS',
+          value: '${stats.total}',
+        ),
+        const SizedBox(width: 10),
+        _StatCard(
+          label: 'COVERAGE',
+          value: '${stats.coveragePercent}%',
+          valueColour: theme.colorScheme.primary,
+        ),
+        const SizedBox(width: 10),
+        _StatCard(
+          label: 'ISSUES',
+          value: '${stats.countOf(CoverageStatus.qualityIssues)}',
+          dotColour: mediaColors.tv,
+          valueColour: stats.countOf(CoverageStatus.qualityIssues) > 0
+              ? mediaColors.tv
+              : null,
         ),
       ],
     );

--- a/test/unit/domain/rip_coverage_test.dart
+++ b/test/unit/domain/rip_coverage_test.dart
@@ -1,0 +1,171 @@
+/// Tests for rip coverage categorisation and aggregate stats.
+///
+/// Author: Paul Snow
+/// Since: 0.0.0
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/rip_album.dart';
+import 'package:mymediascanner/domain/entities/rip_coverage.dart';
+import 'package:mymediascanner/domain/entities/rip_track.dart';
+
+MediaItem music(
+  String id, {
+  List<String>? trackListing,
+}) {
+  return MediaItem(
+    id: id,
+    barcode: 'b$id',
+    barcodeType: 'EAN13',
+    mediaType: MediaType.music,
+    title: 'Album $id',
+    extraMetadata: trackListing == null ? const {} : {'track_listing': trackListing},
+    dateAdded: 0,
+    dateScanned: 0,
+    updatedAt: 0,
+  );
+}
+
+RipAlbum album(String id, String mediaItemId, {int trackCount = 10}) => RipAlbum(
+      id: id,
+      libraryPath: '/lib/$id',
+      mediaItemId: mediaItemId,
+      trackCount: trackCount,
+      totalSizeBytes: 0,
+      lastScannedAt: 0,
+      updatedAt: 0,
+    );
+
+RipTrack track(
+  String albumId, {
+  String? arStatus,
+  int? checkedAt,
+  int clicks = 0,
+}) =>
+    RipTrack(
+      id: '$albumId-t',
+      ripAlbumId: albumId,
+      trackNumber: 1,
+      filePath: '/x.flac',
+      fileSizeBytes: 0,
+      updatedAt: 0,
+      accurateRipStatus: arStatus,
+      qualityCheckedAt: checkedAt,
+      clickCount: clicks,
+    );
+
+void main() {
+  group('categoriseRipCoverage', () {
+    test('unlinked music item is notRipped', () {
+      final entries = categoriseRipCoverage(
+        items: [music('m1')],
+        albums: const [],
+        tracksByAlbum: const {},
+      );
+      expect(entries.single.status, CoverageStatus.notRipped);
+      expect(entries.single.album, isNull);
+    });
+
+    test('linked with fewer tracks than listing is partiallyRipped', () {
+      final entries = categoriseRipCoverage(
+        items: [music('m1', trackListing: ['a', 'b', 'c'])],
+        albums: [album('a1', 'm1', trackCount: 2)],
+        tracksByAlbum: const {},
+      );
+      expect(entries.single.status, CoverageStatus.partiallyRipped);
+    });
+
+    test('linked and complete with no analysis is fullyRipped', () {
+      final entries = categoriseRipCoverage(
+        items: [music('m1', trackListing: ['a', 'b'])],
+        albums: [album('a1', 'm1', trackCount: 2)],
+        tracksByAlbum: {
+          'a1': [track('a1')], // no qualityCheckedAt
+        },
+      );
+      expect(entries.single.status, CoverageStatus.fullyRipped);
+    });
+
+    test('complete but analysed with defects is qualityIssues', () {
+      final entries = categoriseRipCoverage(
+        items: [music('m1', trackListing: ['a', 'b'])],
+        albums: [album('a1', 'm1', trackCount: 2)],
+        tracksByAlbum: {
+          'a1': [track('a1', arStatus: 'verified', checkedAt: 1, clicks: 3)],
+        },
+      );
+      expect(entries.single.status, CoverageStatus.qualityIssues);
+    });
+
+    test('complete but analysed with mismatch is qualityIssues', () {
+      final entries = categoriseRipCoverage(
+        items: [music('m1', trackListing: ['a'])],
+        albums: [album('a1', 'm1', trackCount: 1)],
+        tracksByAlbum: {
+          'a1': [track('a1', arStatus: 'mismatch', checkedAt: 1)],
+        },
+      );
+      expect(entries.single.status, CoverageStatus.qualityIssues);
+    });
+
+    test('empty track listing treats any linked album as fully ripped', () {
+      final entries = categoriseRipCoverage(
+        items: [music('m1')], // no track_listing
+        albums: [album('a1', 'm1', trackCount: 5)],
+        tracksByAlbum: const {},
+      );
+      expect(entries.single.status, CoverageStatus.fullyRipped);
+    });
+
+    test('entries are sorted by status index', () {
+      final entries = categoriseRipCoverage(
+        items: [
+          music('m1', trackListing: ['a']), // fully (linked below)
+          music('m2'), // not ripped
+        ],
+        albums: [album('a1', 'm1', trackCount: 1)],
+        tracksByAlbum: const {},
+      );
+      expect(entries.first.status, CoverageStatus.notRipped);
+    });
+  });
+
+  group('computeRipCoverageStats', () {
+    test('counts per status, ripped count and coverage percent', () {
+      final entries = categoriseRipCoverage(
+        items: [
+          music('m1', trackListing: ['a']), // fully
+          music('m2', trackListing: ['a', 'b']), // partial (album has 1)
+          music('m3'), // not ripped
+          music('m4', trackListing: ['a']), // quality issues
+        ],
+        albums: [
+          album('a1', 'm1', trackCount: 1),
+          album('a2', 'm2', trackCount: 1),
+          album('a4', 'm4', trackCount: 1),
+        ],
+        tracksByAlbum: {
+          'a4': [track('a4', arStatus: 'mismatch', checkedAt: 1)],
+        },
+      );
+      final stats = computeRipCoverageStats(entries);
+      expect(stats.total, 4);
+      expect(stats.countOf(CoverageStatus.fullyRipped), 1);
+      expect(stats.countOf(CoverageStatus.partiallyRipped), 1);
+      expect(stats.countOf(CoverageStatus.notRipped), 1);
+      expect(stats.countOf(CoverageStatus.qualityIssues), 1);
+      // ripped = fully + qualityIssues
+      expect(stats.rippedCount, 2);
+      expect(stats.coveragePercent, 50);
+    });
+
+    test('empty collection is zero coverage, no division by zero', () {
+      final stats = computeRipCoverageStats(const []);
+      expect(stats.total, 0);
+      expect(stats.coveragePercent, 0);
+      expect(stats.rippedCount, 0);
+    });
+  });
+}

--- a/test/widget/rips/rip_health_widgets_test.dart
+++ b/test/widget/rips/rip_health_widgets_test.dart
@@ -9,12 +9,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mymediascanner/app/theme/app_theme.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/rip_album_health.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
 import 'package:mymediascanner/domain/repositories/i_rip_library_repository.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/screens/rips/widgets/rip_health_widgets.dart';
 
 class MockRipLibraryRepository extends Mock implements IRipLibraryRepository {}
+
+class MockMediaItemRepository extends Mock implements IMediaItemRepository {}
 
 void main() {
   testWidgets('RipStatusPill renders label and detail', (tester) async {
@@ -49,5 +53,32 @@ void main() {
     expect(find.text('ATTENTION'), findsOneWidget);
     expect(find.text('AR COVERAGE'), findsOneWidget);
     expect(find.text('TOTAL SIZE'), findsOneWidget);
+  });
+
+  testWidgets('RipCoverageStatCards shows the four coverage cards',
+      (tester) async {
+    final ripRepo = MockRipLibraryRepository();
+    when(() => ripRepo.watchAll()).thenAnswer((_) => Stream.value(const []));
+    when(() => ripRepo.watchAllTracksByAlbum())
+        .thenAnswer((_) => Stream.value(const {}));
+    final mediaRepo = MockMediaItemRepository();
+    when(() => mediaRepo.watchAll(mediaType: MediaType.music))
+        .thenAnswer((_) => Stream.value(const []));
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        ripLibraryRepositoryProvider.overrideWithValue(ripRepo),
+        mediaItemRepositoryProvider.overrideWithValue(mediaRepo),
+      ],
+      child: MaterialApp(
+        theme: AppTheme.dark(),
+        home: const Scaffold(body: RipCoverageStatCards()),
+      ),
+    ));
+    await tester.pump();
+    expect(find.text('RIPPED'), findsOneWidget);
+    expect(find.text('TOTAL CDS'), findsOneWidget);
+    expect(find.text('COVERAGE'), findsOneWidget);
+    expect(find.text('ISSUES'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to the Rip Library redesign (#109). Brings the **Coverage** and **Playlists** tabs — which sit inside the Rips screen — up to the same visual language as the redesigned Library tab, and makes the shared screen header context-aware per tab.

## What changed

- **Context-aware header** — the header stat cards now match the active tab: Library keeps its health cards, **Coverage** shows Ripped / Total CDs / Coverage % / Issues, and **Playlists** shows no stat cards (previously it incorrectly displayed album-health numbers).
- **Shared coverage model** — extracted `categoriseRipCoverage` + `RipCoverageStats` into `lib/domain/entities/rip_coverage.dart` (pure Dart, TDD), reused by both the header cards and the Coverage list. Quality-issue escalation reuses the library-wide all-tracks stream from #109, so it stays in sync with analysis.
- **Coverage body** — dropped the old summary bar (its numbers moved to the header), switched to pill-style filter chips with colour dots + counts (matching the Library tab), and replaced the flat list rows with richer rows: cover thumbnail, Space Grotesk title, artist, a coverage status pill, and mono track count.
- **Playlists body** — mono "MY PLAYLISTS" section label and Space Grotesk / mono typography on the playlist cards.

## Testing

- `flutter analyze` clean.
- New unit tests for coverage categorisation + stats (11 cases); widget test for the coverage stat cards. Full suite: **1748 tests pass**.
- Live macOS smoke: Coverage tab shows correct context cards (Ripped 0 / Total CDs 3 / Coverage 0% / Issues 0), pill chips filter, richer rows render; Playlists tab shows no stat cards and the mono label.

Design source: internal themed design mock (Coverage & Playlists are the "Tier 1" consistency gap identified after #109).


