### PR TITLE
feat(android): enable Google Play releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,27 @@ jobs:
 
       - name: Run tests
         run: flutter test
+
+  privacy-policy:
+    name: Privacy policy up to date
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      # Pinned so the rendered HTML is byte-identical to what the script
+      # produces locally — otherwise the diff below would be version noise.
+      - name: Install asciidoctor
+        run: gem install asciidoctor -v 2.0.23 --no-document
+
+      # docs/privacy-policy.html is what GitHub Pages serves as the app's
+      # Play Store privacy policy URL. If it drifts from the AsciiDoc source,
+      # the published policy silently stops matching the repo.
+      - name: Check rendered privacy policy matches source
+        run: tools/render-privacy-policy.sh --check

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,4 +1,4 @@
-name: Release Android APK
+name: Release Android
 
 on:
   push:
@@ -24,6 +24,14 @@ on:
         options:
           - 'false'
           - 'true'
+      publish_to_play:
+        description: 'Upload the AAB to the Play internal testing track'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
 
 env:
   FLUTTER_CHANNEL: stable
@@ -31,11 +39,17 @@ env:
 
 jobs:
   build-android-apk:
-    name: Build Android APK
+    name: Build Android APK + AAB
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
+
+    env:
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+
+    outputs:
+      aab_name: ${{ steps.rename_aab.outputs.aab_name }}
 
     steps:
       - name: Checkout repository
@@ -90,6 +104,26 @@ jobs:
       - name: Run tests
         run: flutter test
 
+      # Without this the release build falls back to debug keys, which Play
+      # rejects — android/app/build.gradle.kts fails the build outright when
+      # CI is set and key.properties is missing. See docs/PLAY_STORE_RELEASE.md.
+      - name: Configure release signing
+        if: env.ANDROID_KEYSTORE_BASE64 != ''
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+          cat > android/key.properties <<'EOF'
+          storeFile=upload-keystore.jks
+          EOF
+          {
+            echo "storePassword=${KEYSTORE_PASSWORD}"
+            echo "keyAlias=${KEY_ALIAS}"
+            echo "keyPassword=${KEY_PASSWORD}"
+          } >> android/key.properties
+
       - name: Determine build flavor
         id: flavor
         run: |
@@ -126,6 +160,40 @@ jobs:
           path: ${{ steps.rename_apk.outputs.apk_path }}
           retention-days: 30
 
+      # Play accepts app bundles, not APKs. The APK above stays for direct
+      # sideloading from the GitHub Release.
+      - name: Build release App Bundle
+        run: flutter build appbundle --release --flavor ${{ steps.flavor.outputs.flavor }}
+
+      - name: Locate and rename AAB
+        id: rename_aab
+        run: |
+          FLAVOR="${{ steps.flavor.outputs.flavor }}"
+          VERSION=$(grep '^\s*version:' pubspec.yaml | sed 's/.*version:[[:space:]]*//' | sed 's/+.*//' | tr -d ' ')
+          AAB_DIR="build/app/outputs/bundle/${FLAVOR}Release"
+          AAB_SRC=$(find "$AAB_DIR" -maxdepth 1 -name "app-${FLAVOR}-release.aab" | head -n 1)
+          if [ -z "$AAB_SRC" ]; then
+            echo "ERROR: Release AAB not found in $AAB_DIR" >&2
+            ls -la "$AAB_DIR" >&2
+            exit 1
+          fi
+          AAB_NAME="MyMediaScanner-${VERSION}-${FLAVOR}-release.aab"
+          mv "$AAB_SRC" "${AAB_DIR}/${AAB_NAME}"
+          echo "aab_name=${AAB_NAME}" >> "$GITHUB_OUTPUT"
+          echo "aab_path=${AAB_DIR}/${AAB_NAME}" >> "$GITHUB_OUTPUT"
+
+      # Proves the bundle carries the upload key rather than debug keys —
+      # the failure mode that silently shipped debug-signed artefacts before.
+      - name: Report AAB signing certificate
+        run: keytool -printcert -jarfile "${{ steps.rename_aab.outputs.aab_path }}"
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.rename_aab.outputs.aab_name }}
+          path: ${{ steps.rename_aab.outputs.aab_path }}
+          retention-days: 30
+
       - name: Determine release metadata
         id: release_meta
         if: startsWith(github.ref, 'refs/tags/')
@@ -146,5 +214,52 @@ jobs:
           name: ${{ steps.release_meta.outputs.release_name }}
           draft: false
           prerelease: ${{ steps.release_meta.outputs.prerelease }}
-          files: ${{ steps.rename_apk.outputs.apk_path }}
+          files: |
+            ${{ steps.rename_apk.outputs.apk_path }}
+            ${{ steps.rename_aab.outputs.aab_path }}
           generate_release_notes: true
+
+  publish-play:
+    name: Publish to Google Play (internal)
+    needs: build-android-apk
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_to_play == 'true'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Require Play service account secret
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -z "$PLAY_SERVICE_ACCOUNT_JSON" ]; then
+            echo "ERROR: PLAY_SERVICE_ACCOUNT_JSON secret is not set." >&2
+            echo "       See docs/PLAY_STORE_RELEASE.md for how to create it." >&2
+            exit 1
+          fi
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install fastlane
+        run: gem install fastlane --no-document
+
+      - name: Download AAB artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build-android-apk.outputs.aab_name }}
+          path: dist
+
+      - name: Upload to Play internal testing track
+        working-directory: android
+        env:
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          AAB_NAME: ${{ needs.build-android-apk.outputs.aab_name }}
+        run: |
+          printf '%s' "$PLAY_SERVICE_ACCOUNT_JSON" > "${RUNNER_TEMP}/play-key.json"
+          export PLAY_JSON_KEY_PATH="${RUNNER_TEMP}/play-key.json"
+          export AAB_PATH="../dist/${AAB_NAME}"
+          fastlane beta

--- a/README.adoc
+++ b/README.adoc
@@ -251,6 +251,16 @@ npx antora local-antora-playbook-search.yml
 # Output: target/public/
 ----
 
+== Releasing
+
+Android releases go to Google Play. See link:docs/PLAY_STORE_RELEASE.md[docs/PLAY_STORE_RELEASE.md] for the full runbook -- upload keystore, Play Console declarations, store graphics, and the tag-and-publish workflow.
+
+== Privacy
+
+MyMediaScanner has no servers and no accounts. Your collection is stored locally on your device, and the app contains no analytics, advertising, or crash-reporting SDKs.
+
+Full policy: https://bovinemagnet.github.io/MyMediaScanner/privacy-policy.html[Privacy Policy] -- source at link:{url-docs}/privacy-policy.adoc[privacy-policy.adoc], rendered to `docs/privacy-policy.html` by `tools/render-privacy-policy.sh`.
+
 == Licence
 
 Private project. All rights reserved.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -65,11 +65,23 @@ android {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
-            // Sign with the upload keystore when android/key.properties exists;
-            // fall back to debug keys for local release builds without one.
+            // Sign with the upload keystore when android/key.properties exists.
+            // Locally we fall back to debug keys so `flutter run --release`
+            // still works, but on CI a missing keystore is a hard error — a
+            // debug-signed artefact would be rejected by Play and is worse
+            // than a failed build.
             signingConfig = if (keystorePropertiesFile.exists()) {
                 signingConfigs.getByName("release")
+            } else if (System.getenv("CI") != null) {
+                throw GradleException(
+                    "Release build on CI without android/key.properties. " +
+                        "Set the ANDROID_KEYSTORE_* secrets — see docs/PLAY_STORE_RELEASE.md."
+                )
             } else {
+                logger.warn(
+                    "WARNING: android/key.properties not found — signing the release " +
+                        "build with DEBUG keys. This artefact cannot be uploaded to Play."
+                )
                 signingConfigs.getByName("debug")
             }
             proguardFiles(

--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,2 +1,5 @@
-json_key_file("") # Path to service account JSON (set in CI secrets)
+# Path to the Google Play service account JSON.
+# Locally: export PLAY_JSON_KEY_PATH=/path/to/play-service-account.json
+# On CI:   written from the PLAY_SERVICE_ACCOUNT_JSON secret by release-android.yml
+json_key_file(ENV["PLAY_JSON_KEY_PATH"] || "")
 package_name("com.paulsnow.mymediascanner")

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,37 +1,48 @@
 default_platform(:android)
 
+# Output of `flutter build appbundle --release --flavor prod`, relative to
+# android/ (fastlane's working directory). Override with AAB_PATH when the
+# bundle comes from somewhere else, e.g. a downloaded CI artefact.
+AAB_PATH = ENV["AAB_PATH"] || "../build/app/outputs/bundle/prodRelease/app-prod-release.aab"
+
+# Fastlane cannot create the Play Console app entry — the very first bundle
+# must be uploaded by hand. Metadata pushes fail until the listing exists, so
+# set SKIP_METADATA=true for that first run.
+SKIP_METADATA = ENV["SKIP_METADATA"] == "true"
+
 platform :android do
-  desc "Upload to Google Play internal testing track"
-  lane :beta do
-    # Prerequisites:
-    # 1. Set json_key_file in Appfile to your Google Play service account JSON path
-    # 2. Build the APK/AAB first: flutter build appbundle --release --flavor prod
-    #
-    # Usage: cd android && fastlane beta
+  # Prerequisites for every lane below:
+  # 1. export PLAY_JSON_KEY_PATH=/path/to/play-service-account.json
+  # 2. flutter build appbundle --release --flavor prod
+  # See docs/PLAY_STORE_RELEASE.md.
+
+  private_lane :upload_bundle do |options|
     upload_to_play_store(
-      track: "internal",
-      aab: "../build/app/outputs/bundle/prodRelease/app-prod-release.aab",
-      skip_upload_metadata: false,
-      skip_upload_changelogs: false,
+      track: options[:track],
+      aab: AAB_PATH,
+      validate_only: options[:validate_only] || false,
+      skip_upload_metadata: SKIP_METADATA,
+      skip_upload_changelogs: SKIP_METADATA,
       skip_upload_images: true,
       skip_upload_screenshots: true
     )
   end
 
+  desc "Dry-run the upload against the Play API without publishing"
+  lane :validate do
+    # Usage: cd android && fastlane validate
+    upload_bundle(track: "internal", validate_only: true)
+  end
+
+  desc "Upload to Google Play internal testing track"
+  lane :beta do
+    # Usage: cd android && fastlane beta
+    upload_bundle(track: "internal")
+  end
+
   desc "Upload to Google Play production track"
   lane :release do
-    # Prerequisites:
-    # 1. Set json_key_file in Appfile to your Google Play service account JSON path
-    # 2. Build the APK/AAB first: flutter build appbundle --release --flavor prod
-    #
     # Usage: cd android && fastlane release
-    upload_to_play_store(
-      track: "production",
-      aab: "../build/app/outputs/bundle/prodRelease/app-prod-release.aab",
-      skip_upload_metadata: false,
-      skip_upload_changelogs: false,
-      skip_upload_images: true,
-      skip_upload_screenshots: true
-    )
+    upload_bundle(track: "production")
   end
 end

--- a/docs/PLAY_STORE_RELEASE.md
+++ b/docs/PLAY_STORE_RELEASE.md
@@ -1,0 +1,346 @@
+# Releasing MyMediaScanner on Google Play
+
+Author: Paul Snow
+
+This is the runbook for getting MyMediaScanner onto the Google Play Store and
+keeping it there. Steps 1–8 are one-off setup. Step 9 is what you repeat for
+every subsequent release.
+
+Package name: `com.paulsnow.mymediascanner` (the `prod` flavour; `dev` builds
+carry the `.dev` suffix and must never be uploaded).
+
+---
+
+## Before you start: the 14-day gate
+
+Google requires personal developer accounts registered after November 2023 to
+run a **closed test with at least 12 testers opted in continuously for 14
+days** before you can apply for production access. If that applies to you, the
+path is internal testing → closed testing (14 days) → production, so create
+the developer account *first* — the wait is the long pole, not the build.
+Confirm the current rule in Play Console, as the thresholds change.
+
+---
+
+## 1. Create the Play Developer account
+
+<https://play.google.com/console/signup> — US$25, one-off. Identity
+verification takes a day or two. Organisation accounts also need a D-U-N-S
+number.
+
+## 2. Publish the privacy policy
+
+Play requires a publicly reachable privacy policy URL for every app. The
+policy is already written and describes what the app actually does. It lives
+in the Antora docs tree as
+`src/docs/modules/ROOT/pages/privacy-policy.adoc`, and is rendered to
+`docs/privacy-policy.html` — GitHub Pages cannot render AsciiDoc, so the HTML
+is generated and committed:
+
+```bash
+gem install asciidoctor -v 2.0.23   # once; CI pins the same version
+tools/render-privacy-policy.sh
+```
+
+Edit the `.adoc`, re-run the script, and commit both files. CI fails if they
+drift apart. The generated page is rendered with `webfonts!` so it makes no
+external requests — a privacy policy that phones home to a font CDN is not a
+good look.
+
+To publish:
+
+> GitHub → repo **Settings** → **Pages** → Source: *Deploy from a branch* →
+> Branch `main`, folder `/docs` → **Save**
+
+The URL is then:
+
+```
+https://bovinemagnet.github.io/MyMediaScanner/privacy-policy.html
+```
+
+`docs/.nojekyll` is present so Pages serves the file verbatim instead of
+running a Jekyll build over the whole `docs/` tree. The repo is public, so
+enabling Pages exposes nothing that was not already visible.
+
+Load the URL in a browser and confirm it renders before pasting it into Play
+Console — a 404 there is a common review rejection.
+
+## 3. Generate the upload keystore
+
+> **Already done on Paul's Mac.** `android/key.properties` points at
+> `/Users/paul/keys/mymediascanner-upload.jks` with alias `upload`, and a
+> release bundle built from it carries `CN=Paul Snow, O=Snowed Under
+> Productions`. Skip to the verification at the end of this section — do
+> **not** regenerate the key.
+
+This key signs bundles you upload. Google re-signs them with its own app
+signing key before distribution, so this is your *upload* key.
+
+```bash
+keytool -genkey -v \
+  -keystore ~/keys/mymediascanner-upload.jks \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -alias upload
+```
+
+Answer the prompts (your name, organisation, country code). Note the store
+password and the key password — you will need both.
+
+> **Back this file up somewhere durable, off this machine.** Losing the
+> upload key means filing a support request with Google to reset it. Losing
+> it with no backup and no reset is how apps get abandoned.
+
+Then create `android/key.properties` (already gitignored via
+`android/.gitignore:12`):
+
+```properties
+storePassword=<store password>
+keyPassword=<key password>
+keyAlias=upload
+storeFile=/Users/paul/keys/mymediascanner-upload.jks
+```
+
+`storeFile` is resolved relative to `android/app/`, so use an absolute path
+locally.
+
+Verify signing works — this is the check that catches a misconfigured
+keystore before Play does:
+
+```bash
+flutter build appbundle --release --flavor prod
+keytool -printcert -jarfile build/app/outputs/bundle/prodRelease/app-prod-release.aab
+```
+
+The certificate owner must be the CN you just entered, **not**
+`CN=Android Debug`. `android/app/build.gradle.kts` warns loudly when
+`key.properties` is missing locally, and fails the build outright on CI.
+
+## 4. Create the app in Play Console
+
+Play Console → **Create app**:
+
+| Field | Value |
+|-------|-------|
+| App name | MyMediaScanner |
+| Default language | English (United Kingdom) |
+| App or game | App |
+| Free or paid | Free |
+
+Free cannot be changed to paid later. Paid can be made free.
+
+## 5. Complete the declarations
+
+Everything under **Policy and programmes → App content**:
+
+- **Privacy policy** — the URL from step 2.
+- **Ads** — no ads. There is no ad SDK in `pubspec.yaml`.
+- **App access** — all functionality is available without logging in, but
+  metadata lookup returns nothing until the user supplies an API key. Say so,
+  and **put a working TMDB key in the reviewer notes**, otherwise the
+  reviewer sees an app where scanning appears to do nothing and the review
+  fails.
+- **Content rating** — complete the questionnaire. Reference/utility app, no
+  user-generated content shared between users, no violence, no gambling.
+- **Target audience** — 18+ (or 13+); not designed for children.
+- **Data safety** — see the next section.
+- **Government apps** — no. **Financial features** — none.
+- **Health** — none.
+
+### Data safety answers
+
+Based on what the code actually does — no analytics, advertising, or
+crash-reporting SDKs are present:
+
+| Question | Answer |
+|----------|--------|
+| Does your app collect or share user data? | **No** |
+| Is data encrypted in transit? | Yes (HTTPS to metadata APIs; the optional PostgreSQL connection is user-configured) |
+| Can users request data deletion? | Yes — uninstalling removes the local database |
+
+"Collect" in Play's sense means transmitted off the device to *you*. Barcode
+lookups go to third-party APIs but nothing is retained by the developer and
+no personal or device identifiers are attached. The camera is used only for
+on-device barcode decoding and ML Kit OCR — declare it as such, not as photo
+collection.
+
+## 6. Store listing graphics
+
+The listing text is already in the repo and is pushed by Fastlane from
+`android/fastlane/metadata/android/en-GB/` (`title.txt`,
+`short_description.txt`, `full_description.txt`, `changelogs/`). Graphics must
+be uploaded through the Console.
+
+| Asset | Requirement |
+|-------|-------------|
+| App icon | 512 × 512 PNG, 32-bit |
+| Feature graphic | 1024 × 500 PNG or JPEG |
+| Phone screenshots | 2–8, 16:9 or 9:16, each side 320–3840 px |
+| 7" and 10" tablet screenshots | Optional, but needed to be listed as tablet-optimised |
+
+The 13 PNGs in `src/docs/modules/ROOT/images/screenshots/` are **desktop**
+captures produced by `tools/capture-screenshots.sh` running the Linux build —
+wrong aspect ratio for a phone listing. Capture fresh ones from an Android
+emulator:
+
+```bash
+flutter run --flavor dev            # on a phone-sized emulator
+# then, per screen:
+adb exec-out screencap -p > shot-01-dashboard.png
+```
+
+Good candidates: dashboard, collection grid, scanner, item detail, insights.
+
+## 7. Create the Play service account (for automated uploads)
+
+Only needed once you want CI to upload. The first bundle goes up by hand
+(step 8) regardless.
+
+1. Play Console → **Setup → API access** → link or create a Google Cloud
+   project.
+2. In Google Cloud Console, create a **service account** and generate a JSON
+   key.
+3. Back in Play Console → **Users and permissions** → invite the service
+   account address, grant it access to this app with **Release → Release apps
+   to testing tracks** (add production later if you want the `release` lane).
+
+Test the credentials without publishing anything:
+
+```bash
+cd android
+PLAY_JSON_KEY_PATH=/path/to/play-service-account.json fastlane validate
+```
+
+The `validate` lane runs the same upload with `validate_only: true`.
+
+## 8. First upload — by hand
+
+Fastlane cannot create the Play Console app entry, and this first upload is
+what enrols the app in Play App Signing. Do it through the Console.
+
+```bash
+flutter analyze && flutter test
+flutter build appbundle --release --flavor prod
+```
+
+Before uploading, check the merged manifest for permissions that plugins
+injected. `flutter_local_notifications`, `file_picker`, and `image_picker`
+all add permissions that are not in
+`android/app/src/main/AndroidManifest.xml`, and some of them
+(`SCHEDULE_EXACT_ALARM`, any `MANAGE_EXTERNAL_STORAGE`) require a separate
+declaration form in Console:
+
+```bash
+bundletool dump manifest \
+  --bundle=build/app/outputs/bundle/prodRelease/app-prod-release.aab
+```
+
+### Watch the download size
+
+The `prod` bundle is around 113 MB. That is the whole bundle across every
+ABI, not what a user downloads — Play splits it per device — but it is worth
+checking the **download size** Play reports after upload. Play caps any
+single generated APK set at 200 MB.
+
+Most of the weight is native: `flutter_zxing`'s FFI libraries and the four
+extra ML Kit language models (Chinese, Devanagari, Japanese, Korean) that
+`android/app/build.gradle.kts` pulls in purely to satisfy R8's missing-class
+check. If size ever becomes a problem, those four are the first thing to
+look at — the app only uses Latin-script recognition.
+
+### Test the bundle on a device
+
+Install it on real hardware before uploading. `isMinifyEnabled = true`, and
+Drift, Retrofit, and ML Kit all use reflection — R8 stripping something is
+the classic way a release build breaks when debug builds are fine:
+
+```bash
+bundletool build-apks \
+  --bundle=build/app/outputs/bundle/prodRelease/app-prod-release.aab \
+  --output=/tmp/mms.apks --mode=universal
+bundletool install-apks --apks=/tmp/mms.apks
+```
+
+Exercise a barcode scan, a metadata lookup, and cover OCR on the device
+before uploading.
+
+Finally: Play Console → **Testing → Internal testing** → **Create new
+release** → upload the `.aab` → add testers → roll out.
+
+## 9. Every release after that
+
+1. Bump the build number in `pubspec.yaml`. Play requires a strictly
+   increasing `versionCode`, and this is where it comes from:
+
+   ```yaml
+   version: 1.0.1+2      # versionName 1.0.1, versionCode 2
+   ```
+
+2. Add a changelog at
+   `android/fastlane/metadata/android/en-GB/changelogs/<versionCode>.txt`.
+   The filename must match the new `versionCode`.
+
+3. Commit and tag:
+
+   ```bash
+   git tag v1.0.1 && git push origin v1.0.1
+   ```
+
+   The tag push builds the APK and AAB and attaches both to a GitHub Release.
+   It does **not** upload to Play.
+
+4. To upload to Play, run the workflow manually: Actions → **Release
+   Android** → **Run workflow** → `flavor: prod`, `publish_to_play: true`.
+   That runs `fastlane beta`, which pushes the bundle and the listing
+   metadata to the internal track.
+
+5. Promote internal → closed → production in Play Console when you are ready.
+
+### Required GitHub secrets
+
+Settings → Secrets and variables → Actions:
+
+| Secret | Value |
+|--------|-------|
+| `ANDROID_KEYSTORE_BASE64` | `base64 -i ~/keys/mymediascanner-upload.jks \| pbcopy` |
+| `ANDROID_KEYSTORE_PASSWORD` | The store password from step 3 |
+| `ANDROID_KEY_ALIAS` | `upload` |
+| `ANDROID_KEY_PASSWORD` | The key password from step 3 |
+| `PLAY_SERVICE_ACCOUNT_JSON` | Full contents of the service account JSON from step 7 |
+
+Until `ANDROID_KEYSTORE_BASE64` is set, the release workflow **fails** rather
+than producing a debug-signed artefact. That is deliberate: a debug-signed
+"release" APK on a GitHub Release is worse than a red build.
+
+---
+
+## Troubleshooting
+
+**"You uploaded an APK that is not signed with the upload certificate"** —
+the keystore in CI differs from the one used for the first manual upload.
+Compare `keytool -printcert -jarfile <aab>` against the upload certificate
+fingerprint shown in Play Console → Setup → App integrity.
+
+**"Version code N has already been used"** — bump the `+N` in
+`pubspec.yaml`.
+
+**Fastlane fails on metadata upload for the very first automated run** — the
+listing must exist first. Run with `SKIP_METADATA=true` to push only the
+bundle.
+
+**App works in debug, crashes or shows empty data in release** — R8. Check
+`android/app/proguard-rules.pro` and reproduce with the `bundletool` install
+above, not with `flutter run --release`.
+
+## Related files
+
+| File | Purpose |
+|------|---------|
+| `android/app/build.gradle.kts` | Flavours, signing config, R8 |
+| `android/key.properties` | Local keystore credentials (gitignored) |
+| `android/fastlane/Fastfile` | `validate`, `beta`, `release` lanes |
+| `android/fastlane/Appfile` | Package name, service account key path |
+| `android/fastlane/metadata/android/en-GB/` | Store listing text and changelogs |
+| `.github/workflows/release-android.yml` | Build, sign, publish |
+| `src/docs/modules/ROOT/pages/privacy-policy.adoc` | Privacy policy source |
+| `docs/privacy-policy.html` | Generated; published via GitHub Pages |
+| `tools/render-privacy-policy.sh` | Renders the `.adoc` to that HTML |

--- a/docs/privacy-policy.html
+++ b/docs/privacy-policy.html
@@ -1,0 +1,638 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
+<meta name="description" content="How MyMediaScanner handles your data on-device, and which third-party services receive lookup requests.">
+<title>MyMediaScanner Privacy Policy</title>
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child{border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:first-child,.sidebarblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child,.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active,#footnotes .footnote a:first-of-type:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,td.hdlist1,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="article">
+<div id="header">
+<h1>MyMediaScanner Privacy Policy</h1>
+</div>
+<div id="content">
+<div id="preamble">
+<div class="sectionbody">
+<div class="paragraph">
+<p><em>Last updated: 6 August 2026</em></p>
+</div>
+<div class="paragraph">
+<p>MyMediaScanner is an app for cataloguing a personal collection of physical media — CDs, DVDs, Blu-rays, books, and video games.
+This policy explains what the app does with your information.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_the_short_version"><a class="anchor" href="#_the_short_version"></a>The short version</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>MyMediaScanner has no servers and no accounts.
+Your collection is stored on your device.
+Nothing is sent to the developer, and the app contains no analytics, advertising, or crash-reporting SDKs.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_what_the_app_stores_and_where"><a class="anchor" href="#_what_the_app_stores_and_where"></a>What the app stores, and where</h2>
+<div class="sectionbody">
+<div class="ulist">
+<ul>
+<li>
+<p><strong>Your collection</strong> — items, shelves, tags, locations, series, wishlist, borrowers, and loan records — is stored in a local SQLite database on your device.</p>
+</li>
+<li>
+<p><strong>Cached metadata and cover artwork</strong> retrieved from the services listed below is stored locally so the app works offline and makes fewer network requests.</p>
+</li>
+<li>
+<p><strong>Your settings</strong>, such as the chosen theme and layout preferences, are stored locally.</p>
+</li>
+<li>
+<p><strong>Credentials you enter</strong> — third-party API keys and, if you use it, your PostgreSQL connection details — are held in the operating system&#8217;s secure storage (the Android Keystore, the iOS and macOS Keychain, or the platform equivalent).</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Uninstalling the app removes this data from your device.
+The app performs no automatic backup to the developer or to any third party.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_camera"><a class="anchor" href="#_camera"></a>Camera</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The app requests camera access so you can scan barcodes and, optionally, read text from a cover using OCR.
+Camera frames are processed on your device and are not uploaded anywhere.
+Text recognition uses Google ML Kit&#8217;s on-device models.
+The app does not store photographs of what you scan; it keeps only the decoded barcode number.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_information_sent_to_third_parties"><a class="anchor" href="#_information_sent_to_third_parties"></a>Information sent to third parties</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>When you scan an item or search for one, the app sends the barcode, ISBN, IMDb ID, or search text to metadata providers in order to look up a title.
+It sends nothing else about you — no device identifier, no account, no location.
+Which providers are used depends on the media type and on which API keys you have supplied.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 40%;">
+<col style="width: 40%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Provider</th>
+<th class="tableblock halign-left valign-top">Used for</th>
+<th class="tableblock halign-left valign-top">Privacy policy</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TMDB</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Films and TV</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.themoviedb.org/privacy-policy">themoviedb.org/privacy-policy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TheTVDB</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TV series</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.thetvdb.com/privacy-policy">thetvdb.com/privacy-policy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Discogs</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Music releases</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.discogs.com/privacy">discogs.com/privacy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MusicBrainz</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Music releases</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://metabrainz.org/privacy">metabrainz.org/privacy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TheAudioDB</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Music metadata</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.theaudiodb.com/">theaudiodb.com</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fanart.tv</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Artwork</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://fanart.tv/privacy-policy/">fanart.tv/privacy-policy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Google Books</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Books</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://policies.google.com/privacy">policies.google.com/privacy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Open Library</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Books</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://archive.org/about/terms.php">archive.org/about/terms</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">UPCitemdb</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Barcode fallback</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.upcitemdb.com/wp/docs/privacy-policy/">upcitemdb.com privacy policy</a></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AccurateRip</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Audio rip verification (desktop only)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="https://www.accuraterip.com/">accuraterip.com</a></p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p>These providers will see the IP address your request comes from, as they would for any internet request.
+Their handling of that is governed by their own policies, linked above.
+The developer of MyMediaScanner receives none of it.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_optional_tmdb_account_linking"><a class="anchor" href="#_optional_tmdb_account_linking"></a>Optional TMDB account linking</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>If you choose to connect a TMDB account, the app authenticates directly with TMDB and can read and update your TMDB watchlist, ratings, and favourites.
+That activity goes to TMDB under their privacy policy.
+Your TMDB session token is kept in your device&#8217;s secure storage.
+You can disconnect the account from Settings at any time.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_optional_self_hosted_sync"><a class="anchor" href="#_optional_self_hosted_sync"></a>Optional self-hosted sync</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>The app can synchronise your collection to a PostgreSQL database.
+That database is one <strong>you</strong> run and configure — the app connects directly to the address you give it.
+No intermediary service is involved and the developer has no access to it.
+Securing that server, and the network path to it, is your responsibility.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_music_rip_library_scanning"><a class="anchor" href="#_music_rip_library_scanning"></a>Music rip library scanning</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>On desktop platforms, the app can scan a folder of FLAC or MP3 files that you nominate.
+It reads audio tags, embedded artwork, and CUE sheets to build a local index and to compare against your physical collection.
+Those files are read from disk and analysed locally; their contents are not uploaded.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_children"><a class="anchor" href="#_children"></a>Children</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>MyMediaScanner is not directed at children and does not knowingly collect information from anyone.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_changes_to_this_policy"><a class="anchor" href="#_changes_to_this_policy"></a>Changes to this policy</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Any changes will be published on this page with an updated date above.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_contact"><a class="anchor" href="#_contact"></a>Contact</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Questions about this policy, or about the app&#8217;s handling of data, can be raised as an issue at <a href="https://github.com/bovinemagnet/MyMediaScanner/issues">GitHub</a>.</p>
+</div>
+</div>
+</div>
+</div>
+</body>
+</html>

--- a/src/docs/modules/ROOT/nav.adoc
+++ b/src/docs/modules/ROOT/nav.adoc
@@ -26,3 +26,4 @@
 * xref:api-configuration.adoc[API Configuration]
 * xref:integrations.adoc[Metadata Integrations]
 * xref:testing.adoc[Testing]
+* xref:privacy-policy.adoc[Privacy Policy]

--- a/src/docs/modules/ROOT/pages/privacy-policy.adoc
+++ b/src/docs/modules/ROOT/pages/privacy-policy.adoc
@@ -1,0 +1,117 @@
+= MyMediaScanner Privacy Policy
+:description: How MyMediaScanner handles your data on-device, and which third-party services receive lookup requests.
+
+_Last updated: 6 August 2026_
+
+MyMediaScanner is an app for cataloguing a personal collection of physical media — CDs, DVDs, Blu-rays, books, and video games.
+This policy explains what the app does with your information.
+
+== The short version
+
+MyMediaScanner has no servers and no accounts.
+Your collection is stored on your device.
+Nothing is sent to the developer, and the app contains no analytics, advertising, or crash-reporting SDKs.
+
+== What the app stores, and where
+
+* *Your collection* — items, shelves, tags, locations, series, wishlist, borrowers, and loan records — is stored in a local SQLite database on your device.
+* *Cached metadata and cover artwork* retrieved from the services listed below is stored locally so the app works offline and makes fewer network requests.
+* *Your settings*, such as the chosen theme and layout preferences, are stored locally.
+* *Credentials you enter* — third-party API keys and, if you use it, your PostgreSQL connection details — are held in the operating system's secure storage (the Android Keystore, the iOS and macOS Keychain, or the platform equivalent).
+
+Uninstalling the app removes this data from your device.
+The app performs no automatic backup to the developer or to any third party.
+
+== Camera
+
+The app requests camera access so you can scan barcodes and, optionally, read text from a cover using OCR.
+Camera frames are processed on your device and are not uploaded anywhere.
+Text recognition uses Google ML Kit's on-device models.
+The app does not store photographs of what you scan; it keeps only the decoded barcode number.
+
+== Information sent to third parties
+
+When you scan an item or search for one, the app sends the barcode, ISBN, IMDb ID, or search text to metadata providers in order to look up a title.
+It sends nothing else about you — no device identifier, no account, no location.
+Which providers are used depends on the media type and on which API keys you have supplied.
+
+[cols="1,2,2", options="header"]
+|===
+| Provider | Used for | Privacy policy
+
+| TMDB
+| Films and TV
+| https://www.themoviedb.org/privacy-policy[themoviedb.org/privacy-policy]
+
+| TheTVDB
+| TV series
+| https://www.thetvdb.com/privacy-policy[thetvdb.com/privacy-policy]
+
+| Discogs
+| Music releases
+| https://www.discogs.com/privacy[discogs.com/privacy]
+
+| MusicBrainz
+| Music releases
+| https://metabrainz.org/privacy[metabrainz.org/privacy]
+
+| TheAudioDB
+| Music metadata
+| https://www.theaudiodb.com/[theaudiodb.com]
+
+| Fanart.tv
+| Artwork
+| https://fanart.tv/privacy-policy/[fanart.tv/privacy-policy]
+
+| Google Books
+| Books
+| https://policies.google.com/privacy[policies.google.com/privacy]
+
+| Open Library
+| Books
+| https://archive.org/about/terms.php[archive.org/about/terms]
+
+| UPCitemdb
+| Barcode fallback
+| https://www.upcitemdb.com/wp/docs/privacy-policy/[upcitemdb.com privacy policy]
+
+| AccurateRip
+| Audio rip verification (desktop only)
+| https://www.accuraterip.com/[accuraterip.com]
+|===
+
+These providers will see the IP address your request comes from, as they would for any internet request.
+Their handling of that is governed by their own policies, linked above.
+The developer of MyMediaScanner receives none of it.
+
+== Optional TMDB account linking
+
+If you choose to connect a TMDB account, the app authenticates directly with TMDB and can read and update your TMDB watchlist, ratings, and favourites.
+That activity goes to TMDB under their privacy policy.
+Your TMDB session token is kept in your device's secure storage.
+You can disconnect the account from Settings at any time.
+
+== Optional self-hosted sync
+
+The app can synchronise your collection to a PostgreSQL database.
+That database is one *you* run and configure — the app connects directly to the address you give it.
+No intermediary service is involved and the developer has no access to it.
+Securing that server, and the network path to it, is your responsibility.
+
+== Music rip library scanning
+
+On desktop platforms, the app can scan a folder of FLAC or MP3 files that you nominate.
+It reads audio tags, embedded artwork, and CUE sheets to build a local index and to compare against your physical collection.
+Those files are read from disk and analysed locally; their contents are not uploaded.
+
+== Children
+
+MyMediaScanner is not directed at children and does not knowingly collect information from anyone.
+
+== Changes to this policy
+
+Any changes will be published on this page with an updated date above.
+
+== Contact
+
+Questions about this policy, or about the app's handling of data, can be raised as an issue at https://github.com/bovinemagnet/MyMediaScanner/issues[GitHub].

--- a/tools/render-privacy-policy.sh
+++ b/tools/render-privacy-policy.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Render the privacy policy from its AsciiDoc source into the standalone HTML
+# page published by GitHub Pages.
+#
+# GitHub Pages cannot render AsciiDoc (jekyll-asciidoc is not an allowed
+# plugin), and Google Play requires a privacy policy URL that actually
+# displays, so the .adoc source is converted to HTML and committed.
+#
+# Run this after editing the source, and commit both files together.
+#
+# Usage:
+#   tools/render-privacy-policy.sh
+#   tools/render-privacy-policy.sh --check   # verify the HTML is up to date
+#
+# Requires asciidoctor 2.0.23 — the same version CI pins, so that --check
+# compares content rather than renderer differences:
+#
+#   gem install asciidoctor -v 2.0.23
+#
+# Author: Paul Snow
+# Since: 0.0.0
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# `gem install --user-install` puts the binary somewhere that is often not on
+# PATH, so look there before giving up.
+if ! command -v asciidoctor >/dev/null 2>&1 && command -v ruby >/dev/null 2>&1; then
+  PATH="$(ruby -e 'print Gem.user_dir')/bin:${PATH}"
+  export PATH
+fi
+
+SRC="src/docs/modules/ROOT/pages/privacy-policy.adoc"
+OUT="docs/privacy-policy.html"
+CHECK_ONLY=false
+
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=true
+fi
+
+if [[ ! -f "$SRC" ]]; then
+  echo "ERROR: $SRC not found" >&2
+  exit 1
+fi
+
+# -a nofooter drops the generation timestamp, so identical input always
+# produces identical output and the --check diff stays meaningful.
+render() {
+  local target="$1"
+  local -a args=(
+    --backend html5
+    --doctype article
+    --out-file "$target"
+    -a nofooter
+    -a toc!
+    -a sectanchors
+    # A privacy policy should not itself phone home. The default stylesheet
+    # links Google Fonts from a CDN; webfonts! drops that so the page makes
+    # no external requests.
+    -a webfonts!
+    -a lang=en-GB
+    -a "docname=privacy-policy"
+    "$SRC"
+  )
+
+  if ! command -v asciidoctor >/dev/null 2>&1; then
+    echo "ERROR: asciidoctor not found." >&2
+    echo "       Install with: gem install asciidoctor -v 2.0.23" >&2
+    exit 1
+  fi
+  asciidoctor "${args[@]}"
+}
+
+if [[ "$CHECK_ONLY" == true ]]; then
+  TMP_OUT="$(mktemp -t privacy-policy.XXXXXX).html"
+  trap 'rm -f "$TMP_OUT"' EXIT
+  render "$TMP_OUT"
+  if ! diff -q "$OUT" "$TMP_OUT" >/dev/null 2>&1; then
+    echo "ERROR: $OUT is out of date with $SRC." >&2
+    echo "       Run tools/render-privacy-policy.sh and commit the result." >&2
+    diff -u "$OUT" "$TMP_OUT" >&2 || true
+    exit 1
+  fi
+  echo "==> $OUT is up to date"
+  exit 0
+fi
+
+render "$OUT"
+echo "==> Wrote $OUT"
+echo "    Published at https://bovinemagnet.github.io/MyMediaScanner/privacy-policy.html"


### PR DESCRIPTION
## Why

The app has never shipped to Google Play, and four things blocked it.

1. **Nothing built an `.aab`.** `release-android.yml` only ran `flutter build apk`, yet the Fastlane lanes uploaded a bundle that was never produced. Play does not accept APKs for new apps.
2. **The release signing config silently fell back to debug keys** whenever `android/key.properties` was absent. Every "release" APK attached to a GitHub Release so far was debug-signed — a live defect, not just a Play blocker.
3. **`Appfile` had `json_key_file("")`**, so the upload lanes could not authenticate.
4. **No privacy policy.** Play requires a publicly reachable URL for every app.

## What changed

**Signing** — the debug fallback stays for local `flutter run --release`, but now warns loudly, and fails outright when `CI` is set. A misconfigured secret breaks the build instead of shipping an unusable artefact.

**CI** — builds the prod app bundle alongside the APK, decodes the keystore from secrets, prints the signing certificate as a step, and attaches both artefacts to the GitHub Release. A new `publish-play` job runs `fastlane beta` against the internal track, gated behind a `publish_to_play` dispatch input defaulting to `false`, so tag pushes never upload unattended.

**Fastlane** — service account path from `PLAY_JSON_KEY_PATH`; a `validate` lane that dry-runs against the real Play API via `validate_only`; one shared AAB path; `SKIP_METADATA=true` for the first automated run, since Fastlane cannot create the Play Console listing.

**Privacy policy** — source at `src/docs/modules/ROOT/pages/privacy-policy.adoc`, rendered by `tools/render-privacy-policy.sh` to `docs/privacy-policy.html`. GitHub Pages cannot render AsciiDoc (`jekyll-asciidoc` is not an allowed plugin), so the HTML is generated and committed, served from `/docs` with `.nojekyll`. A CI job with a pinned asciidoctor fails if the two drift. Rendered with `webfonts!` so the policy page makes no external requests.

**`docs/PLAY_STORE_RELEASE.md`** — the runbook for what cannot be automated: keystore, Play Console declarations with the Data safety answers spelled out, store graphics, required secrets, per-release loop.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 1,825 tests pass
- `flutter build appbundle --release --flavor prod` succeeds; `keytool -printcert -jarfile` on the result reports `CN=Paul Snow, O=Snowed Under Productions`, not `CN=Android Debug`
- `tools/render-privacy-policy.sh --check` verified on both the pass and fail paths
- Both workflow files parse

## Notes for the reviewer

- Until `ANDROID_KEYSTORE_BASE64` is set, the release workflow now **fails** rather than producing a debug-signed artefact. That is deliberate.
- The bundle is ~113 MB. Within Play's per-device limits, but a chunk is the four ML Kit language models (Chinese, Devanagari, Japanese, Korean) that `build.gradle.kts` pulls in only to satisfy R8's missing-class check, when the app uses Latin script. Left alone here; flagged in the runbook.
- The real schedule constraint is the 12-testers-for-14-days closed testing gate for new personal developer accounts, not the build work.