### PR TITLE
fix(mobile): Android back navigation, AppBar overflow and batch scan count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,8 @@ Cross-platform Flutter/Dart application for scanning barcodes on physical media 
 - Lending tracker (borrowers and loans management)
 - Critic scores from TMDB, Discogs, and Google Books
 - FLAC/MP3 rip library scanner with CUE sheet support and coverage comparison against physical collection
-- Audio quality analysis (AccurateRip verification + click/pop detection)
+- Rip album artwork: extracted at scan time (folder image `cover|folder|album|front`.`jpg|jpeg|png` preferred, embedded FLAC PICTURE fallback) and cached under Application Support/`rip_covers`; path stored in `rip_albums.cover_path`
+- Audio quality analysis (AccurateRip verification + click/pop/clipping/dropout detection via `audio_defect_detector`)
 - Insights & analytics dashboard with CSV/JSON export
 - Camera + Bluetooth/USB scanner support on mobile; webcam scanning on all desktop platforms
 - Media type filter on scan screen
@@ -34,7 +35,7 @@ Cross-platform Flutter/Dart application for scanning barcodes on physical media 
 - **Models:** Freezed for immutable entities and sealed classes
 - **Scanning:** mobile_scanner (ML Kit) on Android/iOS/macOS; camera_desktop + flutter_zxing on Windows/Linux; keyboard-wedge USB scanner on all desktop platforms
 - **OCR:** Google ML Kit text recognition (Android/iOS); macOS Vision framework via method channel (`com.mymediascanner/vision_ocr`); Windows/Linux desktop OCR not currently wired (`TesseractOcrService` is a no-op stub)
-- **Secrets:** flutter_secure_storage for Postgres credentials and API keys
+- **Secrets:** flutter_secure_storage for Postgres credentials and API keys. Non-secrets (rip library path, its sandbox bookmark) live in SharedPreferences — macOS Keychain items do not survive relaunches of ad-hoc-signed debug builds, so never park settings that must persist in secure storage
 - **Fonts:** Manrope and Inter bundled in `assets/fonts/` (no google_fonts runtime dependency)
 
 ## Build & Development Commands
@@ -73,7 +74,7 @@ flutter build macos --debug
 
 ## Testing
 
-The project has ~729 tests: ~683 unit/widget tests covering domain logic, data layer, presentation providers, and widget tests, plus ~46 integration tests covering full-app user flows. Run `flutter test` to execute the unit/widget suite. Integration tests run individually per file: `flutter test integration_test/<file>.dart -d linux`. Tests use `mocktail` for mocking and `ProviderContainer` with overrides for provider testing.
+The project has ~1,790 unit/widget tests covering domain logic, data layer, presentation providers, and widget tests, plus integration tests (18 files) covering full-app user flows. Run `flutter test` to execute the unit/widget suite. Integration tests run individually per file: `flutter test integration_test/<file>.dart -d linux`. Tests use `mocktail` for mocking and `ProviderContainer` with overrides for provider testing.
 
 ### Runtime UI Automation (Marionette MCP)
 
@@ -129,7 +130,9 @@ lib/
 
 ## Navigation Structure
 
-Routes are organised as 8 `StatefulShellBranch` entries:
+Routes are organised as 17 `StatefulShellBranch` entries. Only branches 0,
+1, 2 and 5 own a mobile bottom-nav destination; every other branch is
+reached from within one of those:
 
 | Branch | Route | Screen | Desktop Sidebar | Mobile Bottom Nav |
 |--------|-------|--------|-----------------|-------------------|
@@ -137,12 +140,25 @@ Routes are organised as 8 `StatefulShellBranch` entries:
 | 1 | `/collection` | Collection/Library | Yes | Yes (Library) |
 | 2 | `/scan` | Scanner | Yes | Yes |
 | 3 | `/shelves` | Shelves | Yes | No (accessible from Library AppBar) |
-| 4 | `/batch` | Batch Editor | Yes | No |
+| 4 | `/batch` | Batch Editor | Yes | No (from the scan screen) |
 | 5 | `/insights` | Insights/Statistics | Yes | Yes |
-| 6 | `/settings` | Settings | Yes | No |
+| 6 | `/settings` | Settings | Yes | No (from the dashboard gear) |
 | 7 | `/rips` | Rips (desktop only) | Yes | No |
+| 8 | `/wishlist` | Wishlist | Yes | No (from Library AppBar) |
+| 9 | `/locations` | Locations | Yes | No (desktop only) |
+| 10 | `/series` | Series | Yes | No (desktop only) |
+| 11 | `/wishlist-suggestions` | Wishlist suggestions | Yes | No (from the dashboard) |
+| 12–15 | `/tmdb/{watchlist,rated,favourites,saved}` | TMDB account lists | When TMDB connected | No |
+| 16 | `/tmdb/conflicts` | TMDB sync conflicts | When conflicts exist | No |
 
 Item detail routes are nested under collection: `/collection/item/:id`
+
+Two mappings in `presentation/widgets/app_scaffold.dart` must be kept in
+step with this branch order — `shellIndexToMobileIndex` (which bottom-nav
+tab highlights) and `shellIndexToBackBranch` (where system back goes).
+A branch with no entry in either silently falls back to Home, which reads
+as the nav highlighting an unrelated tab. Branch-root screens also carry
+an explicit `leading` back button, since there is no route to pop.
 
 ## Design System
 
@@ -185,8 +201,8 @@ Shape tokens live in `AppShapes` (chunkier Popcorn radii) and the hero-numeric `
 - Soft deletes only: set `deleted = 1`, never hard-delete rows; deleted records are included in sync
 - Metadata lookup follows a tiered strategy: cache check → barcode type detection → specialist API → UPCitemdb fallback
 - Sync uses last-write-wins per-field conflict resolution based on `updated_at` timestamps, with user-facing conflict resolution UI for concurrent edits within a configurable threshold
-- Database schema changes require a new migration in `AppDatabase`
-- Current schema version is 12 with 13 tables: `media_items`, `tags`, `media_item_tags`, `shelves`, `shelf_items`, `barcode_cache`, `sync_log`, `borrowers`, `loans`, `rip_albums`, `rip_tracks`, `batch_sessions`, `batch_queue_items`
+- Database schema changes require a new migration branch in `AppDatabase._runUpgrade` (runs inside a transaction). Any `addColumn` there must use `_addColumnIfMissing` — the v2/v4/v17 branches create tables from the *current* Dart definition, so later columns may already exist and an unguarded add bricks the upgrade with `duplicate column name`
+- Current schema version is 24 with 18 tables: `media_items`, `tags`, `media_item_tags`, `shelves`, `shelf_items`, `barcode_cache`, `sync_log`, `borrowers`, `loans`, `rip_albums`, `rip_tracks`, `batch_sessions`, `batch_queue_items`, `playlists`, `playlist_tracks`, `locations`, `series`, `tmdb_account_sync_items` (plus the `media_items_fts` FTS5 virtual table)
 - Desktop screens use inline `ScreenHeader` widget instead of AppBar; mobile screens keep AppBar for back navigation
 - Sections use tonal containers (`surfaceContainerHigh`) with uppercase label headers, not dividers
 
@@ -208,6 +224,8 @@ Users supply their own API keys (stored in secure storage) for TMDB, Discogs, UP
 
 ## Known Constraints
 
+- macOS runs in the App Sandbox: the FLAC library folder is only readable via a security-scoped bookmark captured when the user picks it with Browse… (method channel `com.mymediascanner/secure_bookmarks` in `MainFlutterWindow.swift`, re-armed at app startup from `app.dart`). Typed paths cannot be granted access; spawned child processes do not inherit the grant
+- Closures passed to `Isolate.run` must not be created inside `async*` methods or capture `this`/fields — the generator's `_AsyncCompleter` makes the spawn message unsendable and the call fails instantly ("object is unsendable"). Create them in a plain frame capturing only sendable values; note `FlacDecoder.decode` already runs in its own isolate, so never wrap it in another
 - `file_picker` pinned to `>=10.3.10 <11.0.0` — v11 has a broken Android Gradle config (missing kotlin-android plugin)
 - iOS deployment target is 15.5 (required by google_mlkit_commons)
 - Google ML Kit ships no arm64-**simulator** binary, so Flutter builds the iOS simulator app as x86_64 — which cannot run on Apple-Silicon iOS 26+ simulators. Physical devices (arm64) build and run normally. To run on a simulator, use `scripts/ios_sim.sh`, which temporarily overrides `google_mlkit_text_recognition` with the pure-Dart stub in `tool/mlkit_text_recognition_stub` (cover OCR returns no text on the simulator; barcode scanning is unaffected)

--- a/lib/presentation/screens/batch/batch_placeholder_screen.dart
+++ b/lib/presentation/screens/batch/batch_placeholder_screen.dart
@@ -136,6 +136,12 @@ class _BatchPlaceholderScreenState
           ? null
           : AppBar(
               title: const Text('Batch Editor'),
+              // Own shell branch entered from the scan screen, so there is
+              // no route to pop and no automatic back button.
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => context.go('/scan'),
+              ),
               actions: [
                 IconButton(
                   icon: const Icon(Icons.undo),

--- a/lib/presentation/screens/collection/collection_screen.dart
+++ b/lib/presentation/screens/collection/collection_screen.dart
@@ -66,6 +66,7 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
     final rippedIds = ref.watch(rippedItemIdsProvider).value ?? <String>{};
     final selectedId = ref.watch(selectedItemProvider);
     final viewMode = ref.watch(collectionViewModeProvider);
+    final filter = ref.watch(collectionFilterProvider);
     final isDesktop = PlatformCapability.isDesktop;
 
     final masterContent = Column(
@@ -191,6 +192,10 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
             ? null
             : AppBar(
                 title: const Text('Library'),
+                // The secondary actions live in an overflow menu: five
+                // IconButtons plus the SortSelector overflowed
+                // AppBar.actions by 57px on a 411dp phone and squeezed the
+                // title out of the toolbar entirely.
                 actions: [
                   IconButton(
                     icon: const Icon(Icons.shelves),
@@ -205,23 +210,77 @@ class _CollectionScreenState extends ConsumerState<CollectionScreen> {
                     tooltip: 'Wishlist',
                     onPressed: () => context.go('/wishlist'),
                   ),
-                  IconButton(
-                    icon: const Icon(Icons.image_search),
-                    tooltip: 'Fetch missing covers',
-                    onPressed: () =>
-                        showFillMissingCoversDialog(context, ref),
+                  PopupMenuButton<String>(
+                    tooltip: 'More actions',
+                    onSelected: (value) {
+                      final notifier =
+                          ref.read(collectionFilterProvider.notifier);
+                      switch (value) {
+                        case 'direction':
+                          notifier.setSort(
+                            filter.sortBy ?? 'dateAdded',
+                            ascending: !filter.ascending,
+                          );
+                        case 'covers':
+                          showFillMissingCoversDialog(context, ref);
+                        case 'export':
+                          _showExportDialog(context, ref);
+                        case 'statistics':
+                          context.go('/collection/statistics');
+                        default:
+                          if (value.startsWith('sort:')) {
+                            notifier.setSort(value.substring(5));
+                          }
+                      }
+                    },
+                    itemBuilder: (_) => [
+                      for (final entry in SortSelector.options.entries)
+                        PopupMenuItem(
+                          value: 'sort:${entry.key}',
+                          child: ListTile(
+                            leading: Icon(
+                              (filter.sortBy ?? 'dateAdded') == entry.key
+                                  ? Icons.radio_button_checked
+                                  : Icons.radio_button_unchecked,
+                            ),
+                            title: Text('Sort by ${entry.value}'),
+                          ),
+                        ),
+                      const PopupMenuDivider(),
+                      PopupMenuItem(
+                        value: 'direction',
+                        child: ListTile(
+                          leading: Icon(filter.ascending
+                              ? Icons.arrow_upward
+                              : Icons.arrow_downward),
+                          title:
+                              Text(filter.ascending ? 'Ascending' : 'Descending'),
+                        ),
+                      ),
+                      const PopupMenuDivider(),
+                      const PopupMenuItem(
+                        value: 'covers',
+                        child: ListTile(
+                          leading: Icon(Icons.image_search),
+                          title: Text('Fetch missing covers'),
+                        ),
+                      ),
+                      const PopupMenuItem(
+                        value: 'export',
+                        child: ListTile(
+                          leading: Icon(Icons.download),
+                          title: Text('Export collection'),
+                        ),
+                      ),
+                      const PopupMenuItem(
+                        value: 'statistics',
+                        child: ListTile(
+                          leading: Icon(Icons.bar_chart),
+                          title: Text('Statistics'),
+                        ),
+                      ),
+                    ],
                   ),
-                  IconButton(
-                    icon: const Icon(Icons.download),
-                    tooltip: 'Export collection',
-                    onPressed: () => _showExportDialog(context, ref),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.bar_chart),
-                    tooltip: 'Statistics',
-                    onPressed: () => context.go('/collection/statistics'),
-                  ),
-                  const SortSelector(),
                 ],
               ),
         body: MasterDetailLayout(

--- a/lib/presentation/screens/collection/widgets/sort_selector.dart
+++ b/lib/presentation/screens/collection/widgets/sort_selector.dart
@@ -5,7 +5,10 @@ import 'package:mymediascanner/presentation/providers/collection_provider.dart';
 class SortSelector extends ConsumerWidget {
   const SortSelector({super.key});
 
-  static const _options = {
+  /// Sort keys mapped to their user-facing labels. Also used by the
+  /// collection screen's mobile overflow menu, which offers the same sort
+  /// choices without the width cost of a dropdown in `AppBar.actions`.
+  static const options = {
     'dateAdded': 'Date Added',
     'title': 'Title',
     'year': 'Year',
@@ -29,7 +32,7 @@ class SortSelector extends ConsumerWidget {
             value: filter.sortBy,
             isExpanded: true,
             underline: const SizedBox.shrink(),
-            items: _options.entries
+            items: options.entries
                 .map((e) => DropdownMenuItem(
                       value: e.key,
                       child: Text(e.value,

--- a/lib/presentation/screens/collection/widgets/time_period_selector.dart
+++ b/lib/presentation/screens/collection/widgets/time_period_selector.dart
@@ -81,6 +81,11 @@ class TimePeriodSelector extends ConsumerWidget {
                 ),
               );
             }).toList(),
+            // Without this the selected segment alone gives up ~24px to a
+            // leading checkmark, so its label is the only one the FittedBox
+            // shrinks — "12 months" renders visibly smaller than its
+            // neighbours. The filled background already signals selection.
+            showSelectedIcon: false,
             selected: {selected},
             onSelectionChanged: (newSelection) {
               ref

--- a/lib/presentation/screens/item_detail/item_detail_screen.dart
+++ b/lib/presentation/screens/item_detail/item_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:mymediascanner/app/theme/app_layout_extension.dart';
+import 'package:mymediascanner/core/constants/app_constants.dart';
 import 'package:mymediascanner/app/theme/app_media_colors.dart';
 import 'package:mymediascanner/domain/entities/media_item.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
@@ -54,39 +55,100 @@ class ItemDetailScreen extends ConsumerWidget {
         if (item == null) {
           return const Scaffold(body: ErrorState(message: 'Item not found'));
         }
+        final needsCover = item.coverUrl == null || item.coverUrl!.isEmpty;
+        // On a phone the four-or-five actions leave the title ~83dp — barely
+        // two words. Collapse everything but Edit into an overflow menu
+        // there; desktop has the width to keep them all inline.
+        final isCompact = MediaQuery.sizeOf(context).width <
+            AppConstants.compactBreakpoint;
+
         return Scaffold(
           appBar: AppBar(
             title: Text(item.title),
             actions: [
-              IconButton(
-                icon: const Icon(Icons.shelves),
-                onPressed: () => showDialog<void>(
-                  context: context,
-                  builder: (_) => ShelfPickerDialog(mediaItemId: item.id),
-                ),
-                tooltip: 'Add to shelf',
-              ),
-              IconButton(
-                icon: const Icon(Icons.refresh),
-                onPressed: () => _refreshMetadata(context, ref, item),
-                tooltip: 'Refresh metadata',
-              ),
-              if (item.coverUrl == null || item.coverUrl!.isEmpty)
+              if (!isCompact) ...[
                 IconButton(
-                  icon: const Icon(Icons.image_search),
-                  onPressed: () => _fetchMissingCover(context, ref, item),
-                  tooltip: 'Fetch cover art',
+                  icon: const Icon(Icons.shelves),
+                  onPressed: () => showDialog<void>(
+                    context: context,
+                    builder: (_) => ShelfPickerDialog(mediaItemId: item.id),
+                  ),
+                  tooltip: 'Add to shelf',
                 ),
+                IconButton(
+                  icon: const Icon(Icons.refresh),
+                  onPressed: () => _refreshMetadata(context, ref, item),
+                  tooltip: 'Refresh metadata',
+                ),
+                if (needsCover)
+                  IconButton(
+                    icon: const Icon(Icons.image_search),
+                    onPressed: () => _fetchMissingCover(context, ref, item),
+                    tooltip: 'Fetch cover art',
+                  ),
+              ],
               IconButton(
                 icon: const Icon(Icons.edit),
                 onPressed: () => context.go('/collection/item/${item.id}/edit'),
                 tooltip: 'Edit',
               ),
-              IconButton(
-                icon: const Icon(Icons.delete_outline),
-                onPressed: () => _confirmDelete(context, ref),
-                tooltip: 'Delete',
-              ),
+              if (!isCompact)
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: () => _confirmDelete(context, ref),
+                  tooltip: 'Delete',
+                ),
+              if (isCompact)
+                PopupMenuButton<String>(
+                  tooltip: 'More actions',
+                  onSelected: (value) {
+                    switch (value) {
+                      case 'shelf':
+                        showDialog<void>(
+                          context: context,
+                          builder: (_) =>
+                              ShelfPickerDialog(mediaItemId: item.id),
+                        );
+                      case 'refresh':
+                        _refreshMetadata(context, ref, item);
+                      case 'cover':
+                        _fetchMissingCover(context, ref, item);
+                      case 'delete':
+                        _confirmDelete(context, ref);
+                    }
+                  },
+                  itemBuilder: (_) => [
+                    const PopupMenuItem(
+                      value: 'shelf',
+                      child: ListTile(
+                        leading: Icon(Icons.shelves),
+                        title: Text('Add to shelf'),
+                      ),
+                    ),
+                    const PopupMenuItem(
+                      value: 'refresh',
+                      child: ListTile(
+                        leading: Icon(Icons.refresh),
+                        title: Text('Refresh metadata'),
+                      ),
+                    ),
+                    if (needsCover)
+                      const PopupMenuItem(
+                        value: 'cover',
+                        child: ListTile(
+                          leading: Icon(Icons.image_search),
+                          title: Text('Fetch cover art'),
+                        ),
+                      ),
+                    const PopupMenuItem(
+                      value: 'delete',
+                      child: ListTile(
+                        leading: Icon(Icons.delete_outline),
+                        title: Text('Delete'),
+                      ),
+                    ),
+                  ],
+                ),
             ],
           ),
           body: SafeArea(

--- a/lib/presentation/screens/item_detail/widgets/location_section.dart
+++ b/lib/presentation/screens/item_detail/widgets/location_section.dart
@@ -84,14 +84,20 @@ class LocationSection extends ConsumerWidget {
         children: [
           Row(
             children: [
-              Text(
-                'LOCATION',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: colors.onSurfaceVariant,
-                  letterSpacing: 0.8,
+              // Expanded rather than Spacer: at large text scales the
+              // buttons alone are wider than the row, so the label has to
+              // be the part that gives way.
+              Expanded(
+                child: Text(
+                  'LOCATION',
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colors.onSurfaceVariant,
+                    letterSpacing: 0.8,
+                  ),
                 ),
               ),
-              const Spacer(),
+              const SizedBox(width: 8),
               TextButton.icon(
                 onPressed: () => _changeLocation(context, ref),
                 icon: Icon(

--- a/lib/presentation/screens/item_detail/widgets/purchase_info_section.dart
+++ b/lib/presentation/screens/item_detail/widgets/purchase_info_section.dart
@@ -173,6 +173,9 @@ class _PurchaseInfoSectionState extends State<PurchaseInfoSection> {
           DropdownButtonFormField<ItemCondition?>(
             key: const Key('condition-dropdown'),
             initialValue: widget.item.condition,
+            // Without this the selected label keeps its natural width and
+            // overflows the field at large text scales.
+            isExpanded: true,
             decoration: const InputDecoration(
               labelText: 'Condition',
               border: OutlineInputBorder(),

--- a/lib/presentation/screens/scanner/mobile_scan_screen.dart
+++ b/lib/presentation/screens/scanner/mobile_scan_screen.dart
@@ -13,6 +13,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:mymediascanner/core/utils/debug_log.dart';
+import 'package:mymediascanner/presentation/providers/batch_editor_provider.dart';
 import 'package:mymediascanner/presentation/providers/scanner_provider.dart';
 import 'package:mymediascanner/presentation/screens/scanner/widgets/batch_scan_counter.dart';
 import 'package:mymediascanner/presentation/screens/scanner/widgets/manual_barcode_entry_dialog.dart';
@@ -165,6 +166,17 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen>
     _cameraController.start();
     debugLog('[MMS-scan] _resumeScanning exit (camera.start dispatched)');
   }
+
+  /// How many scans are actually sitting in the batch queue.
+  ///
+  /// `ScannerState.batchCount` is a separate tally that `toggleBatchMode`
+  /// resets to zero, while the batch session and its rows survive the
+  /// toggle — so it under-reports (the AppBar read "1 scanned" against
+  /// three queued rows). The editor's own list is the source of truth.
+  int get _queuedCount => ref.watch(batchEditorProvider).maybeWhen(
+        data: (state) => state.items.length,
+        orElse: () => 0,
+      );
 
   /// Queue a batch-mode scan result without blocking the synchronous
   /// `ref.listen` callback. The batch editor rolls the item back from
@@ -384,10 +396,10 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen>
         ),
         actions: [
           // Batch mode toggle
-          if (scannerState.batchMode && scannerState.batchCount > 0)
+          if (scannerState.batchMode && _queuedCount > 0)
             Padding(
               padding: const EdgeInsets.only(right: 4),
-              child: BatchScanCounter(count: scannerState.batchCount),
+              child: BatchScanCounter(count: _queuedCount),
             ),
           const Text(
             'Batch',
@@ -408,6 +420,8 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen>
   }
 
   Widget _buildCameraBody(ScannerState scannerState) {
+    final showsStatusStrip = scannerState.state == ScanState.lookingUp ||
+        (scannerState.batchMode && _queuedCount > 0);
     return Stack(
       children: [
         MobileScanner(
@@ -515,6 +529,20 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen>
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
+                // Dropped while a status strip is showing: the panel grows
+                // from the bottom, and keeping both pushes the hint up into
+                // the scan cutout. The strip already says what is happening.
+                if (!showsStatusStrip) ...[
+                  Text(
+                    'Position barcode in frame',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                ],
                 const SaveTargetToggle(),
                 const SizedBox(height: 8),
                 const ScanModeToggle(),
@@ -527,11 +555,12 @@ class _MobileScanScreenState extends ConsumerState<MobileScanScreen>
                     color: Theme.of(context).colorScheme.primary,
                     onCancel: () => ref.read(scannerProvider.notifier).cancel(),
                   ),
-                ] else if (scannerState.batchMode &&
-                    scannerState.batchCount > 0) ...[
+                ] else if (scannerState.batchMode && _queuedCount > 0) ...[
                   const SizedBox(height: 12),
                   _StatusStrip(
-                    label: '${scannerState.batchCount} items queued to batch',
+                    label: _queuedCount == 1
+                        ? '1 item queued to batch'
+                        : '$_queuedCount items queued to batch',
                     color: Theme.of(context).colorScheme.primary,
                   ),
                 ],

--- a/lib/presentation/screens/scanner/widgets/scan_overlay.dart
+++ b/lib/presentation/screens/scanner/widgets/scan_overlay.dart
@@ -23,29 +23,15 @@ class ScanOverlay extends StatelessWidget {
           height: cutoutHeight,
         );
 
-        return Stack(
-          children: [
-            CustomPaint(
-              size: size,
-              painter: _ScanOverlayPainter(
-                cutoutRect: cutoutRect,
-                cornerColour: Theme.of(context).colorScheme.primary,
-              ),
-            ),
-            Positioned(
-              left: 0,
-              right: 0,
-              top: cutoutRect.bottom + 24,
-              child: Text(
-                'Position barcode in frame',
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-            ),
-          ],
+        // The hint text lives in the scan screen's bottom control panel,
+        // not here. Positioned against the cutout it sat at a fixed offset
+        // while the panel grew upward, so the batch banner overlapped it.
+        return CustomPaint(
+          size: size,
+          painter: _ScanOverlayPainter(
+            cutoutRect: cutoutRect,
+            cornerColour: Theme.of(context).colorScheme.primary,
+          ),
         );
       },
     );

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -31,9 +31,26 @@ class SettingsScreen extends ConsumerWidget {
     return Scaffold(
       appBar: isDesktop
           ? null
-          : AppBar(title: const Text('Settings')),
+          : AppBar(
+              title: const Text('Settings'),
+              // Own shell branch entered from the dashboard, so there is no
+              // route to pop and no automatic back button.
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => context.go('/'),
+              ),
+            ),
       body: ListView(
-        padding: const EdgeInsets.all(16),
+        // The shell Scaffold sets extendBody, so the list runs underneath
+        // the bottom nav and reports its height as MediaQuery padding.
+        // Without adding it here the final tile ("About …") sits behind the
+        // nav bar with no scroll extent left to reveal it.
+        padding: EdgeInsets.fromLTRB(
+          16,
+          16,
+          16,
+          16 + MediaQuery.paddingOf(context).bottom,
+        ),
         children: [
           if (isDesktop)
             const ScreenHeader(

--- a/lib/presentation/screens/wishlist/wishlist_screen.dart
+++ b/lib/presentation/screens/wishlist/wishlist_screen.dart
@@ -56,7 +56,15 @@ class WishlistScreen extends ConsumerWidget {
     }
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Wishlist')),
+      appBar: AppBar(
+        title: const Text('Wishlist'),
+        // Own shell branch entered from the Library AppBar, so there is no
+        // route to pop and no automatic back button. Same as ShelvesScreen.
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => context.go('/collection'),
+        ),
+      ),
       body: body,
     );
   }

--- a/lib/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen.dart
+++ b/lib/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mymediascanner/core/utils/platform_utils.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
 import 'package:mymediascanner/domain/entities/metadata_result.dart';
@@ -29,7 +30,15 @@ class WishlistSuggestionsScreen extends ConsumerWidget {
     return Scaffold(
       appBar: isDesktop
           ? null
-          : AppBar(title: const Text('Wishlist suggestions')),
+          : AppBar(
+              title: const Text('Wishlist suggestions'),
+              // Own shell branch entered from the dashboard, so there is no
+              // route to pop and no automatic back button.
+              leading: IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => context.go('/'),
+              ),
+            ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),
         child: Column(

--- a/lib/presentation/widgets/app_scaffold.dart
+++ b/lib/presentation/widgets/app_scaffold.dart
@@ -104,11 +104,26 @@ class AppScaffold extends StatelessWidget {
     final useSidebar = width >= AppConstants.compactBreakpoint;
     final isDesktop = PlatformCapability.isDesktop;
 
+    // Each branch roots its own navigator, so once a branch's nested routes
+    // have popped there is nothing left for the root navigator to pop and
+    // Android back closes the app — even from Settings or Shelves. Send it
+    // to the branch the screen was entered from instead. Nested routes
+    // (item detail, shelf detail) still pop normally: their branch
+    // navigator handles back before it ever reaches this PopScope.
     Widget wrapWithShortcuts(Widget scaffold) {
-      if (!isDesktop) return scaffold;
+      final backBranch = shellIndexToBackBranch(navigationShell.currentIndex);
+      final guarded = PopScope(
+        canPop: backBranch == null,
+        onPopInvokedWithResult: (didPop, _) {
+          if (didPop || backBranch == null) return;
+          navigationShell.goBranch(backBranch);
+        },
+        child: scaffold,
+      );
+      if (!isDesktop) return guarded;
       return DesktopShortcuts(
         onSwitchTab: _onDestinationSelected,
-        child: scaffold,
+        child: guarded,
       );
     }
 
@@ -186,7 +201,7 @@ class AppScaffold extends StatelessWidget {
     // Branch 0 = Dashboard (Home), 1 = Collection (Library),
     // 2 = Scanner, 3 = Shelves, 4 = Batch, 5 = Insights, 6 = Settings, 7 = Rips
     // Mobile shows: Home(0), Scanner(2), Library(1), Insights(5)
-    final mobileIndex = _shellIndexToMobileIndex(navigationShell.currentIndex);
+    final mobileIndex = shellIndexToMobileIndex(navigationShell.currentIndex);
 
     final design = Theme.of(context).extension<AppDesignExtension>();
     final colors = Theme.of(context).colorScheme;
@@ -230,16 +245,6 @@ class AppScaffold extends StatelessWidget {
     );
   }
 
-  int _shellIndexToMobileIndex(int shellIndex) {
-    return switch (shellIndex) {
-      0 => 0, // Dashboard -> Home
-      1 => 2, // Collection -> Library
-      2 => 1, // Scanner -> Scanner
-      5 => 3, // Insights -> Insights
-      _ => 0, // Default to Home
-    };
-  }
-
   int _mobileIndexToShellIndex(int mobileIndex) {
     return switch (mobileIndex) {
       0 => 0, // Home -> Dashboard
@@ -249,6 +254,50 @@ class AppScaffold extends StatelessWidget {
       _ => 0,
     };
   }
+}
+
+/// Maps a router shell branch index onto the four-entry mobile bottom nav.
+///
+/// Only four of the router's 17 branches have their own bottom-nav
+/// destination. The rest are reached from within one of those four, so each
+/// maps onto the destination it is entered from — otherwise the nav
+/// highlights an unrelated tab while the user is somewhere else entirely.
+///
+/// Keep this in step with the branch order in `app/router.dart`.
+int shellIndexToMobileIndex(int shellIndex) {
+  return switch (shellIndex) {
+    0 => 0, // Dashboard  -> Home
+    1 => 2, // Collection -> Library
+    2 => 1, // Scanner    -> Scanner
+    3 => 2, // Shelves    -> Library  (entered from the Library AppBar)
+    4 => 1, // Batch      -> Scanner  (entered from the scan screen)
+    5 => 3, // Insights   -> Insights
+    6 => 0, // Settings   -> Home     (entered from the dashboard)
+    // 7 Rips, 8 Wishlist, 9 Locations, 10 Series, 11 Wishlist suggestions
+    // and 12-16 the TMDB account lists are all library-side content views.
+    >= 7 && <= 16 => 2, // -> Library
+    _ => 0, // Default to Home
+  };
+}
+
+/// The branch a system back gesture should return to, or `null` on the
+/// Dashboard where back should fall through and exit the app.
+///
+/// Every branch is a root of its own navigator, so once its nested routes
+/// have popped there is nothing left to pop and Android back would close
+/// the app — even from Settings or Shelves. These targets mirror the
+/// leading back buttons on the same screens so both gestures agree.
+int? shellIndexToBackBranch(int shellIndex) {
+  return switch (shellIndex) {
+    0 => null, // Dashboard  -> let back exit the app
+    3 => 1, // Shelves    -> Collection
+    4 => 2, // Batch      -> Scanner
+    11 => 0, // Suggestions -> Dashboard
+    // 7 Rips, 8 Wishlist, 9 Locations, 10 Series and 12-16 the TMDB
+    // account lists are all reached from the library.
+    >= 7 && <= 16 => 1, // -> Collection
+    _ => 0, // Everything else -> Dashboard
+  };
 }
 
 // ── Desktop sidebar ──────────────────────────────────────────────────

--- a/test/unit/presentation/widgets/app_scaffold_nav_index_test.dart
+++ b/test/unit/presentation/widgets/app_scaffold_nav_index_test.dart
@@ -1,0 +1,102 @@
+// Unit tests for the shell-branch -> mobile-bottom-nav index mapping.
+//
+// Four of the eight router branches own a bottom-nav destination. The other
+// four are reached from within one of those, and must highlight the tab they
+// were entered from rather than falling back to Home.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/widgets/app_scaffold.dart';
+
+void main() {
+  group('shellIndexToMobileIndex', () {
+    test('maps the four branches that own a nav destination', () {
+      expect(shellIndexToMobileIndex(0), 0, reason: 'Dashboard -> Home');
+      expect(shellIndexToMobileIndex(2), 1, reason: 'Scanner -> Scanner');
+      expect(shellIndexToMobileIndex(1), 2, reason: 'Collection -> Library');
+      expect(shellIndexToMobileIndex(5), 3, reason: 'Insights -> Insights');
+    });
+
+    test('highlights Library for Shelves, entered from the Library AppBar', () {
+      expect(shellIndexToMobileIndex(3), 2);
+    });
+
+    test('highlights Scanner for Batch, entered from the scan screen', () {
+      expect(shellIndexToMobileIndex(4), 1);
+    });
+
+    test('highlights Library for Rips, a library-side view', () {
+      expect(shellIndexToMobileIndex(7), 2);
+    });
+
+    test('highlights Home for Settings, entered from the dashboard', () {
+      expect(shellIndexToMobileIndex(6), 0);
+    });
+
+    test('highlights Library for the content branches 8-16', () {
+      // Wishlist is reachable on mobile from the Library AppBar; the rest
+      // are desktop-sidebar views. All of them list media, so Library is
+      // the honest tab rather than Home.
+      for (var branch = 8; branch <= 16; branch++) {
+        expect(
+          shellIndexToMobileIndex(branch),
+          2,
+          reason: 'branch $branch is a library-side content view',
+        );
+      }
+    });
+
+    test('falls back to Home for an unknown branch index', () {
+      expect(shellIndexToMobileIndex(99), 0);
+    });
+  });
+
+  group('shellIndexToBackBranch', () {
+    test('returns null on the Dashboard so back exits the app', () {
+      expect(shellIndexToBackBranch(0), isNull);
+    });
+
+    test('returns Dashboard from the other top-level tabs', () {
+      expect(shellIndexToBackBranch(1), 0, reason: 'Collection -> Dashboard');
+      expect(shellIndexToBackBranch(2), 0, reason: 'Scanner -> Dashboard');
+      expect(shellIndexToBackBranch(5), 0, reason: 'Insights -> Dashboard');
+    });
+
+    test('returns the branch each drill-down was entered from', () {
+      expect(shellIndexToBackBranch(3), 1, reason: 'Shelves -> Collection');
+      expect(shellIndexToBackBranch(4), 2, reason: 'Batch -> Scanner');
+      expect(shellIndexToBackBranch(6), 0, reason: 'Settings -> Dashboard');
+      expect(shellIndexToBackBranch(8), 1, reason: 'Wishlist -> Collection');
+      expect(
+        shellIndexToBackBranch(11),
+        0,
+        reason: 'Wishlist suggestions -> Dashboard',
+      );
+    });
+
+    test('mirrors the leading back buttons on those screens', () {
+      // ShelvesScreen and WishlistScreen send their AppBar back button to
+      // /collection; BatchPlaceholderScreen to /scan; SettingsScreen and
+      // WishlistSuggestionsScreen to /. System back must agree, or the two
+      // gestures land the user in different places.
+      expect(shellIndexToBackBranch(3), shellIndexToBackBranch(8));
+      expect(shellIndexToBackBranch(6), shellIndexToBackBranch(11));
+    });
+
+    test('sends the remaining library-side branches to Collection', () {
+      for (final branch in [7, 9, 10, 12, 13, 14, 15, 16]) {
+        expect(
+          shellIndexToBackBranch(branch),
+          1,
+          reason: 'branch $branch is reached from the library',
+        );
+      }
+    });
+
+    test('falls back to Dashboard for an unknown branch index', () {
+      expect(shellIndexToBackBranch(99), 0);
+    });
+  });
+}

--- a/test/widget/presentation/screens/collection/collection_screen_test.dart
+++ b/test/widget/presentation/screens/collection/collection_screen_test.dart
@@ -69,6 +69,16 @@ void _configureDesktopViewport(WidgetTester tester) {
   addTearDown(tester.view.resetDevicePixelRatio);
 }
 
+/// Sets a phone-sized viewport matching a Galaxy S9+ in logical pixels
+/// (411.4×797.7dp) so [CollectionScreen]'s mobile `AppBar` branch is laid
+/// out at a realistic narrow width.
+void _configureMobileViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(411, 798);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
 /// Wraps [CollectionScreen] in a minimal GoRouter + ProviderScope so that
 /// GoRouter-dependent code (context.go, etc.) does not throw.
 Widget _wrap({
@@ -351,5 +361,116 @@ void main() {
       },
       variant: TargetPlatformVariant.desktop(),
     );
+
+    testWidgets(
+      'mobile AppBar lays out without overflowing on a phone-width screen',
+      (tester) async {
+        _configureMobileViewport(tester);
+        _stubEmpty(mediaRepo, loanRepo, ripRepo);
+
+        await tester.pumpWidget(
+          _wrap(
+            mediaRepo: mediaRepo,
+            loanRepo: loanRepo,
+            borrowerRepo: borrowerRepo,
+            ripRepo: ripRepo,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'mobile AppBar keeps its title visible alongside the actions',
+      (tester) async {
+        _configureMobileViewport(tester);
+        _stubEmpty(mediaRepo, loanRepo, ripRepo);
+
+        await tester.pumpWidget(
+          _wrap(
+            mediaRepo: mediaRepo,
+            loanRepo: loanRepo,
+            borrowerRepo: borrowerRepo,
+            ripRepo: ripRepo,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // find.text alone is not enough: an ellipsised title still matches
+        // even when the actions have squeezed it down to a few pixels.
+        expect(find.text('Library'), findsOneWidget);
+        expect(
+          tester.getSize(find.text('Library')).width,
+          greaterThan(50),
+          reason: 'the title must have room to render, not be ellipsised away',
+        );
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    testWidgets(
+      'mobile AppBar exposes the secondary actions in an overflow menu',
+      (tester) async {
+        _configureMobileViewport(tester);
+        _stubEmpty(mediaRepo, loanRepo, ripRepo);
+
+        await tester.pumpWidget(
+          _wrap(
+            mediaRepo: mediaRepo,
+            loanRepo: loanRepo,
+            borrowerRepo: borrowerRepo,
+            ripRepo: ripRepo,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(PopupMenuButton<String>));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Fetch missing covers'), findsOneWidget);
+        expect(find.text('Export collection'), findsOneWidget);
+        expect(find.text('Statistics'), findsOneWidget);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+
+    // Android 14+ lets users scale text to 200%; the AppBar and the grid
+    // cards must still fit a 411dp phone.
+    for (final scale in const [1.3, 1.6, 2.0]) {
+      testWidgets(
+        'lays out without overflow at textScale $scale',
+        (tester) async {
+          _configureMobileViewport(tester);
+          _stubEmpty(mediaRepo, loanRepo, ripRepo);
+          when(() => mediaRepo.watchByStatus(OwnershipStatus.owned))
+              .thenAnswer((_) => Stream.value([
+                    _item(
+                      id: 'p1',
+                      title: 'A Really Rather Long Film Title Indeed',
+                    ),
+                    _item(id: 'p2', title: 'Short'),
+                  ]));
+
+          await tester.pumpWidget(
+            MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+              child: _wrap(
+                mediaRepo: mediaRepo,
+                loanRepo: loanRepo,
+                borrowerRepo: borrowerRepo,
+                ripRepo: ripRepo,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+      );
+    }
   });
 }

--- a/test/widget/presentation/screens/collection/widgets/time_period_selector_test.dart
+++ b/test/widget/presentation/screens/collection/widgets/time_period_selector_test.dart
@@ -51,4 +51,26 @@ void main() {
       expect(tester.takeException(), isNull);
     },
   );
+
+  testWidgets(
+    'the selected segment reserves no width for a checkmark icon',
+    (tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: Scaffold(
+              body: SizedBox(width: 320, child: TimePeriodSelector()),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The default leading checkmark steals horizontal space from the
+      // selected segment only, so its label alone scales down and renders
+      // visibly smaller than its neighbours. Selection stays legible via
+      // the filled background colour instead.
+      expect(find.byIcon(Icons.check), findsNothing);
+    },
+  );
 }

--- a/test/widget/presentation/screens/item_detail/item_detail_screen_test.dart
+++ b/test/widget/presentation/screens/item_detail/item_detail_screen_test.dart
@@ -334,5 +334,83 @@ void main() {
         expect(find.textContaining('MusicBrainz'), findsOneWidget);
       },
     );
+
+    // -----------------------------------------------------------------------
+    // AppBar crowding on a phone-width screen
+    // -----------------------------------------------------------------------
+
+    testWidgets(
+      'AppBar title keeps its width on a phone when the item has no cover',
+      (tester) async {
+        // A cover-less item shows the extra "Fetch cover art" action, which
+        // is the worst case: five IconButtons plus the back button leave the
+        // title barely any room on a 411dp phone.
+        tester.view.physicalSize = const Size(411, 798);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        _stubLendingProviders(loanRepo, borrowerRepo);
+        _stubNoRip(ripRepo);
+
+        await tester.pumpWidget(
+          _wrap(
+            item: _baseItem,
+            mediaRepo: mediaRepo,
+            loanRepo: loanRepo,
+            borrowerRepo: borrowerRepo,
+            ripRepo: ripRepo,
+            tagRepo: tagRepo,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final titleFinder = find.descendant(
+          of: find.byType(AppBar),
+          matching: find.text(_baseItem.title),
+        );
+        expect(titleFinder, findsOneWidget);
+        expect(
+          tester.getSize(titleFinder).width,
+          greaterThan(150),
+          reason: 'the actions must not squeeze the title off the toolbar',
+        );
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    // Android 14+ lets users scale text to 200%. At that size the purchase
+    // and location sections overflowed their rows.
+    for (final scale in const [1.3, 1.6, 2.0]) {
+      testWidgets(
+        'lays out without overflow at textScale $scale',
+        (tester) async {
+          tester.view.physicalSize = const Size(411, 798);
+          tester.view.devicePixelRatio = 1.0;
+          addTearDown(tester.view.resetPhysicalSize);
+          addTearDown(tester.view.resetDevicePixelRatio);
+
+          _stubLendingProviders(loanRepo, borrowerRepo);
+          _stubNoRip(ripRepo);
+
+          await tester.pumpWidget(
+            MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+              child: _wrap(
+                item: _baseItem,
+                mediaRepo: mediaRepo,
+                loanRepo: loanRepo,
+                borrowerRepo: borrowerRepo,
+                ripRepo: ripRepo,
+                tagRepo: tagRepo,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+        },
+      );
+    }
   });
 }

--- a/test/widget/presentation/screens/wishlist/wishlist_screen_test.dart
+++ b/test/widget/presentation/screens/wishlist/wishlist_screen_test.dart
@@ -35,6 +35,10 @@ Widget _wrap(IMediaItemRepository repo, {GoRouter? router}) {
             builder: (_, _) => const WishlistScreen(),
           ),
           GoRoute(
+            path: '/collection',
+            builder: (_, _) => const Scaffold(body: Text('collection')),
+          ),
+          GoRoute(
             path: '/collection/item/:id',
             builder: (_, state) =>
                 Scaffold(body: Text('detail:${state.pathParameters['id']}')),
@@ -115,4 +119,36 @@ void main() {
     expect(captured.ownershipStatus, OwnershipStatus.owned);
     expect(captured.acquiredAt, isNotNull);
   });
+
+  testWidgets(
+    'mobile AppBar offers a way back to the collection',
+    (tester) async {
+      // /wishlist is its own shell branch entered from the Library AppBar,
+      // so there is no route to pop and GoRouter renders no back button.
+      // Without an explicit one the only way out is the bottom nav — the
+      // same reason ShelvesScreen carries a leading back button.
+      tester.view.physicalSize = const Size(411, 798);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final repo = MockMediaItemRepository();
+      when(() => repo.watchByStatus(OwnershipStatus.wishlist))
+          .thenAnswer((_) => Stream.value([_wishlistItem()]));
+
+      await tester.pumpWidget(_wrap(repo));
+      await tester.pumpAndSettle();
+
+      final back = find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byIcon(Icons.arrow_back),
+      );
+      expect(back, findsOneWidget);
+
+      await tester.tap(back);
+      await tester.pumpAndSettle();
+
+      expect(find.text('collection'), findsOneWidget);
+    },
+  );
 }

--- a/test/widget/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen_test.dart
+++ b/test/widget/presentation/screens/wishlist_suggestions/wishlist_suggestions_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:mymediascanner/domain/entities/media_item.dart';
 import 'package:mymediascanner/domain/entities/media_type.dart';
@@ -125,4 +126,48 @@ void main() {
     final status = captured[1] as OwnershipStatus;
     expect(status, OwnershipStatus.wishlist);
   });
+
+  testWidgets(
+    'mobile AppBar offers a way back to the dashboard',
+    (tester) async {
+      // Reached from the dashboard recommendations section, and its own
+      // shell branch — so nothing to pop and no automatic back button.
+      final router = GoRouter(
+        initialLocation: '/wishlist-suggestions',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, _) => const Scaffold(body: Text('dashboard')),
+          ),
+          GoRoute(
+            path: '/wishlist-suggestions',
+            builder: (_, _) => const WishlistSuggestionsScreen(),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            wishlistSuggestionsProvider.overrideWith((ref) async => const []),
+            saveMediaItemUseCaseProvider.overrideWithValue(saveUseCase),
+          ],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final back = find.descendant(
+        of: find.byType(AppBar),
+        matching: find.byIcon(Icons.arrow_back),
+      );
+      expect(back, findsOneWidget);
+
+      await tester.tap(back);
+      await tester.pumpAndSettle();
+
+      expect(find.text('dashboard'), findsOneWidget);
+    },
+    variant: TargetPlatformVariant.only(TargetPlatform.android),
+  );
 }


### PR DESCRIPTION
Three independent mobile fixes found while working through the app on a phone, plus a docs refresh.

## Android system back closed the app

Every `StatefulShellBranch` roots its own navigator, so once a branch's nested routes had popped there was nothing left for the root navigator to pop — back closed the app outright from Settings, Shelves, Wishlist and the rest, not just the Dashboard.

The shell now wraps in a `PopScope` that redirects to the branch the screen was entered from, and the branch-root screens carry an explicit leading back button so the gesture and the button agree.

Separately, the bottom-nav index mapping only covered 4 of the router's 17 branches; the other 13 fell through to Home and highlighted an unrelated tab while the user was somewhere else. Both mappings are now top-level functions (`shellIndexToMobileIndex`, `shellIndexToBackBranch`) covering every branch, with unit tests.

## AppBar actions overflowed on phones

The Library AppBar carried five `IconButton`s plus a `SortSelector` dropdown, overrunning `AppBar.actions` by 57px on a 411dp phone and squeezing the title out of the toolbar. Item detail was the same — four or five actions left the title about 83dp.

Secondary actions move into an overflow menu on both: unconditionally on the collection, and only below the compact breakpoint on item detail so desktop keeps them inline.

Two large-text-scale fixes ride along — the `LOCATION` header takes an `Expanded` so the label rather than the buttons gives way, and the condition dropdown takes `isExpanded`.

## Batch counter under-reported

`ScannerState.batchCount` is a separate tally that `toggleBatchMode` resets to zero, while the batch session and its rows survive the toggle — the AppBar read "1 scanned" against three queued rows. It now reads the batch editor's list, which is the source of truth.

The "Position barcode in frame" hint also moves out of the overlay into the bottom control panel; positioned against the scan cutout it sat at a fixed offset while the panel grew upward beneath it, so the batch banner overlapped it.

## Docs

The route table stopped at 8 branches against 17, the schema notes described v12/13 tables against v24/18, and the test count was stale by about a thousand. Also records constraints not recoverable from the code: the macOS sandbox bookmark, the `Isolate.run` closure restriction in `async*` frames, and the `_addColumnIfMissing` migration rule.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 1791 passed

Not yet exercised on a physical device. The back gesture and the overflow menus are phone-specific, and widget tests will not catch a `PopScope` misbehaving against the real Android back handler — worth a device pass before merging.