### PR TITLE
fix(a11y): honour the platform text-size setting

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -6,6 +6,7 @@ import 'package:mymediascanner/presentation/providers/text_scale_provider.dart';
 import 'package:mymediascanner/app/router.dart';
 import 'package:mymediascanner/app/theme/app_theme.dart';
 import 'package:mymediascanner/core/constants/app_constants.dart';
+import 'package:mymediascanner/core/utils/text_scale.dart';
 import 'package:mymediascanner/domain/entities/tmdb_deep_link_event.dart';
 import 'package:mymediascanner/presentation/providers/repository_providers.dart';
 import 'package:mymediascanner/presentation/providers/settings_provider.dart';
@@ -109,11 +110,10 @@ class _AppState extends ConsumerState<App> {
       builder: (context, child) {
         if (child == null) return const SizedBox.shrink();
         final mq = MediaQuery.of(context);
-        final platformScaler = mq.textScaler;
-        final combined =
-            platformScaler.scale(textScale) / platformScaler.scale(1.0);
         return MediaQuery(
-          data: mq.copyWith(textScaler: TextScaler.linear(combined)),
+          data: mq.copyWith(
+            textScaler: stackTextScale(mq.textScaler, textScale),
+          ),
           child: child,
         );
       },

--- a/lib/core/utils/text_scale.dart
+++ b/lib/core/utils/text_scale.dart
@@ -1,0 +1,54 @@
+// Combines the user's in-app text-size factor with the platform's own
+// text-scaling setting.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'package:flutter/painting.dart';
+
+/// Ceiling on the combined text scale.
+///
+/// The in-app factor reaches 1.5 and Android's own setting reaches 2.0, so
+/// stacking them unchecked lands at 3.0 — enough to push the dashboard hero
+/// off the side of the screen. 2.0 is the largest scale the widget tests
+/// cover and the largest the layouts are known to survive.
+const double kMaxEffectiveTextScale = 2.0;
+
+/// Returns a [TextScaler] applying the user's in-app [factor] on top of the
+/// [platform] scaler, so the app scales with the device text-size setting
+/// rather than replacing it.
+///
+/// Delegating to [platform] rather than collapsing it to a single number
+/// keeps the platform's own curve intact. Android 14+ scales large text less
+/// aggressively than small text, and flattening that curve is what makes
+/// headings overflow at high scale factors.
+TextScaler stackTextScale(TextScaler platform, double factor) {
+  final stacked =
+      factor == 1.0 ? platform : _StackedTextScaler(platform, factor);
+  return stacked.clamp(maxScaleFactor: kMaxEffectiveTextScale);
+}
+
+class _StackedTextScaler extends TextScaler {
+  const _StackedTextScaler(this._platform, this._factor);
+
+  final TextScaler _platform;
+  final double _factor;
+
+  @override
+  double scale(double fontSize) => _platform.scale(fontSize * _factor);
+
+  @override
+  // ignore: deprecated_member_use
+  double get textScaleFactor => _platform.textScaleFactor * _factor;
+
+  // MediaQuery compares its data on every rebuild, so an instance that never
+  // equals its predecessor would notify every dependent needlessly.
+  @override
+  bool operator ==(Object other) =>
+      other is _StackedTextScaler &&
+      other._platform == _platform &&
+      other._factor == _factor;
+
+  @override
+  int get hashCode => Object.hash(_platform, _factor);
+}

--- a/lib/presentation/screens/settings/settings_screen.dart
+++ b/lib/presentation/screens/settings/settings_screen.dart
@@ -1017,7 +1017,8 @@ class _TextScaleSection extends ConsumerWidget {
           const SizedBox(height: 4),
           Text(
             'Stacks on top of the platform text-size setting so the whole '
-            'app scales together with the rest of your device.',
+            'app scales together with the rest of your device. The combined '
+            'size is capped so layouts stay usable.',
             style: theme.textTheme.bodySmall
                 ?.copyWith(color: colors.onSurfaceVariant),
           ),

--- a/test/unit/core/utils/text_scale_test.dart
+++ b/test/unit/core/utils/text_scale_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mymediascanner/core/utils/text_scale.dart';
+
+/// A non-linear scaler in the spirit of Android 14+: small text scales fully,
+/// large text is compressed so headings do not run away. Kept gentle enough
+/// that it stays clear of [kMaxEffectiveTextScale].
+class _CompressingScaler extends TextScaler {
+  const _CompressingScaler();
+
+  @override
+  double scale(double fontSize) => fontSize < 20 ? fontSize * 1.3 : fontSize + 6;
+
+  @override
+  // ignore: deprecated_member_use
+  double get textScaleFactor => 1.3;
+}
+
+void main() {
+  group('stackTextScale', () {
+    test('applies the in-app factor when the platform does not scale', () {
+      final scaler = stackTextScale(TextScaler.noScaling, 1.5);
+
+      expect(scaler.scale(14), 21);
+    });
+
+    test('keeps the platform scale when the in-app factor is 1.0', () {
+      final scaler = stackTextScale(const TextScaler.linear(1.3), 1.0);
+
+      expect(scaler.scale(14), closeTo(18.2, 0.0001));
+    });
+
+    test('stacks the in-app factor on top of the platform scale', () {
+      final scaler = stackTextScale(const TextScaler.linear(1.3), 1.5);
+
+      // 1.3 × 1.5 = 1.95
+      expect(scaler.scale(14), closeTo(27.3, 0.0001));
+    });
+
+    test('preserves a non-linear platform curve rather than flattening it', () {
+      const platform = _CompressingScaler();
+      final scaler = stackTextScale(platform, 1.5);
+
+      // Body text: 14 × 1.5 = 21 unscaled, which the platform compresses.
+      expect(scaler.scale(14), platform.scale(14 * 1.5));
+      // Hero text stays compressed too — flattening the curve to a single
+      // factor is what makes large text overflow.
+      expect(scaler.scale(45), platform.scale(45 * 1.5));
+    });
+
+    test('caps the effective scale so layouts stay usable', () {
+      // Platform at its Android maximum plus the app's own 150% would reach
+      // 3.0, which pushes the dashboard hero off the side of the screen.
+      final scaler = stackTextScale(const TextScaler.linear(2.0), 1.5);
+
+      expect(scaler.scale(14), 14 * kMaxEffectiveTextScale);
+    });
+
+    test('leaves scales below the cap untouched', () {
+      final scaler = stackTextScale(const TextScaler.linear(1.2), 1.15);
+
+      // 1.38 is comfortably under the cap, so nothing is clamped.
+      expect(scaler.scale(14), closeTo(19.32, 0.0001));
+    });
+
+    test('caps the platform scale even without an in-app factor', () {
+      final scaler = stackTextScale(const TextScaler.linear(2.5), 1.0);
+
+      expect(scaler.scale(14), 14 * kMaxEffectiveTextScale);
+    });
+
+    test('is equal for the same platform scaler and factor', () {
+      // MediaQuery compares its data on every rebuild; an unequal scaler each
+      // build would notify every dependent needlessly.
+      expect(
+        stackTextScale(const TextScaler.linear(1.3), 1.5),
+        stackTextScale(const TextScaler.linear(1.3), 1.5),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## The bug

`lib/app/app.dart` replaced the platform text scaler with:

```dart
final combined = platformScaler.scale(textScale) / platformScaler.scale(1.0);
mq.copyWith(textScaler: TextScaler.linear(combined))
```

For a linear scaler, `scale(x) == x * p`, so that expression reduces to `textScale` — the platform factor cancels out. The device's own text-size setting was discarded entirely.

Found while verifying #121 on a physical handset: raising the Android font size from 1.1 to 2.0 changed nothing on screen, and every `RichText` reported `textScaler: "no scaling"`. The Settings copy claimed it "stacks on top of the platform text-size setting so the whole app scales together with the rest of your device".

## The fix

`stackTextScale` composes the two by delegating to the platform scaler rather than collapsing it to a single factor. That keeps the platform's own curve intact — Android 14+ scales large text less aggressively than small text, and flattening that curve is precisely what makes headings overflow while body text is still comfortable.

## The cap

Stacking makes higher combined scales reachable: 1.5 in-app x 2.0 platform = 3.0. I checked 3.0 on the handset and it pushes the dashboard hero off the side of the screen ("Vault." clipped mid-word), so the effective scale is capped at 2.0 via `TextScaler.clamp` — the largest scale the widget tests cover and the largest the layouts are known to survive. The Settings copy now mentions the cap, since otherwise every chip looks identical once the device is already at maximum.

If you would rather let it run past 2.0, `kMaxEffectiveTextScale` is the single knob.

## Tests

`test/unit/core/utils/text_scale_test.dart` — 8 tests: stacking, platform-only, in-app-only, non-linear curve preservation, both cap paths, and scaler equality (so `MediaQuery` does not notify every dependent on each rebuild).

Written test-first: the three stacking tests failed against the old expression with the actual bug values (14.0 instead of 18.2, 21.0 instead of 27.3), and both cap tests failed at 42 and 35 before the clamp.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 1825/1825 passing
- Physical SM-G965F: OS scale 1.3 and 2.0 now both move the app, no overflow logged; 2.0 x 150% renders identically to 2.0
