### PR TITLE
fix(android): pin mobile_scanner to 7.2.0 to unbreak the Android build

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1112,10 +1112,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: "59ad810aee674633e208f286516464b05003614e686075ef2d4fa7ee2e82ba4b"
+      sha256: c92c26bf2231695b6d3477c8dcf435f51e28f87b1745966b1fe4c47a286171ce
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.2.0"
   mocktail:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,12 @@ dependencies:
   postgres: ^3.5.9
   dio: ^5.9.2
   retrofit: ^4.9.2
-  mobile_scanner: ^7.2.0
+  # Pinned to 7.2.0: mobile_scanner 7.2.1+ bumped its Android module to
+  # Kotlin 2.3.20+ / AGP 8.13.2, which the project's Kotlin 2.2.20 / AGP 8.11.1
+  # toolchain cannot configure — its plugin class then never compiles and the
+  # Android build fails with "cannot find symbol MobileScannerPlugin". 7.2.0 is
+  # the last release on Kotlin 2.1.0. Revisit when the app's AGP/Kotlin are bumped.
+  mobile_scanner: 7.2.0
   flutter_secure_storage: ^10.0.0
   cached_network_image: ^3.4.1
   freezed_annotation: ^3.1.0


### PR DESCRIPTION
## Problem
The Android build fails with:
```
GeneratedPluginRegistrant.java:89: error: cannot find symbol
  new dev.steenbakker.mobile_scanner.MobileScannerPlugin()
```
The committed `pubspec.lock` resolved **mobile_scanner 7.3.0** (and 7.2.1 is affected too). Those versions bumped the plugin's Android module to **Kotlin 2.3.20+/2.4.10 and AGP 8.13.2**, but the project pins **Kotlin 2.2.20 / AGP 8.11.1** (`android/settings.gradle.kts`). The plugin module fails to configure under the older toolchain, so its Kotlin never compiles and `MobileScannerPlugin` is absent from the app's Java compile classpath. Reproducible on a clean build.

## Fix
Pin `mobile_scanner` to exactly **7.2.0** — the last release on Kotlin 2.1.0, which builds cleanly with the project's toolchain. Same pattern as the existing `file_picker` pin. An inline comment records why, and to revisit when the app's AGP/Kotlin are bumped.

## Verification
- `flutter build apk --debug --flavor dev` → `✓ Built app-dev-debug.apk` (with 7.3.0/7.2.1 it fails; with 7.2.0 `:mobile_scanner:compileDebugKotlin` runs and the build passes).
- Installed and launched on a physical device (Samsung SM G965F, Android 10): app runs, and the **camera scanner loads and requests camera permission at runtime** — proving the plugin registers and functions.

No Dart/app code changes; only the dependency constraint and lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REjQXwtZxAcqBjEDW1AHs2