### PR TITLE
fix(labels): embed Unicode-capable fonts in generated label PDFs (#106)

### DIFF
--- a/lib/domain/services/label_pdf_generator.dart
+++ b/lib/domain/services/label_pdf_generator.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:flutter/services.dart' show rootBundle;
 import 'package:mymediascanner/domain/entities/label_sheet_preset.dart';
 import 'package:mymediascanner/domain/entities/label_target.dart';
 import 'package:pdf/pdf.dart';
@@ -9,7 +10,10 @@ import 'package:pdf/widgets.dart' as pw;
 /// grid defined by a [LabelSheetPreset]. Each label carries a QR of the
 /// target's [LabelTarget.qrPayload] and its human-readable title.
 ///
-/// Pure: no I/O, no Flutter dependencies. Returns the rendered PDF as a
+/// Embeds the bundled Manrope regular/bold fonts so titles, subtitles,
+/// and QR payload text render Unicode text (accented Latin, Cyrillic,
+/// CJK, etc.) correctly instead of falling back to the PDF package's
+/// non-Unicode default Helvetica fonts. Returns the rendered PDF as a
 /// [Uint8List]; callers are responsible for previewing, saving, or
 /// sharing the bytes.
 class LabelPdfGenerator {
@@ -21,7 +25,15 @@ class LabelPdfGenerator {
     required List<LabelTarget> targets,
     required LabelSheetPreset preset,
   }) async {
-    final doc = pw.Document();
+    final baseFont = pw.Font.ttf(
+      await rootBundle.load('assets/fonts/Manrope-Regular.ttf'),
+    );
+    final boldFont = pw.Font.ttf(
+      await rootBundle.load('assets/fonts/Manrope-Bold.ttf'),
+    );
+    final doc = pw.Document(
+      theme: pw.ThemeData.withFont(base: baseFont, bold: boldFont),
+    );
     final perPage = preset.labelsPerPage;
     final pageSize = PdfPageFormat(preset.pageWidthPt, preset.pageHeightPt);
 

--- a/test/unit/domain/services/label_pdf_generator_test.dart
+++ b/test/unit/domain/services/label_pdf_generator_test.dart
@@ -1,9 +1,14 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mymediascanner/domain/entities/label_sheet_preset.dart';
 import 'package:mymediascanner/domain/entities/label_target.dart';
 import 'package:mymediascanner/domain/services/label_pdf_generator.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   const generator = LabelPdfGenerator();
 
   test('a4_24 preset reports 24 labels per page', () {
@@ -77,5 +82,45 @@ void main() {
       preset: preset,
     );
     expect(bytes.length, greaterThan(onePage.length));
+  });
+
+  test(
+      'renders accented Latin and non-Latin Unicode label text without '
+      'Helvetica Unicode warnings', () async {
+    final targets = [
+      const LabelTarget(
+        qrPayload: 'item:cafe',
+        title: 'Café Tacvba',
+        subtitle: 'Русская полка',
+      ),
+      const LabelTarget(
+        qrPayload: 'item:jp',
+        title: 'こんにちは世界',
+        subtitle: '日本語のサブタイトル',
+      ),
+    ];
+
+    final prints = <String>[];
+    late Uint8List bytes;
+    await runZoned(
+      () async {
+        bytes = await generator.generate(
+          targets: targets,
+          preset: LabelSheetPresets.a4_8,
+        );
+      },
+      zoneSpecification: ZoneSpecification(
+        print: (self, parent, zone, line) => prints.add(line),
+      ),
+    );
+
+    expect(bytes.length, greaterThan(500));
+    expect(String.fromCharCodes(bytes.sublist(0, 5)), '%PDF-');
+    expect(
+      prints.where((line) => line.contains('has no Unicode support')),
+      isEmpty,
+      reason: 'Helvetica fallback fonts should not be instantiated once '
+          'Unicode-capable fonts are embedded',
+    );
   });
 }


### PR DESCRIPTION
Fixes #106.

## Problem
`LabelPdfGenerator` built a `pw.Document()` with no embedded font, so titles/subtitles/QR payload text rendered with the PDF package default Helvetica — which has no Unicode support. Non-Latin or accented label text rendered incorrectly, and the test suite emitted Helvetica Unicode warnings.

## Fix
Load the already-bundled **Manrope** Regular + Bold TTFs via `rootBundle` and set them as the document theme (`pw.ThemeData.withFont(base:, bold:)`), so all label text renders Unicode correctly. Layout and QR rendering are unchanged.

## Testing
Added a regression test covering accented Latin (\"Café Tacvba\") and non-Latin labels; asserts generation succeeds, produces a non-trivial PDF, and emits no Helvetica Unicode warnings (fails without the fix). Label tests 8/8 pass; full suite 1749/1749; `flutter analyze` clean.

## Note for reviewer
This adds a `package:flutter/services.dart` (`rootBundle`) import to a `domain/` service. It matches existing precedent (`ocr_metadata_usecase.dart`) and the issue’s suggested approach, and the clean-architecture rule in play is “domain has zero deps on data/presentation” (not “no Flutter framework”). If you would rather keep this class free of Flutter imports, an alternative is to inject the font bytes from the caller — happy to refactor to that if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REjQXwtZxAcqBjEDW1AHs2