### PR TITLE
fix(collection): preserve media-type filter during full-text search (#103)

### DIFF
--- a/lib/data/repositories/media_item_repository_impl.dart
+++ b/lib/data/repositories/media_item_repository_impl.dart
@@ -69,7 +69,6 @@ class MediaItemRepositoryImpl implements IMediaItemRepository {
       final taggedIds = await resolveTaggedIds();
       return rows
           .where((r) =>
-              useFts ||
               mediaType == null ||
               r.mediaType == mediaType.name)
           .where((r) =>

--- a/test/unit/data/repositories/media_item_repository_impl_test.dart
+++ b/test/unit/data/repositories/media_item_repository_impl_test.dart
@@ -167,6 +167,26 @@ void main() {
           .first;
       expect(filtered.map((e) => e.id).toSet(), {'b'});
     });
+
+    test('mediaType filter is preserved on the FTS search path (#103)',
+        () async {
+      // Identically-titled rows across two media types: an unfiltered FTS
+      // search would match both, but a mediaType filter must narrow to one.
+      await repo.save(baseItem(id: 'book1')
+          .copyWith(mediaType: MediaType.book, title: 'Chronicles'));
+      await repo.save(baseItem(id: 'film1')
+          .copyWith(mediaType: MediaType.film, title: 'Chronicles'));
+
+      final books = await repo
+          .watchAll(mediaType: MediaType.book, searchQuery: 'Chronicles')
+          .first;
+      expect(books.map((e) => e.id).toSet(), {'book1'});
+
+      final films = await repo
+          .watchAll(mediaType: MediaType.film, searchQuery: 'Chronicles')
+          .first;
+      expect(films.map((e) => e.id).toSet(), {'film1'});
+    });
   });
 
   group('mirror auto-remove hook (update + softDelete)', () {


### PR DESCRIPTION
Fixes #103.

## Problem
`MediaItemRepositoryImpl.watchAll()` used FTS (`watchSearch()`) for queries >= 2 chars, and the in-memory predicate started with `useFts ||` — so the media-type filter was bypassed whenever search was active. Searching with a Book/Film/Music/Game filter returned matches from every type.

## Fix
Drop the `useFts ||` short-circuit from the media-type predicate so the selected media type is enforced on the FTS path too. FTS relevance ordering is untouched (this is a filter, not a re-sort); tag composition and the short-query fallback are unchanged.

## Testing
Added a repository regression test with identically-titled items across two media types, searching the shared term under a media-type filter (fails pre-fix, passes after). `flutter test` for the repository: 22/22 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REjQXwtZxAcqBjEDW1AHs2