### PR TITLE
fix(export): keep cover assets in sync with private/deleted exclusion and failed downloads (#101, #104)

### DIFF
--- a/lib/data/services/static_export_writer.dart
+++ b/lib/data/services/static_export_writer.dart
@@ -38,7 +38,11 @@ class StaticExportWriter {
 
     Map<String, Uint8List> covers = const {};
     if (options.bundleCovers) {
-      covers = await _fetchCovers(items, onProgress: onProgress);
+      // Only fetch covers for items the service will actually render —
+      // private-tagged and soft-deleted items are excluded from the
+      // export, so their covers should never be downloaded either (#101).
+      final visible = _service.visibleItems(items, options);
+      covers = await _fetchCovers(visible, onProgress: onProgress);
     }
 
     final bundle = _service.build(

--- a/lib/domain/services/static_export_service.dart
+++ b/lib/domain/services/static_export_service.dart
@@ -39,29 +39,55 @@ class StaticExportOptions {
 class StaticExportService {
   const StaticExportService();
 
+  /// Items that survive the private/deleted exclusion for [options].
+  /// Exposed so callers (e.g. [StaticExportWriter]) can apply the same
+  /// exclusion before fetching cover assets.
+  List<MediaItem> visibleItems(
+    List<MediaItem> items,
+    StaticExportOptions options,
+  ) =>
+      items
+          .where((i) => !i.deleted)
+          .where((i) => !_hasTag(i, options.privateTag))
+          .toList();
+
   /// Build the export. Returns a map of relative paths to byte content.
+  ///
+  /// The `covers` entries are filtered down to the ones expected by a
+  /// visible item's `coverUrl` — covers for private/deleted items are
+  /// dropped even if present in [covers], and a cover missing from
+  /// [covers] (e.g. a failed download) is treated as absent so the
+  /// rendered HTML never links to a local asset that doesn't exist.
   Map<String, Uint8List> build({
     required List<MediaItem> items,
     StaticExportOptions options = const StaticExportOptions(),
     Map<String, Uint8List> covers = const {},
   }) {
-    final visible = items
-        .where((i) => !i.deleted)
-        .where((i) => !_hasTag(i, options.privateTag))
-        .toList();
+    final visible = visibleItems(items, options);
 
-    final index = _renderIndex(visible, options);
+    final expectedCoverKeys = <String>{
+      for (final i in visible)
+        if (i.coverUrl != null && i.coverUrl!.isNotEmpty)
+          '${i.id}${_extFromUrl(i.coverUrl!)}',
+    };
+    final bundledCovers = <String, Uint8List>{
+      for (final e in covers.entries)
+        if (expectedCoverKeys.contains(e.key)) e.key: e.value,
+    };
+    final bundledKeys = bundledCovers.keys.toSet();
+
+    final index = _renderIndex(visible, options, bundledKeys);
     final output = <String, Uint8List>{
       'index.html': Uint8List.fromList(utf8.encode(index)),
     };
 
     for (final item in visible) {
-      final page = _renderItem(item, options);
+      final page = _renderItem(item, options, bundledKeys);
       output['items/${item.id}.html'] =
           Uint8List.fromList(utf8.encode(page));
     }
 
-    for (final e in covers.entries) {
+    for (final e in bundledCovers.entries) {
       output['covers/${e.key}'] = e.value;
     }
 
@@ -70,7 +96,11 @@ class StaticExportService {
 
   // ── HTML rendering ────────────────────────────────────────────────
 
-  String _renderIndex(List<MediaItem> items, StaticExportOptions opts) {
+  String _renderIndex(
+    List<MediaItem> items,
+    StaticExportOptions opts,
+    Set<String> bundledCoverKeys,
+  ) {
     final mediaTypes = <String>{for (final i in items) i.mediaType.label};
     final tags = <String>{
       for (final i in items)
@@ -81,7 +111,7 @@ class StaticExportService {
 
     final cards = <String>[];
     for (final item in items) {
-      final cover = _coverPath(item, opts);
+      final cover = _coverPath(item, opts, bundledCoverKeys);
       final tagList = _tagsOf(item)
           .where((t) => t != opts.privateTag)
           .join(',');
@@ -176,8 +206,12 @@ ${cards.join('\n')}
 ''';
   }
 
-  String _renderItem(MediaItem item, StaticExportOptions opts) {
-    final cover = _coverPath(item, opts);
+  String _renderItem(
+    MediaItem item,
+    StaticExportOptions opts,
+    Set<String> bundledCoverKeys,
+  ) {
+    final cover = _coverPath(item, opts, bundledCoverKeys);
     final details = <(String, String)>[
       if (item.year != null) ('Year', item.year.toString()),
       if (item.publisher != null) ('Publisher', item.publisher!),
@@ -242,15 +276,23 @@ ${cards.join('\n')}
 
   // ── Helpers ───────────────────────────────────────────────────────
 
-  /// Returns the `covers/<id>.<ext>` path when covers are bundled and we
-  /// have a URL (used by the writer to pick the extension). Returns the
-  /// original URL when not bundling.
-  String? _coverPath(MediaItem item, StaticExportOptions opts) {
+  /// Returns the `covers/<id>.<ext>` path when covers are bundled and the
+  /// cover was actually supplied in [bundledCoverKeys] (i.e. the download
+  /// succeeded). Returns the original URL when not bundling, or `null`
+  /// when bundling was expected but the cover is missing — e.g. a failed
+  /// download — so the caller falls back to the placeholder instead of
+  /// linking to a local asset that was never written.
+  String? _coverPath(
+    MediaItem item,
+    StaticExportOptions opts,
+    Set<String> bundledCoverKeys,
+  ) {
     final url = item.coverUrl;
     if (url == null || url.isEmpty) return null;
     if (!opts.bundleCovers) return url;
-    final ext = _extFromUrl(url);
-    return 'covers/${item.id}$ext';
+    final key = '${item.id}${_extFromUrl(url)}';
+    if (!bundledCoverKeys.contains(key)) return null;
+    return 'covers/$key';
   }
 
   static String _extFromUrl(String url) {

--- a/test/unit/data/services/static_export_writer_test.dart
+++ b/test/unit/data/services/static_export_writer_test.dart
@@ -17,6 +17,8 @@ MediaItem _item({
   String title = 'Title',
   String? coverUrl,
   MediaType mediaType = MediaType.film,
+  List<String> tags = const [],
+  bool deleted = false,
 }) =>
     MediaItem(
       id: id,
@@ -25,7 +27,8 @@ MediaItem _item({
       mediaType: mediaType,
       title: title,
       coverUrl: coverUrl,
-      extraMetadata: const {},
+      deleted: deleted,
+      extraMetadata: tags.isEmpty ? const {} : {'tags': tags},
       dateAdded: 0,
       dateScanned: 0,
       updatedAt: 0,
@@ -113,7 +116,9 @@ void main() {
     expect(await coverFile.readAsBytes(), Uint8List.fromList(bytes));
   });
 
-  test('skips covers when the download fails', () async {
+  test(
+      'skips covers when the download fails and HTML has no broken '
+      'reference (#104)', () async {
     final dio = MockDio();
     when(() => dio.get<List<int>>(
           any(),
@@ -136,6 +141,82 @@ void main() {
     }
     // Export itself still succeeds.
     expect(await File(p.join(tempDir.path, 'index.html')).exists(), isTrue);
+
+    final indexHtml =
+        await File(p.join(tempDir.path, 'index.html')).readAsString();
+    expect(indexHtml, isNot(contains('covers/a.jpg')));
+
+    final itemHtml =
+        await File(p.join(tempDir.path, 'items', 'a.html')).readAsString();
+    expect(itemHtml, isNot(contains('covers/a.jpg')));
+  });
+
+  // Regression tests for #101: the writer must not fetch or persist
+  // covers for items that the service would exclude from the HTML.
+  test('does not fetch or write covers for private-tagged items', () async {
+    final dio = MockDio();
+    when(() => dio.get<List<int>>(
+          any(),
+          options: any(named: 'options'),
+        )).thenAnswer(
+            (_) async => _bytesResponse([1, 2, 3], 'https://example.com'));
+
+    final writer = StaticExportWriter(dio: dio);
+    await writer.write(
+      targetDir: tempDir,
+      items: [
+        _item(id: 'visible', coverUrl: 'https://example.com/visible.jpg'),
+        _item(
+          id: 'secret',
+          coverUrl: 'https://example.com/secret.jpg',
+          tags: ['private'],
+        ),
+      ],
+      options: const StaticExportOptions(bundleCovers: true),
+    );
+
+    verifyNever(() => dio.get<List<int>>(
+          'https://example.com/secret.jpg',
+          options: any(named: 'options'),
+        ));
+    expect(
+        await File(p.join(tempDir.path, 'covers', 'secret.jpg')).exists(),
+        isFalse);
+    expect(
+        await File(p.join(tempDir.path, 'covers', 'visible.jpg')).exists(),
+        isTrue);
+  });
+
+  test('does not fetch or write covers for soft-deleted items', () async {
+    final dio = MockDio();
+    when(() => dio.get<List<int>>(
+          any(),
+          options: any(named: 'options'),
+        )).thenAnswer(
+            (_) async => _bytesResponse([1, 2, 3], 'https://example.com'));
+
+    final writer = StaticExportWriter(dio: dio);
+    await writer.write(
+      targetDir: tempDir,
+      items: [
+        _item(id: 'live', coverUrl: 'https://example.com/live.jpg'),
+        _item(
+          id: 'gone',
+          coverUrl: 'https://example.com/gone.jpg',
+          deleted: true,
+        ),
+      ],
+      options: const StaticExportOptions(bundleCovers: true),
+    );
+
+    verifyNever(() => dio.get<List<int>>(
+          'https://example.com/gone.jpg',
+          options: any(named: 'options'),
+        ));
+    expect(await File(p.join(tempDir.path, 'covers', 'gone.jpg')).exists(),
+        isFalse);
+    expect(await File(p.join(tempDir.path, 'covers', 'live.jpg')).exists(),
+        isTrue);
   });
 
   test('reports progress for write phase', () async {

--- a/test/unit/domain/services/static_export_service_test.dart
+++ b/test/unit/domain/services/static_export_service_test.dart
@@ -85,12 +85,34 @@ void main() {
         contains('https://example.com/a.jpg'));
   });
 
-  test('rewrites cover path when bundling covers', () {
+  test('rewrites cover path when bundling covers and the cover exists', () {
+    final bytes = Uint8List.fromList(const [1, 2, 3]);
     final out = service.build(
       items: [_item(id: 'a', coverUrl: 'https://example.com/a.jpg?foo')],
       options: const StaticExportOptions(bundleCovers: true),
+      covers: {'a.jpg': bytes},
     );
     expect(_asString(out['index.html']!), contains('covers/a.jpg'));
+  });
+
+  // Regression test for #104: a bundled-cover download can fail, leaving
+  // the covers map without an entry for the item. The HTML must not
+  // reference a covers/<id>.<ext> path that was never written.
+  test('falls back to placeholder when a bundled cover is missing '
+      '(failed download)', () {
+    final out = service.build(
+      items: [_item(id: 'a', coverUrl: 'https://example.com/a.jpg')],
+      options: const StaticExportOptions(bundleCovers: true),
+      // covers map intentionally empty: simulates a failed/skipped fetch.
+    );
+
+    final index = _asString(out['index.html']!);
+    expect(index, isNot(contains('covers/a.jpg')));
+    expect(index, contains('class="placeholder"'));
+
+    final item = _asString(out['items/a.html']!);
+    expect(item, isNot(contains('covers/a.jpg')));
+    expect(item, contains('<div class="cover"></div>'));
   });
 
   test('media-type filter dropdown includes every present type', () {
@@ -122,13 +144,76 @@ void main() {
     expect(index, contains('Paul&#39;s library'));
   });
 
-  test('bundled covers map writes to covers/<key> verbatim', () {
+  test('bundled cover for a visible item is written verbatim', () {
     final bytes = Uint8List.fromList(const [0x89, 0x50, 0x4e, 0x47]);
     final out = service.build(
-      items: const [],
+      items: [_item(id: 'a', coverUrl: 'https://example.com/a.jpg')],
       options: const StaticExportOptions(bundleCovers: true),
       covers: {'a.jpg': bytes},
     );
     expect(out['covers/a.jpg'], bytes);
+  });
+
+  // Regression tests for #101: cover assets must respect the same
+  // private/deleted exclusion that already applies to the HTML pages.
+  group('excludes covers for hidden items (#101)', () {
+    test('excludes covers for private-tagged items', () {
+      final bytes = Uint8List.fromList(const [1, 2, 3]);
+      final out = service.build(
+        items: [
+          _item(id: 'visible', coverUrl: 'https://example.com/visible.jpg'),
+          _item(
+            id: 'secret',
+            coverUrl: 'https://example.com/secret.jpg',
+            tags: ['private'],
+          ),
+        ],
+        options: const StaticExportOptions(bundleCovers: true),
+        covers: {
+          'visible.jpg': bytes,
+          'secret.jpg': bytes,
+        },
+      );
+      expect(out.keys, contains('covers/visible.jpg'));
+      expect(out.keys, isNot(contains('covers/secret.jpg')));
+    });
+
+    test('excludes covers for soft-deleted items', () {
+      final bytes = Uint8List.fromList(const [1, 2, 3]);
+      final out = service.build(
+        items: [
+          _item(id: 'live', coverUrl: 'https://example.com/live.jpg'),
+          _item(
+            id: 'gone',
+            coverUrl: 'https://example.com/gone.jpg',
+            deleted: true,
+          ),
+        ],
+        options: const StaticExportOptions(bundleCovers: true),
+        covers: {
+          'live.jpg': bytes,
+          'gone.jpg': bytes,
+        },
+      );
+      expect(out.keys, contains('covers/live.jpg'));
+      expect(out.keys, isNot(contains('covers/gone.jpg')));
+    });
+
+    test('respects a custom privateTag value', () {
+      final bytes = Uint8List.fromList(const [1, 2, 3]);
+      final out = service.build(
+        items: [
+          _item(
+            id: 'a',
+            coverUrl: 'https://example.com/a.jpg',
+            tags: ['nsfw'],
+          ),
+        ],
+        options:
+            const StaticExportOptions(privateTag: 'nsfw', bundleCovers: true),
+        covers: {'a.jpg': bytes},
+      );
+      expect(out.keys, isNot(contains('covers/a.jpg')));
+    });
   });
 }


### PR DESCRIPTION
Fixes #101 and #104 — both concern cover handling in the static HTML export and share the same visible-items / bundled-keys logic, so they land together.

## #101 — private/deleted covers were still bundled
`build()` filtered private-tagged and soft-deleted items out of the HTML, but the covers map was emitted wholesale and the writer downloaded a cover for every input item. Private/deleted covers could therefore be published even though nothing linked to them.

**Fix:** extracted `StaticExportService.visibleItems(items, options)` (the single source of the private/deleted exclusion). The writer now fetches covers only for visible items, and `build()` intersects the supplied covers with the keys expected by visible items — so excluded covers are neither downloaded nor written. A custom `privateTag` is respected via the shared helper.

## #104 — broken cover references after a failed download
`_coverPath()` rewrote every non-empty URL to `covers/<id>.<ext>` whenever bundling, even when the download had failed and no file was written → broken `<img>`.

**Fix:** `_coverPath()` now consults the set of actually-bundled cover keys and returns `null` (→ placeholder) when the cover is missing, so HTML links to a local cover only when it exists. Successful downloads still use local paths. Chose the self-contained placeholder fallback over a remote-URL fallback (the issue allowed either).

## Testing
Regression tests for: private/deleted covers not fetched or written, custom privateTag respected, visible covers still bundled, failed/empty download → placeholder on index AND detail pages, successful bundle → local path. 24/24 pass across the service + writer test files; `flutter analyze` clean on the touched files.

No public API removed; only a new public `visibleItems()` helper added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REjQXwtZxAcqBjEDW1AHs2