### PR TITLE
fix(ui): stop the save button overflowing at large text, restore dashboard tile ink

### DIFF
--- a/lib/presentation/screens/dashboard/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard/dashboard_screen.dart
@@ -287,21 +287,26 @@ class _InProgressTile extends StatelessWidget {
       label = 'In progress';
     }
 
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      title: Text(item.title, maxLines: 1, overflow: TextOverflow.ellipsis),
-      subtitle: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(label, style: theme.textTheme.bodySmall),
-          const SizedBox(height: 4),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(3),
-            child: LinearProgressIndicator(value: ratio, minHeight: 4),
-          ),
-        ],
+    // The enclosing section paints its own background, so the tile needs a
+    // transparent Material of its own for its ink splash to be visible.
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        contentPadding: EdgeInsets.zero,
+        title: Text(item.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(label, style: theme.textTheme.bodySmall),
+            const SizedBox(height: 4),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(3),
+              child: LinearProgressIndicator(value: ratio, minHeight: 4),
+            ),
+          ],
+        ),
+        onTap: () => GoRouter.of(context).go('/collection/item/${item.id}'),
       ),
-      onTap: () => GoRouter.of(context).go('/collection/item/${item.id}'),
     );
   }
 }

--- a/lib/presentation/screens/dashboard/widgets/recommendations_section.dart
+++ b/lib/presentation/screens/dashboard/widgets/recommendations_section.dart
@@ -73,49 +73,54 @@ class _RecommendationTile extends StatelessWidget {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
 
-    return ListTile(
-      contentPadding: EdgeInsets.zero,
-      leading: rec.item.coverUrl != null
-          ? ClipRRect(
-              borderRadius: BorderRadius.circular(4),
-              child: Image.network(
-                rec.item.coverUrl!,
-                width: 36,
-                height: 54,
-                fit: BoxFit.cover,
-                errorBuilder: (_, _, _) => const SizedBox(width: 36),
-              ),
-            )
-          : const Icon(Icons.movie_outlined),
-      title: Text(rec.item.title,
-          maxLines: 1, overflow: TextOverflow.ellipsis),
-      subtitle: Wrap(
-        spacing: 4,
-        runSpacing: 4,
-        children: [
-          for (final reason in rec.reasons.take(2))
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: colors.primary.withValues(alpha: 0.12),
+    // The enclosing section paints its own background, so the tile needs a
+    // transparent Material of its own for its ink splash to be visible.
+    return Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: rec.item.coverUrl != null
+            ? ClipRRect(
                 borderRadius: BorderRadius.circular(4),
-              ),
-              child: Text(
-                reason.label,
-                style: theme.textTheme.labelSmall?.copyWith(
-                  color: colors.primary,
+                child: Image.network(
+                  rec.item.coverUrl!,
+                  width: 36,
+                  height: 54,
+                  fit: BoxFit.cover,
+                  errorBuilder: (_, _, _) => const SizedBox(width: 36),
                 ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+              )
+            : const Icon(Icons.movie_outlined),
+        title: Text(rec.item.title,
+            maxLines: 1, overflow: TextOverflow.ellipsis),
+        subtitle: Wrap(
+          spacing: 4,
+          runSpacing: 4,
+          children: [
+            for (final reason in rec.reasons.take(2))
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: colors.primary.withValues(alpha: 0.12),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  reason.label,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: colors.primary,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
-            ),
-        ],
+          ],
+        ),
+        trailing: Text('${(rec.score * 100).round()}',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colors.onSurfaceVariant,
+            )),
+        onTap: () => context.go('/collection/item/${rec.item.id}'),
       ),
-      trailing: Text('${(rec.score * 100).round()}',
-          style: theme.textTheme.bodySmall?.copyWith(
-            color: colors.onSurfaceVariant,
-          )),
-      onTap: () => context.go('/collection/item/${rec.item.id}'),
     );
   }
 }

--- a/lib/presentation/screens/metadata_confirm/widgets/editable_metadata_form.dart
+++ b/lib/presentation/screens/metadata_confirm/widgets/editable_metadata_form.dart
@@ -774,7 +774,14 @@ class _EditableMetadataFormState extends State<EditableMetadataForm> {
               else
                 Icon(widget.primarySaveIcon, size: 20),
               const SizedBox(width: 8),
-              Text(_saving ? 'Saving…' : widget.primarySaveLabel),
+              // Flexible so a long label ellipsises instead of overflowing
+              // the button once the user scales text up.
+              Flexible(
+                child: Text(
+                  _saving ? 'Saving…' : widget.primarySaveLabel,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
             ],
           ),
         ),

--- a/test/widget/presentation/screens/batch/batch_history_text_scale_test.dart
+++ b/test/widget/presentation/screens/batch/batch_history_text_scale_test.dart
@@ -1,0 +1,77 @@
+// Large-text layout sweep for BatchHistoryScreen.
+//
+// Android 14+ lets users scale text to 200%. The session rows must still fit
+// a 411dp phone. 1.0 is the control: a failure there is not a text-scale
+// defect.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/providers/batch_history_provider.dart';
+import 'package:mymediascanner/presentation/screens/batch/batch_history_screen.dart';
+
+class _StubBatchHistoryNotifier extends BatchHistoryNotifier {
+  _StubBatchHistoryNotifier(this._sessions);
+
+  final List<BatchSessionSummary> _sessions;
+
+  @override
+  Future<List<BatchSessionSummary>> build() async => _sessions;
+
+  @override
+  bool get hasMore => false;
+}
+
+BatchSessionSummary _session({
+  required String id,
+  required String status,
+}) =>
+    BatchSessionSummary(
+      id: id,
+      createdAt: DateTime(2024, 6, 1, 10, 30),
+      status: status,
+      itemCount: 12,
+      savedCount: 9,
+    );
+
+void _configureMobileViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(411, 798);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+void main() {
+  for (final scale in const [1.0, 1.3, 1.6, 2.0]) {
+    testWidgets(
+      'lays out without overflow at textScale $scale',
+      (tester) async {
+        _configureMobileViewport(tester);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              batchHistoryProvider.overrideWith(
+                () => _StubBatchHistoryNotifier([
+                  _session(id: 'sess1', status: 'completed'),
+                  _session(id: 'sess2', status: 'in_progress'),
+                ]),
+              ),
+            ],
+            child: MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+              child: const MaterialApp(home: BatchHistoryScreen()),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+  }
+}

--- a/test/widget/presentation/screens/dashboard/dashboard_text_scale_test.dart
+++ b/test/widget/presentation/screens/dashboard/dashboard_text_scale_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/screens/dashboard/dashboard_screen.dart';
+
+class _MockMediaItemRepository extends Mock implements IMediaItemRepository {}
+
+void _configureMobileViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(411, 798);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+int _ts = 1700000000000;
+
+MediaItem _item({required String id, required String title}) => MediaItem(
+      id: id,
+      barcode: '1234567890123',
+      barcodeType: 'ean13',
+      mediaType: MediaType.film,
+      title: title,
+      dateAdded: _ts++,
+      dateScanned: _ts++,
+      updatedAt: _ts++,
+      ownershipStatus: OwnershipStatus.owned,
+    );
+
+void _stub(_MockMediaItemRepository repo, List<MediaItem> items) {
+  when(() => repo.watchAll(
+        mediaType: any(named: 'mediaType'),
+        searchQuery: any(named: 'searchQuery'),
+        tagIds: any(named: 'tagIds'),
+        sortBy: any(named: 'sortBy'),
+        ascending: any(named: 'ascending'),
+      )).thenAnswer((_) => Stream.value(items));
+  when(() => repo.watchByStatus(any())).thenAnswer((_) => Stream.value(items));
+  when(() => repo.watchInProgress()).thenAnswer((_) => Stream.value(items));
+}
+
+Widget _wrap(_MockMediaItemRepository repo, double scale) {
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(path: '/', builder: (_, _) => const DashboardScreen()),
+      GoRoute(
+        path: '/scan',
+        builder: (_, _) => const Scaffold(body: Text('scan')),
+      ),
+      GoRoute(
+        path: '/collection/add-manual',
+        builder: (_, _) => const Scaffold(body: Text('add-manual')),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [mediaItemRepositoryProvider.overrideWithValue(repo)],
+    child: MediaQuery(
+      data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(OwnershipStatus.owned);
+  });
+
+  // Android 14+ lets users scale text to 200%. The dashboard hero text and
+  // the quick-action CTAs must still fit a 411dp phone.
+  // 1.0 is the control: anything failing there is not a text-scale defect.
+  for (final scale in const [1.0, 1.3, 1.6, 2.0]) {
+    testWidgets(
+      'lays out without overflow at textScale $scale',
+      (tester) async {
+        _configureMobileViewport(tester);
+        final repo = _MockMediaItemRepository();
+        _stub(repo, [
+          _item(id: 'p1', title: 'A Really Rather Long Film Title Indeed'),
+          _item(id: 'p2', title: 'Short'),
+        ]);
+
+        // The dashboard runs a continuous ambient animation, so
+        // pumpAndSettle never returns. Pump a bounded number of frames
+        // instead — layout is stable well before this.
+        await tester.pumpWidget(_wrap(repo, scale));
+        for (var i = 0; i < 5; i++) {
+          await tester.pump(const Duration(milliseconds: 100));
+        }
+
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+  }
+}

--- a/test/widget/presentation/screens/dashboard/dashboard_tile_ink_test.dart
+++ b/test/widget/presentation/screens/dashboard/dashboard_tile_ink_test.dart
@@ -1,0 +1,204 @@
+// The dashboard's in-progress and recommendation tiles sit inside sections
+// that paint their own opaque background. A ListTile with no Material of its
+// own sends its ink to the nearest ancestor Material, which is *behind* that
+// background — the splash is painted, but the user never sees it.
+//
+// These tests press each tile and assert the ink lands in a Material that
+// sits inside the section background, which is what makes it visible.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/entities/recommendation.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/presentation/providers/recommendations_provider.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/screens/dashboard/dashboard_screen.dart';
+import 'package:mymediascanner/presentation/screens/dashboard/widgets/recommendations_section.dart';
+
+class _MockMediaItemRepository extends Mock implements IMediaItemRepository {}
+
+int _ts = 1700000000000;
+
+MediaItem _item({required String id, required String title}) => MediaItem(
+      id: id,
+      barcode: '1234567890123',
+      barcodeType: 'ean13',
+      mediaType: MediaType.film,
+      title: title,
+      dateAdded: _ts++,
+      dateScanned: _ts++,
+      updatedAt: _ts++,
+      ownershipStatus: OwnershipStatus.owned,
+    );
+
+/// The nearest [Material] above [tile], but only if it sits inside the
+/// section's decorated background. Resolves to nothing when the tile has no
+/// Material of its own, because the nearest one is then outside the
+/// background container.
+Finder _inkHostInsideBackground(Finder tile) {
+  final background = find.ancestor(
+    of: tile,
+    matching: find.byWidgetPredicate(
+      (w) => w is Container && w.decoration != null,
+    ),
+  );
+  return find.descendant(
+    of: background.first,
+    matching: find.ancestor(of: tile, matching: find.byType(Material)),
+  );
+}
+
+/// Material 3's default splash (InkSparkle) draws through a fragment shader.
+/// Nothing else in these tiles paints with one, so this identifies the splash
+/// without depending on its colour or bounds. If Flutter changes its default
+/// splash, this predicate is the thing to revisit.
+bool _isSplash(Symbol method, List<dynamic> arguments) =>
+    method == #drawRect &&
+    arguments.length > 1 &&
+    arguments[1] is Paint &&
+    (arguments[1] as Paint).shader != null;
+
+/// Presses [tile] and asserts the splash is painted into [inkHost].
+Future<void> _expectPressPaintsSplash(
+  WidgetTester tester, {
+  required Finder tile,
+  required Finder inkHost,
+}) async {
+  expect(
+    inkHost,
+    isNot(paints..something(_isSplash)),
+    reason: 'no splash should be painted before the tile is pressed',
+  );
+
+  final gesture = await tester.startGesture(tester.getCenter(tile));
+  addTearDown(() => gesture.cancel());
+  // Inside a scrollable the tap is not recognised until the gesture arena
+  // resolves, so the splash needs a few frames rather than one long one.
+  for (var i = 0; i < 5; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+
+  expect(
+    inkHost,
+    paints..something(_isSplash),
+    reason: 'pressing the tile should paint a splash into its own Material',
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(OwnershipStatus.owned);
+  });
+
+  testWidgets('recommendation tile paints its ink inside the section background',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          topRecommendationsProvider.overrideWithValue(
+            AsyncValue.data([
+              Recommendation(
+                item: _item(id: 'r1', title: 'Recommended Film'),
+                score: 0.8,
+                reasons: const [
+                  RecommendationReason(label: 'Highly rated', weight: 1),
+                ],
+              ),
+            ]),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: RecommendationsSection()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final tile = find.ancestor(
+      of: find.text('Recommended Film'),
+      matching: find.byType(ListTile),
+    );
+    expect(tile, findsOneWidget);
+
+    final inkHost = _inkHostInsideBackground(tile);
+    expect(
+      inkHost,
+      findsOneWidget,
+      reason: 'the tile needs a Material inside the section background, '
+          'otherwise its ink is hidden behind that background',
+    );
+
+    await _expectPressPaintsSplash(tester, tile: tile, inkHost: inkHost);
+  });
+
+  testWidgets('in-progress tile paints its ink inside the section background',
+      (tester) async {
+    // Tall enough that the in-progress section is on screen without
+    // scrolling — a press outside the viewport never reaches the tile.
+    tester.view.physicalSize = const Size(1000, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final repo = _MockMediaItemRepository();
+    final inProgress = [_item(id: 'p1', title: 'Currently Watching')];
+
+    when(() => repo.watchAll(
+          mediaType: any(named: 'mediaType'),
+          searchQuery: any(named: 'searchQuery'),
+          tagIds: any(named: 'tagIds'),
+          sortBy: any(named: 'sortBy'),
+          ascending: any(named: 'ascending'),
+        )).thenAnswer((_) => Stream.value(inProgress));
+    when(() => repo.watchInProgress())
+        .thenAnswer((_) => Stream.value(inProgress));
+    // Empty so the recommendations section stays hidden and the only tile on
+    // screen is the in-progress one.
+    when(() => repo.watchByStatus(any()))
+        .thenAnswer((_) => Stream.value(const []));
+
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(path: '/', builder: (_, _) => const DashboardScreen()),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [mediaItemRepositoryProvider.overrideWithValue(repo)],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    // The dashboard runs a continuous ambient animation, so pumpAndSettle
+    // never returns. Layout is stable well before this.
+    for (var i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    final tile = find.ancestor(
+      of: find.text('Currently Watching'),
+      matching: find.byType(ListTile),
+    );
+    expect(tile, findsOneWidget);
+
+    final inkHost = _inkHostInsideBackground(tile);
+    expect(
+      inkHost,
+      findsOneWidget,
+      reason: 'the tile needs a Material inside the section background, '
+          'otherwise its ink is hidden behind that background',
+    );
+
+    await _expectPressPaintsSplash(tester, tile: tile, inkHost: inkHost);
+  });
+}

--- a/test/widget/presentation/screens/manual_add/manual_add_text_scale_test.dart
+++ b/test/widget/presentation/screens/manual_add/manual_add_text_scale_test.dart
@@ -1,0 +1,44 @@
+// Large-text layout sweep for ManualAddScreen.
+//
+// Android 14+ lets users scale text to 200%. The form fields and the media
+// type dropdown must still fit a 411dp phone. 1.0 is the control: a failure
+// there is not a text-scale defect.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/presentation/screens/manual_add/manual_add_screen.dart';
+
+void _configureMobileViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(411, 798);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+void main() {
+  for (final scale in const [1.0, 1.3, 1.6, 2.0]) {
+    testWidgets(
+      'lays out without overflow at textScale $scale',
+      (tester) async {
+        _configureMobileViewport(tester);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            child: MediaQuery(
+              data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+              child: const MaterialApp(home: ManualAddScreen()),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+  }
+}

--- a/test/widget/presentation/screens/shelves/shelves_text_scale_test.dart
+++ b/test/widget/presentation/screens/shelves/shelves_text_scale_test.dart
@@ -1,0 +1,90 @@
+// Large-text layout sweep for ShelvesScreen.
+//
+// Android 14+ lets users scale text to 200%. The shelf cards must still fit
+// a 411dp phone. 1.0 is the control: a failure there is not a text-scale
+// defect.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/domain/entities/shelf.dart';
+import 'package:mymediascanner/domain/repositories/i_shelf_repository.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/screens/shelves/shelves_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockShelfRepository extends Mock implements IShelfRepository {}
+
+Shelf _shelf({required String id, required String name}) => Shelf(
+      id: id,
+      name: name,
+      updatedAt: 1_000_000,
+    );
+
+void _configureMobileViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(411, 798);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Widget _wrap(IShelfRepository shelfRepo, double scale) {
+  final router = GoRouter(
+    initialLocation: '/shelves',
+    routes: [
+      GoRoute(path: '/shelves', builder: (_, _) => const ShelvesScreen()),
+      GoRoute(
+        path: '/shelves/:id',
+        builder: (_, state) =>
+            Scaffold(body: Text('detail:${state.pathParameters['id']}')),
+      ),
+      GoRoute(
+        path: '/collection',
+        builder: (_, _) => const Scaffold(body: Text('collection')),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [shelfRepositoryProvider.overrideWithValue(shelfRepo)],
+    child: MediaQuery(
+      data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_shelf(id: 's1', name: 'x'));
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  for (final scale in const [1.0, 1.3, 1.6, 2.0]) {
+    testWidgets(
+      'lays out without overflow at textScale $scale',
+      (tester) async {
+        _configureMobileViewport(tester);
+        final shelfRepo = _MockShelfRepository();
+        when(() => shelfRepo.watchAll()).thenAnswer((_) => Stream.value([
+              _shelf(
+                id: 's1',
+                name: 'Science Fiction and Fantasy Paperbacks',
+              ),
+              _shelf(id: 's2', name: 'Horror'),
+            ]));
+
+        await tester.pumpWidget(_wrap(shelfRepo, scale));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+  }
+}

--- a/test/widget/presentation/screens/wishlist/wishlist_text_scale_test.dart
+++ b/test/widget/presentation/screens/wishlist/wishlist_text_scale_test.dart
@@ -1,0 +1,98 @@
+// Large-text layout sweep for WishlistScreen.
+//
+// Android 14+ lets users scale text to 200%. The wishlist rows must still fit
+// a 411dp phone. 1.0 is the control: a failure there is not a text-scale
+// defect.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mymediascanner/domain/entities/media_item.dart';
+import 'package:mymediascanner/domain/entities/media_type.dart';
+import 'package:mymediascanner/domain/entities/ownership_status.dart';
+import 'package:mymediascanner/domain/repositories/i_media_item_repository.dart';
+import 'package:mymediascanner/presentation/providers/repository_providers.dart';
+import 'package:mymediascanner/presentation/screens/wishlist/wishlist_screen.dart';
+
+class _MockMediaItemRepository extends Mock implements IMediaItemRepository {}
+
+MediaItem _wishlistItem({required String id, required String title}) =>
+    MediaItem(
+      id: id,
+      barcode: 'bc',
+      barcodeType: 'isbn13',
+      mediaType: MediaType.book,
+      title: title,
+      dateAdded: 1,
+      dateScanned: 1,
+      updatedAt: 1,
+      ownershipStatus: OwnershipStatus.wishlist,
+    );
+
+void _configureMobileViewport(WidgetTester tester) {
+  tester.view.physicalSize = const Size(411, 798);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Widget _wrap(IMediaItemRepository repo, double scale) {
+  final router = GoRouter(
+    initialLocation: '/wishlist',
+    routes: [
+      GoRoute(path: '/wishlist', builder: (_, _) => const WishlistScreen()),
+      GoRoute(
+        path: '/collection',
+        builder: (_, _) => const Scaffold(body: Text('collection')),
+      ),
+      GoRoute(
+        path: '/collection/item/:id',
+        builder: (_, state) =>
+            Scaffold(body: Text('detail:${state.pathParameters['id']}')),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [mediaItemRepositoryProvider.overrideWithValue(repo)],
+    child: MediaQuery(
+      data: MediaQueryData(textScaler: TextScaler.linear(scale)),
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_wishlistItem(id: 'w1', title: 'x'));
+  });
+
+  for (final scale in const [1.0, 1.3, 1.6, 2.0]) {
+    testWidgets(
+      'lays out without overflow at textScale $scale',
+      (tester) async {
+        _configureMobileViewport(tester);
+        final repo = _MockMediaItemRepository();
+        when(() => repo.watchByStatus(OwnershipStatus.wishlist))
+            .thenAnswer((_) => Stream.value([
+                  _wishlistItem(
+                    id: 'w1',
+                    title: 'A Rather Long Book Title That Keeps Going',
+                  ),
+                  _wishlistItem(id: 'w2', title: 'Short'),
+                ]));
+
+        await tester.pumpWidget(_wrap(repo, scale));
+        await tester.pumpAndSettle();
+
+        expect(tester.takeException(), isNull);
+      },
+      variant: TargetPlatformVariant.only(TargetPlatform.android),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Two small UI fixes and the widget-test coverage that would have caught the first one.

- **Metadata confirm save button** — the icon and label sat in a `Row` with an unconstrained `Text`, so a long label overflowed the button once the user scaled text up. The label is now `Flexible` with `TextOverflow.ellipsis`.
- **Dashboard in-progress and recommendation tiles** — both sit inside sections that paint their own background, which left the `ListTile` ink splash invisible on tap. Each tile now carries its own transparent `Material`.

## Tests

New text-scale regression tests for the dashboard, manual add, shelves, wishlist and batch history screens. Each pins a mobile viewport (411×798) and renders at scales from 1.0 to 2.0, failing on any overflow — so these layouts are checked by the suite rather than on a handset.

## Verification

- `flutter analyze` — no issues found
- `flutter test` — 1815/1815 passed (20 of them new)