### PR TITLE
fix(settings): stop the playback and palette rows breaking at large text

### DIFF
--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -516,7 +516,10 @@ class _PaletteCard extends StatelessWidget {
         onTap: onTap,
         borderRadius: BorderRadius.circular(12),
         child: Container(
-          height: 88,
+          // A minimum rather than a fixed height: the palette name scales
+          // with text size while the swatches do not, so a hard 88 clipped
+          // and overflowed the tile by ~14px at 1.5x.
+          constraints: const BoxConstraints(minHeight: 88),
           padding: const EdgeInsets.all(10),
           decoration: BoxDecoration(
             color: surface,
@@ -657,6 +660,36 @@ class _ReplayGainSection extends ConsumerWidget {
     final preamp = ref.watch(replayGainPreampProvider);
     final preventClipping = ref.watch(preventClippingProvider);
 
+    final modeSelector = SegmentedButton<ReplayGainMode>(
+      segments: const [
+        ButtonSegment(
+          value: ReplayGainMode.off,
+          label: Text('Off'),
+        ),
+        ButtonSegment(
+          value: ReplayGainMode.track,
+          label: Text('Track'),
+        ),
+        ButtonSegment(
+          value: ReplayGainMode.album,
+          label: Text('Album'),
+        ),
+      ],
+      selected: {mode},
+      onSelectionChanged: (selection) {
+        ref.read(replayGainModeProvider.notifier).setMode(selection.first);
+      },
+      showSelectedIcon: false,
+    );
+
+    // The segment labels scale with text size, and as a ListTile `trailing`
+    // the selector claims its intrinsic width before the title column gets
+    // what is left. At 1.5x on a phone that left the title about 110px, so
+    // "ReplayGain Mode" wrapped one or two characters per line and the row
+    // overflowed. Past ~1.3x there is no longer room for both side by side.
+    final textScale = MediaQuery.textScalerOf(context).scale(14) / 14;
+    final stackSelector = textScale > 1.3;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -665,30 +698,13 @@ class _ReplayGainSection extends ConsumerWidget {
           contentPadding: EdgeInsets.zero,
           title: const Text('ReplayGain Mode'),
           subtitle: const Text('Normalise track loudness'),
-          trailing: SegmentedButton<ReplayGainMode>(
-            segments: const [
-              ButtonSegment(
-                value: ReplayGainMode.off,
-                label: Text('Off'),
-              ),
-              ButtonSegment(
-                value: ReplayGainMode.track,
-                label: Text('Track'),
-              ),
-              ButtonSegment(
-                value: ReplayGainMode.album,
-                label: Text('Album'),
-              ),
-            ],
-            selected: {mode},
-            onSelectionChanged: (selection) {
-              ref
-                  .read(replayGainModeProvider.notifier)
-                  .setMode(selection.first);
-            },
-            showSelectedIcon: false,
-          ),
+          trailing: stackSelector ? null : modeSelector,
         ),
+        if (stackSelector)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: modeSelector,
+          ),
 
         // Pre-amp
         ListTile(

--- a/test/widget/presentation/screens/settings/settings_screen_test.dart
+++ b/test/widget/presentation/screens/settings/settings_screen_test.dart
@@ -96,6 +96,7 @@ class _FakePreventClippingNotifier extends PreventClippingNotifier {
 Widget _buildSettings({
   MockFlutterSecureStorage? storage,
   ThemeChoiceNotifier Function()? themeNotifierFactory,
+  double textScale = 1.0,
 }) {
   final mockStorage = storage ?? MockFlutterSecureStorage();
   when(() => mockStorage.read(key: any(named: 'key')))
@@ -121,8 +122,11 @@ Widget _buildSettings({
           .overrideWith(_FakeReplayGainPreampNotifier.new),
       preventClippingProvider.overrideWith(_FakePreventClippingNotifier.new),
     ],
-    child: const MaterialApp(
-      home: SettingsScreen(),
+    child: MaterialApp(
+      home: MediaQuery(
+        data: MediaQueryData(textScaler: TextScaler.linear(textScale)),
+        child: const SettingsScreen(),
+      ),
     ),
   );
 }
@@ -331,6 +335,37 @@ void main() {
 
     final title = tester.widget<Text>(find.text('Theme'));
     expect(title.maxLines, 1);
+  });
+
+  testWidgets(
+      'ReplayGain Mode label keeps a usable width at 150% text scale',
+      (tester) async {
+    // A phone-width surface — the segmented button and the label are only
+    // in contention when the row is narrow.
+    tester.view.physicalSize = const Size(411 * 3, 900 * 3);
+    tester.view.devicePixelRatio = 3.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_buildSettings(textScale: 1.5));
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byType(SegmentedButton<ReplayGainMode>),
+      200,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.pumpAndSettle();
+
+    // The segmented button's labels scale too, and as `trailing` it takes
+    // its intrinsic width before the title column gets what is left. At
+    // 1.5x that left roughly 110px, so "ReplayGain Mode" wrapped one or
+    // two characters per line. Anything under half the row is unreadable.
+    final width = tester.getSize(find.text('ReplayGain Mode')).width;
+    expect(
+      width,
+      greaterThan(205),
+      reason: 'label squeezed to ${width}px — it will wrap mid-word',
+    );
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Two large-text-scale defects on the settings screen, both found while checking the phone at 150%. Neither came from recent work — both are pre-existing.

## ReplayGain mode row

The selector sits in a `ListTile` `trailing`, which claims its intrinsic width before the title column gets what is left. Its segment labels scale too, so at 1.5x the title had roughly 110px and "ReplayGain Mode" wrapped one or two characters per line — `Repla / yGain / Mode` — while the row threw 19 overflow errors.

Past ~1.3x there is no room for both side by side, so the selector moves onto its own line below the label. The side-by-side layout is unchanged at normal scale.

## Palette tiles

`Container(height: 88)` is hard-coded while the palette name inside scales, so every tile overflowed by ~14px at 1.5x and the labels clipped. Now a `minHeight`, letting them grow.

## Test

`ReplayGain Mode label keeps a usable width at 150% text scale` drives the real `SettingsScreen` at 1.5x on a 411dp surface and asserts the label keeps a usable width. It fails on both defects before this change — the ReplayGain row's overflow errors and the palette tiles' own — so one test covers the pair.

`flutter analyze` clean; `flutter test` 1795 passed.

## Verified on device

Android 10 handset at 150%: "ReplayGain Mode" and "Normalise track loudness" read normally with the selector stacked beneath, and all five palette tiles render their labels in full. Back at Default the original side-by-side row is preserved.