### PR TITLE
fix(nav): move the system-back guard inside the shell branch

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -32,6 +32,7 @@ import 'package:mymediascanner/presentation/screens/about/about_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrowers_screen.dart';
 import 'package:mymediascanner/presentation/screens/borrowers/borrower_detail_screen.dart';
 import 'package:mymediascanner/presentation/widgets/app_scaffold.dart';
+import 'package:mymediascanner/presentation/widgets/branch_back_guard.dart';
 import 'package:mymediascanner/domain/entities/tmdb_bridge_bucket.dart';
 import 'package:mymediascanner/presentation/screens/tmdb/tmdb_bucket_screen.dart';
 import 'package:mymediascanner/presentation/screens/tmdb/tmdb_resolve_conflicts_screen.dart';
@@ -96,7 +97,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/',
-              builder: (context, state) => const DashboardScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: DashboardScreen()),
             ),
           ],
         ),
@@ -106,7 +108,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/collection',
-              builder: (context, state) => const CollectionScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: CollectionScreen()),
               routes: [
                 GoRoute(
                   path: 'statistics',
@@ -148,7 +151,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/scan',
-              builder: (context, state) => const ScannerScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: ScannerScreen()),
               routes: [
                 GoRoute(
                   path: 'confirm',
@@ -172,7 +176,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/shelves',
-              builder: (context, state) => const ShelvesScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: ShelvesScreen()),
               routes: [
                 GoRoute(
                   path: ':id',
@@ -190,8 +195,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/batch',
-              builder: (context, state) =>
-                  const BatchPlaceholderScreen(),
+              builder: (context, state) => const BranchBackGuard(
+                  child: BatchPlaceholderScreen()),
               routes: [
                 GoRoute(
                   path: 'history',
@@ -209,7 +214,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/insights',
-              builder: (context, state) => const StatisticsScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: StatisticsScreen()),
             ),
           ],
         ),
@@ -219,7 +225,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/settings',
-              builder: (context, state) => const SettingsScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: SettingsScreen()),
               routes: [
                 GoRoute(
                   path: 'postgres',
@@ -291,7 +298,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/rips',
-              builder: (context, state) => const RipsScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: RipsScreen()),
             ),
           ],
         ),
@@ -301,7 +309,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/wishlist',
-              builder: (context, state) => const WishlistScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: WishlistScreen()),
             ),
           ],
         ),
@@ -311,7 +320,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/locations',
-              builder: (context, state) => const LocationBrowserScreen(),
+              builder: (context, state) => const BranchBackGuard(
+                  child: LocationBrowserScreen()),
             ),
           ],
         ),
@@ -321,7 +331,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/series',
-              builder: (context, state) => const SeriesListScreen(),
+              builder: (context, state) =>
+                  const BranchBackGuard(child: SeriesListScreen()),
               routes: [
                 GoRoute(
                   path: ':id',
@@ -339,8 +350,8 @@ final router = GoRouter(
           routes: [
             GoRoute(
               path: '/wishlist-suggestions',
-              builder: (context, state) =>
-                  const WishlistSuggestionsScreen(),
+              builder: (context, state) => const BranchBackGuard(
+                  child: WishlistSuggestionsScreen()),
             ),
           ],
         ),
@@ -351,8 +362,9 @@ final router = GoRouter(
             GoRoute(
               path: '/tmdb/watchlist',
               pageBuilder: (context, state) => const NoTransitionPage(
-                  child: TmdbBucketScreen(
-                      bucket: TmdbBridgeBucket.watchlist)),
+                  child: BranchBackGuard(
+                      child: TmdbBucketScreen(
+                          bucket: TmdbBridgeBucket.watchlist))),
             ),
           ],
         ),
@@ -363,8 +375,9 @@ final router = GoRouter(
             GoRoute(
               path: '/tmdb/rated',
               pageBuilder: (context, state) => const NoTransitionPage(
-                  child: TmdbBucketScreen(
-                      bucket: TmdbBridgeBucket.rated)),
+                  child: BranchBackGuard(
+                      child: TmdbBucketScreen(
+                          bucket: TmdbBridgeBucket.rated))),
             ),
           ],
         ),
@@ -375,8 +388,9 @@ final router = GoRouter(
             GoRoute(
               path: '/tmdb/favourites',
               pageBuilder: (context, state) => const NoTransitionPage(
-                  child: TmdbBucketScreen(
-                      bucket: TmdbBridgeBucket.favourite)),
+                  child: BranchBackGuard(
+                      child: TmdbBucketScreen(
+                          bucket: TmdbBridgeBucket.favourite))),
             ),
           ],
         ),
@@ -387,7 +401,9 @@ final router = GoRouter(
             GoRoute(
               path: '/tmdb/saved',
               pageBuilder: (context, state) => const NoTransitionPage(
-                  child: TmdbBucketScreen(bucket: TmdbBridgeBucket.saved)),
+                  child: BranchBackGuard(
+                      child: TmdbBucketScreen(
+                          bucket: TmdbBridgeBucket.saved))),
             ),
           ],
         ),
@@ -399,7 +415,7 @@ final router = GoRouter(
             GoRoute(
               path: '/tmdb/conflicts',
               pageBuilder: (context, state) => const NoTransitionPage(
-                  child: TmdbResolveConflictsScreen()),
+                  child: BranchBackGuard(child: TmdbResolveConflictsScreen())),
             ),
           ],
         ),

--- a/lib/presentation/widgets/app_scaffold.dart
+++ b/lib/presentation/widgets/app_scaffold.dart
@@ -104,26 +104,15 @@ class AppScaffold extends StatelessWidget {
     final useSidebar = width >= AppConstants.compactBreakpoint;
     final isDesktop = PlatformCapability.isDesktop;
 
-    // Each branch roots its own navigator, so once a branch's nested routes
-    // have popped there is nothing left for the root navigator to pop and
-    // Android back closes the app — even from Settings or Shelves. Send it
-    // to the branch the screen was entered from instead. Nested routes
-    // (item detail, shelf detail) still pop normally: their branch
-    // navigator handles back before it ever reaches this PopScope.
+    // The system-back guard is NOT here: a PopScope wrapping the shell is
+    // never consulted on Android 15+, because the platform's back callback
+    // only reaches routes inside the current branch's navigator. It lives
+    // in `BranchBackGuard`, applied per branch root in `app/router.dart`.
     Widget wrapWithShortcuts(Widget scaffold) {
-      final backBranch = shellIndexToBackBranch(navigationShell.currentIndex);
-      final guarded = PopScope(
-        canPop: backBranch == null,
-        onPopInvokedWithResult: (didPop, _) {
-          if (didPop || backBranch == null) return;
-          navigationShell.goBranch(backBranch);
-        },
-        child: scaffold,
-      );
-      if (!isDesktop) return guarded;
+      if (!isDesktop) return scaffold;
       return DesktopShortcuts(
         onSwitchTab: _onDestinationSelected,
-        child: guarded,
+        child: scaffold,
       );
     }
 

--- a/lib/presentation/widgets/branch_back_guard.dart
+++ b/lib/presentation/widgets/branch_back_guard.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/presentation/widgets/app_scaffold.dart';
+
+/// Sends the Android back gesture to the branch a screen was entered from,
+/// instead of letting it close the app.
+///
+/// Wraps the *root* screen of each `StatefulShellBranch`. Every branch roots
+/// its own navigator, so once a branch's nested routes have popped there is
+/// nothing left to pop and back would otherwise fall through to
+/// `SystemNavigator.pop()` — closing the app from Settings, Shelves,
+/// Wishlist and the rest.
+///
+/// This has to sit *inside* the branch. An earlier attempt put the same
+/// `PopScope` around the shell in `AppScaffold`; on an Android 16 device
+/// its callback was never invoked once and back closed the app anyway.
+/// Moving it in-branch fixed it. The difference only shows up on the
+/// `OnBackInvokedCallback` path that Android 15+ uses by default — on the
+/// legacy pop channel (and so in widget tests) a shell-level guard is
+/// consulted quite happily, which is why this was merged looking correct.
+/// In-branch works on both paths.
+///
+/// Nested routes (item detail, shelf detail) are unaffected: their branch
+/// navigator pops them before the guard is reached.
+class BranchBackGuard extends StatelessWidget {
+  const BranchBackGuard({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final shell = StatefulNavigationShell.of(context);
+    final backBranch = shellIndexToBackBranch(shell.currentIndex);
+    return PopScope(
+      canPop: backBranch == null,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop || backBranch == null) return;
+        shell.goBranch(backBranch);
+      },
+      child: child,
+    );
+  }
+}

--- a/test/widget/presentation/widgets/branch_back_guard_test.dart
+++ b/test/widget/presentation/widgets/branch_back_guard_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mymediascanner/presentation/widgets/branch_back_guard.dart';
+
+/// Drives a system back press through a real `StatefulShellRoute` and
+/// asserts where it lands.
+///
+/// Read this before trusting it: `handlePopRoute` simulates the *legacy*
+/// pop channel, and on that path a `PopScope` is consulted wherever it sits
+/// — including around the shell. These tests were checked against the
+/// earlier shell-level placement and passed, so **they cannot tell the two
+/// placements apart**. On Android 15+, where the platform drives back
+/// through `OnBackInvokedCallback`, only the in-branch guard is consulted
+/// and the shell-level one was never called at all.
+///
+/// So: these cover the routing behaviour (which branch back lands on, that
+/// the root still exits, that nested routes pop first) on the legacy path.
+/// They do not prove the guard is reached on a modern device — that needs
+/// checking on a real Android 15+ device or emulator.
+void main() {
+  /// Mirrors the real router's shape closely enough to exercise dispatch:
+  /// an indexed-stack shell whose branches each root their own navigator,
+  /// with branch 1 owning a nested route.
+  GoRouter buildRouter() {
+    return GoRouter(
+      initialLocation: '/',
+      routes: [
+        StatefulShellRoute.indexedStack(
+          builder: (context, state, navigationShell) =>
+              Scaffold(body: navigationShell),
+          branches: [
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/',
+                  builder: (_, _) =>
+                      const BranchBackGuard(child: Text('dashboard')),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/collection',
+                  builder: (_, _) =>
+                      const BranchBackGuard(child: Text('collection')),
+                  routes: [
+                    GoRoute(
+                      path: 'item',
+                      builder: (_, _) => const Scaffold(
+                        body: Text('item detail'),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            // Branch order has to match the real router's, since the guard
+            // resolves its target from the shell's current index.
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/scan',
+                  builder: (_, _) =>
+                      const BranchBackGuard(child: Text('scanner')),
+                ),
+              ],
+            ),
+            StatefulShellBranch(
+              routes: [
+                GoRoute(
+                  path: '/shelves',
+                  builder: (_, _) =>
+                      const BranchBackGuard(child: Text('shelves')),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<void> pumpApp(WidgetTester tester, GoRouter router) async {
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+  }
+
+  /// Returns true when the app handled the pop itself, false when it let the
+  /// press fall through — which on Android closes the app.
+  Future<bool> pressSystemBack(WidgetTester tester) async {
+    final handled = await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+    return handled;
+  }
+
+  testWidgets(
+    'back from a non-root branch returns to its entry branch, not the OS',
+    (tester) async {
+      final router = buildRouter();
+      await pumpApp(tester, router);
+
+      router.go('/shelves');
+      await tester.pumpAndSettle();
+      expect(find.text('shelves'), findsOneWidget);
+
+      final handled = await pressSystemBack(tester);
+
+      expect(handled, isTrue,
+          reason: 'the press must be consumed, or Android closes the app');
+      expect(find.text('collection'), findsOneWidget,
+          reason: 'shelves is entered from the library');
+      expect(find.text('shelves'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'back from the dashboard falls through so the OS can close the app',
+    (tester) async {
+      final router = buildRouter();
+      await pumpApp(tester, router);
+      expect(find.text('dashboard'), findsOneWidget);
+
+      final handled = await pressSystemBack(tester);
+
+      expect(handled, isFalse,
+          reason: 'the dashboard is the root — back should exit');
+      expect(find.text('dashboard'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'back from a nested route pops it without leaving the branch',
+    (tester) async {
+      final router = buildRouter();
+      await pumpApp(tester, router);
+
+      router.go('/collection/item');
+      await tester.pumpAndSettle();
+      expect(find.text('item detail'), findsOneWidget);
+
+      final handled = await pressSystemBack(tester);
+
+      expect(handled, isTrue);
+      expect(find.text('collection'), findsOneWidget,
+          reason: 'the nested route pops back to its own branch root');
+      expect(find.text('item detail'), findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
Follow-up to #116. The back-navigation guard that PR added does not run on Android 15+.

## What was wrong

`AppScaffold` wrapped the shell scaffold in a `PopScope`. On Android 15+ the platform drives back through `OnBackInvokedCallback`, and only routes inside the *current branch's* navigator participate — the shell sits above them, so the guard was silently never consulted.

Verified on an Android 16 emulator: a `debugPrint` in `onPopInvokedWithResult` was never reached once, and back still closed the app from Settings and Wishlist. Moving the same `PopScope` inside `SettingsScreen` made it fire immediately, which confirmed the placement was the whole problem.

**It does work on the legacy pop channel.** Confirmed on an Android 10 handset: the merged `main` build returns Settings to the dashboard exactly as intended. So this is a version-specific failure, not a wholesale one — which is why it survived both the widget tests and review.

## The fix

`BranchBackGuard` holds the logic and is applied to each of the 17 branch-root routes in `router.dart`, putting it inside the branch navigator where the callback reaches it on either path. `shellIndexToBackBranch` is unchanged — it was correct all along, just never consulted on modern Android.

The inert `PopScope` is removed from `AppScaffold`, with a comment recording why the guard cannot live there.

## Verified on device

Both at 411.4dp logical width.

| Case | Android 16 emulator (before) | Android 16 (after) | Android 10 handset (after) |
|---|---|---|---|
| Settings → back | exits to launcher | → Dashboard | → Dashboard |
| Wishlist → back | exits to launcher | → Library | → Library |
| Shelves → back | exits to launcher | stays in app | — |
| Dashboard → back | exits | exits (intended) | exits (intended) |
| Nested route → back | pops correctly | pops correctly | — |

The Library AppBar overflow fix from #116 also confirmed on the handset: title and three actions fit with no overflow.

`flutter analyze` clean; `flutter test` 1794 passed.

## About the tests

Worth being explicit, because it is the reason this shipped broken: **the widget tests could not have caught this and still cannot.** The test binding simulates the legacy pop channel, on which a `PopScope` is consulted wherever it sits — I checked the new tests against the old shell-level placement and they pass there too.

So the new tests cover routing behaviour (which branch back lands on, that the root still exits, that nested routes pop first). They do not prove the guard is reached on a modern device. That limitation is written into the test file's doc comment rather than left for someone to rediscover. Closing it properly would need an `integration_test` running on a real Android 15+ device.