### PR TITLE
feat(ios): make the app TestFlight-ready

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -18,6 +18,14 @@ jobs:
     permissions:
       contents: write
 
+    # Signing switches on only when the secrets exist, the same way
+    # release-android.yml gates on ANDROID_KEYSTORE_BASE64. Without them the
+    # job still proves the app compiles, which is all it did before.
+    env:
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      IOS_DISTRIBUTION_CERT_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERT_BASE64 }}
+      APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,8 +71,16 @@ jobs:
       - name: Run tests
         run: flutter test
 
-      - name: Build iOS release (no codesign)
-        run: flutter build ios --release --no-codesign
+      - name: Report signing mode
+        id: signing
+        run: |
+          if [ -n "$IOS_DISTRIBUTION_CERT_BASE64" ] && [ -n "$APPLE_TEAM_ID" ]; then
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+            echo "Signing enabled — building an uploadable IPA."
+          else
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No iOS signing secrets set; building unsigned. See docs/IOS_RELEASE.md."
+          fi
 
       - name: Determine version
         id: version
@@ -72,28 +88,144 @@ jobs:
           VERSION=$(grep '^\s*version:' pubspec.yaml | sed 's/.*version:[[:space:]]*//' | sed 's/+.*//' | tr -d ' ')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      # ---------------------------------------------------------------- signed
+
+      - name: Import signing certificate and profile
+        if: steps.signing.outputs.signed == 'true'
+        env:
+          CERT_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERT_PASSWORD }}
+          PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          KEYCHAIN=$RUNNER_TEMP/signing.keychain-db
+
+          echo "$IOS_DISTRIBUTION_CERT_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          echo "$PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/profile.mobileprovision"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          # Keep the login keychain in the search list so system roots resolve.
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+
+          PROFILES="$HOME/Library/MobileDevice/Provisioning Profiles"
+          mkdir -p "$PROFILES"
+          cp "$RUNNER_TEMP/profile.mobileprovision" "$PROFILES/"
+
+          rm -f "$RUNNER_TEMP/cert.p12"
+
+      - name: Write signing configuration
+        if: steps.signing.outputs.signed == 'true'
+        env:
+          PROFILE_NAME: ${{ secrets.IOS_PROVISIONING_PROFILE_NAME }}
+        run: |
+          cat > ios/Flutter/Signing.xcconfig <<EOF
+          DEVELOPMENT_TEAM = ${APPLE_TEAM_ID}
+          CODE_SIGN_STYLE = Manual
+          CODE_SIGN_IDENTITY[sdk=iphoneos*] = Apple Distribution
+          PROVISIONING_PROFILE_SPECIFIER = ${PROFILE_NAME}
+          EOF
+
+          BUNDLE_ID=com.paulsnow.mymediascanner
+          cat > "$RUNNER_TEMP/ExportOptions.plist" <<EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+            <dict>
+              <key>method</key><string>app-store-connect</string>
+              <key>teamID</key><string>${APPLE_TEAM_ID}</string>
+              <key>signingStyle</key><string>manual</string>
+              <key>uploadSymbols</key><true/>
+              <key>provisioningProfiles</key>
+              <dict>
+                <key>${BUNDLE_ID}</key><string>${PROFILE_NAME}</string>
+              </dict>
+            </dict>
+          </plist>
+          EOF
+          plutil -lint "$RUNNER_TEMP/ExportOptions.plist"
+
+      # TestFlight rejects a build number it has already seen, so take it from
+      # the run number, which only ever increases.
+      - name: Build signed IPA
+        if: steps.signing.outputs.signed == 'true'
+        id: signed_ipa
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          flutter build ipa --release \
+            --build-number="$BUILD_NUMBER" \
+            --export-options-plist="$RUNNER_TEMP/ExportOptions.plist"
+
+          SRC=$(ls build/ios/ipa/*.ipa | head -1)
+          IPA_NAME="MyMediaScanner-${APP_VERSION}-ios.ipa"
+          mv "$SRC" "build/ios/ipa/${IPA_NAME}"
+          echo "ipa_name=${IPA_NAME}" >> "$GITHUB_OUTPUT"
+          echo "ipa_path=build/ios/ipa/${IPA_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to TestFlight
+        if: steps.signing.outputs.signed == 'true' && env.APPSTORE_API_KEY_ID != ''
+        working-directory: ios
+        env:
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          gem install fastlane --no-document
+          fastlane beta
+
+      # -------------------------------------------------------------- unsigned
+
+      - name: Build iOS release (no codesign)
+        if: steps.signing.outputs.signed != 'true'
+        run: flutter build ios --release --no-codesign
+
       - name: Create unsigned IPA
-        id: ipa
+        if: steps.signing.outputs.signed != 'true'
+        id: unsigned_ipa
+        env:
+          APP_VERSION: ${{ steps.version.outputs.version }}
         run: |
           APP_NAME="MyMediaScanner"
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${APP_VERSION}"
           IPA_NAME="${APP_NAME}-${VERSION}-ios-unsigned.ipa"
-          BUILD_DIR="build/ios/iphoneos"
-          APP_PATH="${BUILD_DIR}/Runner.app"
           PAYLOAD_DIR="build/Payload"
           mkdir -p "${PAYLOAD_DIR}"
-          cp -R "${APP_PATH}" "${PAYLOAD_DIR}/"
+          cp -R "build/ios/iphoneos/Runner.app" "${PAYLOAD_DIR}/"
           cd build
           zip -r -q "${IPA_NAME}" Payload/
           cd ..
           echo "ipa_name=${IPA_NAME}" >> "$GITHUB_OUTPUT"
           echo "ipa_path=build/${IPA_NAME}" >> "$GITHUB_OUTPUT"
 
+      # ----------------------------------------------------------- publication
+
+      - name: Collect artefact paths
+        id: artefact
+        env:
+          SIGNED: ${{ steps.signing.outputs.signed }}
+          SIGNED_NAME: ${{ steps.signed_ipa.outputs.ipa_name }}
+          SIGNED_PATH: ${{ steps.signed_ipa.outputs.ipa_path }}
+          UNSIGNED_NAME: ${{ steps.unsigned_ipa.outputs.ipa_name }}
+          UNSIGNED_PATH: ${{ steps.unsigned_ipa.outputs.ipa_path }}
+        run: |
+          if [ "$SIGNED" = "true" ]; then
+            echo "name=${SIGNED_NAME}" >> "$GITHUB_OUTPUT"
+            echo "path=${SIGNED_PATH}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${UNSIGNED_NAME}" >> "$GITHUB_OUTPUT"
+            echo "path=${UNSIGNED_PATH}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload IPA artefact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.ipa.outputs.ipa_name }}
-          path: ${{ steps.ipa.outputs.ipa_path }}
+          name: ${{ steps.artefact.outputs.name }}
+          path: ${{ steps.artefact.outputs.path }}
           retention-days: 30
 
       - name: Create GitHub Release
@@ -102,5 +234,5 @@ jobs:
         with:
           draft: false
           prerelease: false
-          files: ${{ steps.ipa.outputs.ipa_path }}
+          files: ${{ steps.artefact.outputs.path }}
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ migrate_working_dir/
 # Flutter/Dart/Pub related
 **/doc/api/
 **/ios/Flutter/.last_build_id
+# Local code-signing settings; see ios/Flutter/Signing.xcconfig.example
+**/ios/Flutter/Signing.xcconfig
 .dart_tool/
 .flutter-plugins-dependencies
 # Local-only ML Kit stub toggle for iOS simulator builds (see scripts/ios_sim.sh)

--- a/README.adoc
+++ b/README.adoc
@@ -255,6 +255,8 @@ npx antora local-antora-playbook-search.yml
 
 Android releases go to Google Play. See link:docs/PLAY_STORE_RELEASE.md[docs/PLAY_STORE_RELEASE.md] for the full runbook -- upload keystore, Play Console declarations, store graphics, and the tag-and-publish workflow.
 
+iOS releases go to TestFlight and the App Store. See link:docs/IOS_RELEASE.md[docs/IOS_RELEASE.md] -- Developer Program enrolment, signing, the privacy manifest, App Store Connect API key, and the tag-and-publish workflow.
+
 == Privacy
 
 MyMediaScanner has no servers and no accounts. Your collection is stored locally on your device, and the app contains no analytics, advertising, or crash-reporting SDKs.

--- a/docs/IOS_RELEASE.md
+++ b/docs/IOS_RELEASE.md
@@ -55,6 +55,42 @@ The name must be unique across the whole App Store. If "MyMediaScanner" is
 taken, the store name and the on-device name can differ — only the store name
 has to be unique.
 
+### App Information
+
+App Store Connect → your app → **General** → **App Information**. The text
+values live in `ios/fastlane/metadata/en-GB/`, so paste from there rather than
+inventing new copy — `fastlane release` uploads those same files and would
+otherwise overwrite whatever you typed.
+
+| Field | Value | Limit |
+|---|---|---|
+| Name | `MyMediaScanner` | 30 |
+| Subtitle | `Catalogue your physical media` | 30 |
+| Privacy Policy URL | `https://bovinemagnet.github.io/MyMediaScanner/privacy-policy.html` | — |
+| Primary category | Utilities | — |
+| Secondary category | Reference | — |
+| Content Rights | Contains third-party content — see below | — |
+| Age Rating | answer all "None"; the app rates 4+ | — |
+| Licence Agreement | Apple's standard EULA | — |
+
+Two fields live on the **version** page rather than App Information, and one
+of them has no file in the repo:
+
+| Field | Value |
+|---|---|
+| Promotional text / Description | `description.txt` |
+| Keywords | `keywords.txt` |
+| What's New | `release_notes.txt` |
+| **Support URL** (required) | `https://github.com/bovinemagnet/MyMediaScanner/issues` |
+
+**Content Rights.** Cover art and metadata come from third-party APIs (TMDB,
+Discogs, MusicBrainz, Google Books, Open Library, TheAudioDB, Fanart,
+UPCitemdb), fetched when the user scans an item. Answer that the app contains
+third-party content. Note that TMDB's API terms require visible attribution —
+wording to the effect of "This product uses the TMDB API but is not endorsed
+or certified by TMDB" — and the app does not display it anywhere yet. Worth
+settling before submission.
+
 ## 3. Configure local signing
 
 ```bash

--- a/docs/IOS_RELEASE.md
+++ b/docs/IOS_RELEASE.md
@@ -1,0 +1,210 @@
+# Releasing MyMediaScanner on iOS
+
+Author: Paul Snow
+
+This is the runbook for getting MyMediaScanner onto TestFlight and, from
+there, the App Store. Steps 1–7 are one-off setup. Step 8 is what you repeat
+for every subsequent release.
+
+Bundle identifier: `com.paulsnow.mymediascanner`. Minimum iOS version: 15.5
+(set by `google_mlkit_commons`).
+
+---
+
+## What is already done in the repository
+
+You do not need to touch any of this — it is committed and covered by
+`test/unit/platform/ios_release_config_test.dart`, which fails if any of it
+regresses:
+
+- Purpose strings for camera, photo library and local network. The photo
+  library one is not optional: `cover_ocr_helper.dart` calls
+  `ImageSource.gallery`, and iOS terminates an app that reaches the picker
+  without a string.
+- `ITSAppUsesNonExemptEncryption = false`, so App Store Connect stops asking
+  the export-compliance question on every upload. The app uses HTTPS and the
+  Keychain only, both exempt.
+- `ios/Runner/PrivacyInfo.xcprivacy`, wired into the Runner target's resources
+  so it actually ships in the bundle. Without it uploads are rejected with
+  ITMS-91053.
+- `ios/Flutter/Release.xcconfig` optionally includes `Signing.xcconfig`, so
+  release builds are unsigned until you supply signing settings.
+
+---
+
+## 1. Enrol in the Apple Developer Program
+
+<https://developer.apple.com/programs/enroll/> — US$99 per year, renewed
+annually. Individual enrolment needs photo ID; organisation enrolment needs a
+D-U-N-S number and takes longer.
+
+Note your **Team ID** — the 10-character string under Membership details. You
+need it in step 3.
+
+## 2. Register the app in App Store Connect
+
+<https://appstoreconnect.apple.com> → **Apps** → **+** → **New App**.
+
+- Platform: iOS
+- Bundle ID: `com.paulsnow.mymediascanner` (register it first at
+  Certificates, Identifiers & Profiles → Identifiers if it is not offered)
+- SKU: anything unique to you, e.g. `mymediascanner`
+- Primary language: English (UK)
+
+The name must be unique across the whole App Store. If "MyMediaScanner" is
+taken, the store name and the on-device name can differ — only the store name
+has to be unique.
+
+## 3. Configure local signing
+
+```bash
+cp ios/Flutter/Signing.xcconfig.example ios/Flutter/Signing.xcconfig
+```
+
+Put your Team ID in it and leave `CODE_SIGN_STYLE = Automatic`. The file is
+git-ignored — the same arrangement as `android/key.properties` — so your Team
+ID never lands in the repository.
+
+Then sign in to Xcode once so it can create and download certificates for
+you: **Xcode → Settings → Accounts → +** → Apple ID.
+
+Verify:
+
+```bash
+flutter build ipa --release
+```
+
+The IPA lands in `build/ios/ipa/`. If Xcode complains it cannot create a
+provisioning profile, open `ios/Runner.xcworkspace`, select the Runner target,
+and look at Signing & Capabilities — it will say what is missing.
+
+## 4. Create an App Store Connect API key
+
+This is what lets uploads run without a human answering a 2FA prompt.
+
+App Store Connect → **Users and Access** → **Integrations** → **App Store
+Connect API** → **+**. Give it the **App Manager** role.
+
+You get three things, and the `.p8` can only be downloaded **once**:
+
+| Value | Where it appears |
+|---|---|
+| Key ID | the key's row in the table |
+| Issuer ID | above the table |
+| `.p8` private key | one-time download |
+
+## 5. First upload — by hand
+
+Do the first one locally so any signing problem surfaces with a readable error
+rather than inside a CI log:
+
+```bash
+flutter build ipa --release
+
+export APPSTORE_API_KEY_ID=XXXXXXXXXX
+export APPSTORE_API_ISSUER_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+export APPSTORE_API_PRIVATE_KEY="$(cat ~/Downloads/AuthKey_XXXXXXXXXX.p8)"
+
+cd ios && fastlane beta
+```
+
+Processing in App Store Connect takes 5–30 minutes. When it finishes you get
+an email, and the build appears under **TestFlight**.
+
+## 6. Answer the App Privacy questionnaire
+
+App Store Connect → your app → **App Privacy**. TestFlight external testing
+will not open until this is answered.
+
+The honest answers for this app:
+
+- **Data collection:** none. The catalogue is local SQLite; optional sync goes
+  to a PostgreSQL server the user runs themselves; API keys live in the
+  Keychain on device.
+- **Tracking:** no. There is no advertising identifier and no analytics.
+- Metadata lookups do send a barcode or title to third-party APIs (TMDB,
+  Discogs, MusicBrainz, Google Books, Open Library, TheAudioDB, Fanart,
+  UPCitemdb) when the user scans something. That is a user-initiated query
+  rather than collection on our behalf, which is why
+  `NSPrivacyCollectedDataTypes` is empty — but review may ask about it, so be
+  ready to describe it.
+
+## 7. Set up automated uploads (optional)
+
+`release-ios.yml` builds unsigned unless the signing secrets exist, so CI
+stays green while you decide whether to bother. Add these to
+**Settings → Secrets and variables → Actions** to switch it on:
+
+| Secret | How to produce it |
+|---|---|
+| `APPLE_TEAM_ID` | the 10-character Team ID |
+| `IOS_DISTRIBUTION_CERT_BASE64` | export the Apple Distribution certificate *with its private key* from Keychain Access as `.p12`, then `base64 -i cert.p12 \| pbcopy` |
+| `IOS_DISTRIBUTION_CERT_PASSWORD` | the password you set on the `.p12` |
+| `IOS_PROVISIONING_PROFILE_BASE64` | download the App Store profile from the developer portal, then `base64 -i profile.mobileprovision \| pbcopy` |
+| `IOS_PROVISIONING_PROFILE_NAME` | the profile's name, exactly as shown in the portal |
+| `APPSTORE_API_KEY_ID` | from step 4 |
+| `APPSTORE_API_ISSUER_ID` | from step 4 |
+| `APPSTORE_API_PRIVATE_KEY` | the whole `.p8` file contents, including the BEGIN/END lines |
+
+With `APPLE_TEAM_ID` and `IOS_DISTRIBUTION_CERT_BASE64` present the workflow
+signs; the upload step additionally needs the three `APPSTORE_API_*` values.
+
+CI switches the build to **manual** signing, because automatic signing needs
+an interactive Apple ID session that a runner does not have.
+
+## 8. Every release after that
+
+```bash
+# 1. Bump the version. The build number must increase on every upload.
+#    Edit pubspec.yaml: version: 1.1.0+2
+
+# 2. Land it on main, then tag:
+git tag v1.1.0
+git push origin v1.1.0
+```
+
+The tag triggers `release-all.yml`, which runs the iOS job among the others.
+
+CI passes `--build-number=${{ github.run_number }}`, so the uploaded build
+number comes from the run counter rather than pubspec and can never repeat.
+The version *name* still comes from pubspec, so that is the one to bump.
+
+For a local release instead, repeat step 5.
+
+---
+
+## Troubleshooting
+
+**"No profiles for 'com.paulsnow.mymediascanner' were found"** — the bundle ID
+is not registered, or Xcode is not signed in to the team that owns it. Register
+it under Identifiers, then re-open the workspace.
+
+**Upload rejected, ITMS-91053: Missing API declaration** — a dependency
+reaches a required-reason API that `PrivacyInfo.xcprivacy` does not declare.
+The rejection email names the API category; add it to
+`ios/Runner/PrivacyInfo.xcprivacy` with the appropriate reason code from
+Apple's list, and add it to `_requiredApiReasons` in the test so it stays
+declared.
+
+**"The bundle version must be higher than the previously uploaded version"** —
+TestFlight has seen that build number. Re-run the workflow (the run number
+advances) or bump `+N` in pubspec for a local build.
+
+**App crashes when picking a cover image** — a purpose string has gone
+missing from `Info.plist`. `flutter test test/unit/platform/ios_release_config_test.dart`
+names which one.
+
+**Simulator builds fail or will not launch on Apple Silicon** — expected, and
+unrelated to release. Google ML Kit ships no arm64-simulator slice; use
+`scripts/ios_sim.sh`, or a physical device. Release builds for devices are
+arm64 and unaffected.
+
+## Related files
+
+- `.github/workflows/release-ios.yml` — build, sign and upload
+- `ios/fastlane/Fastfile` — TestFlight and App Store lanes
+- `ios/fastlane/metadata/en-GB/` — store listing text
+- `ios/Flutter/Signing.xcconfig.example` — local signing template
+- `ios/Runner/PrivacyInfo.xcprivacy` — privacy manifest
+- `test/unit/platform/ios_release_config_test.dart` — guards all of the above
+- `docs/PLAY_STORE_RELEASE.md` — the Android equivalent

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+#include? "Signing.xcconfig"

--- a/ios/Flutter/Signing.xcconfig.example
+++ b/ios/Flutter/Signing.xcconfig.example
@@ -1,0 +1,25 @@
+// iOS code-signing settings, kept out of version control.
+//
+// Copy to Signing.xcconfig and fill in your Team ID. Release.xcconfig
+// includes it optionally, so release builds fall back to unsigned when the
+// file is absent — the same shape as android/key.properties.
+//
+// Your Team ID is the 10-character string in the Apple Developer portal
+// under Membership details, and next to the team name in Xcode's Accounts
+// pane.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+DEVELOPMENT_TEAM = YOUR_TEAM_ID
+
+// Let Xcode manage certificates and profiles. This is what you want on a
+// machine signed in to your Apple ID.
+CODE_SIGN_STYLE = Automatic
+
+// For unattended signing (CI, or a machine with no Apple ID session), swap
+// the block above for manual signing and name the profile you installed:
+//
+// CODE_SIGN_STYLE = Manual
+// CODE_SIGN_IDENTITY[sdk=iphoneos*] = Apple Distribution
+// PROVISIONING_PROFILE_SPECIFIER = MyMediaScanner App Store

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		7F4BC375AA9F2C9C3C5A711E /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A490A7609AE08A4ACC0A0300 /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
+		D5A1C0FE2A00000000000002 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D5A1C0FE2A00000000000001 /* PrivacyInfo.xcprivacy */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		C0F1797B32ACC0FF74042DCB /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 14C4A80490D3129618873DAB /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
@@ -65,6 +66,7 @@
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D5A1C0FE2A00000000000001 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A490A7609AE08A4ACC0A0300 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +156,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				D5A1C0FE2A00000000000001 /* PrivacyInfo.xcprivacy */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -278,6 +281,7 @@
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
+				D5A1C0FE2A00000000000002 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -653,7 +657,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>$(DEVELOPMENT_LANGUAGE)</string>
 		<key>CFBundleDisplayName</key>
-		<string>Mymediascanner</string>
+		<string>MyMediaScanner</string>
 		<key>CFBundleExecutable</key>
 		<string>$(EXECUTABLE_NAME)</string>
 		<key>CFBundleIdentifier</key>
@@ -63,6 +63,14 @@
 		<true/>
 		<key>NSCameraUsageDescription</key>
 		<string>MyMediaScanner needs camera access to scan barcodes on your media items.</string>
+		<key>NSPhotoLibraryUsageDescription</key>
+		<string>MyMediaScanner needs access to your photos so you can pick a cover image to read its text.</string>
+		<key>NSLocalNetworkUsageDescription</key>
+		<string>MyMediaScanner needs local network access to sync your collection with a PostgreSQL server on your own network.</string>
+		<!-- HTTPS and Keychain only, both exempt. Declaring it here stops App
+		     Store Connect asking the export compliance question every upload. -->
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 		<key>UILaunchStoryboardName</key>
 		<string>LaunchScreen</string>
 		<key>UIMainStoryboardFile</key>

--- a/ios/Runner/PrivacyInfo.xcprivacy
+++ b/ios/Runner/PrivacyInfo.xcprivacy
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<!-- No advertising identifier, no cross-app tracking, no analytics. -->
+		<key>NSPrivacyTracking</key>
+		<false/>
+		<key>NSPrivacyTrackingDomains</key>
+		<array/>
+		<!-- Nothing is collected by this app or on its behalf: the catalogue
+		     lives in local SQLite, and optional sync goes to a PostgreSQL
+		     server the user owns. Metadata lookups send a barcode or title to
+		     third-party APIs at the user's request; those are not collected
+		     for our purposes. The App Privacy questionnaire in App Store
+		     Connect is where that flow is described to reviewers. -->
+		<key>NSPrivacyCollectedDataTypes</key>
+		<array/>
+		<!-- Required-reason APIs. Over-declaring is harmless; omitting one
+		     that a statically linked dependency reaches gets the upload
+		     rejected with ITMS-91053. -->
+		<key>NSPrivacyAccessedAPITypes</key>
+		<array>
+			<dict>
+				<!-- Cover art, rip scanning and the local database all stat
+				     files inside the app container. -->
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>C617.1</string>
+				</array>
+			</dict>
+			<dict>
+				<!-- shared_preferences: theme choice, text size, rip library
+				     path. Read and written only by this app. -->
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>CA92.1</string>
+				</array>
+			</dict>
+			<dict>
+				<!-- SQLite and artwork caching check for free space before
+				     writing. -->
+				<key>NSPrivacyAccessedAPIType</key>
+				<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+				<key>NSPrivacyAccessedAPITypeReasons</key>
+				<array>
+					<string>E174.1</string>
+				</array>
+			</dict>
+		</array>
+	</dict>
+</plist>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,28 +1,49 @@
 default_platform(:ios)
 
+# Authentication uses an App Store Connect API key rather than an Apple ID and
+# app-specific password: it works unattended and does not break under 2FA.
+#
+# Required environment:
+#   APPSTORE_API_KEY_ID      Key ID from App Store Connect > Users and Access > Integrations
+#   APPSTORE_API_ISSUER_ID   Issuer ID from the same page
+#   APPSTORE_API_PRIVATE_KEY Contents of the downloaded .p8 file
+#
+# Build the IPA first: flutter build ipa --release
+#
+# Author: Paul Snow
+# Since: 0.0.0
+
+def connect_api_key
+  app_store_connect_api_key(
+    key_id: ENV.fetch("APPSTORE_API_KEY_ID"),
+    issuer_id: ENV.fetch("APPSTORE_API_ISSUER_ID"),
+    key_content: ENV.fetch("APPSTORE_API_PRIVATE_KEY")
+  )
+end
+
+# Flutter names the IPA after the Xcode scheme's product, so glob rather than
+# hardcode it — a product rename would otherwise fail only after a green build.
+def built_ipa
+  path = Dir.glob(File.join(__dir__, "..", "..", "build", "ios", "ipa", "*.ipa")).first
+  UI.user_error!("No IPA in build/ios/ipa — run: flutter build ipa --release") if path.nil?
+  path
+end
+
 platform :ios do
   desc "Upload to TestFlight"
   lane :beta do
-    # Prerequisites:
-    # 1. Configure code signing (certificates and provisioning profiles)
-    # 2. Build the IPA first: flutter build ipa --release
-    #
-    # Usage: cd ios && fastlane beta
     upload_to_testflight(
-      ipa: "../build/ios/ipa/MyMediaScanner.ipa",
+      api_key: connect_api_key,
+      ipa: built_ipa,
       skip_waiting_for_build_processing: true
     )
   end
 
-  desc "Upload to App Store"
+  desc "Upload to App Store (does not submit for review)"
   lane :release do
-    # Prerequisites:
-    # 1. Configure code signing (certificates and provisioning profiles)
-    # 2. Build the IPA first: flutter build ipa --release
-    #
-    # Usage: cd ios && fastlane release
     upload_to_app_store(
-      ipa: "../build/ios/ipa/MyMediaScanner.ipa",
+      api_key: connect_api_key,
+      ipa: built_ipa,
       skip_metadata: false,
       skip_screenshots: true,
       submit_for_review: false

--- a/ios/fastlane/metadata/en-GB/privacy_url.txt
+++ b/ios/fastlane/metadata/en-GB/privacy_url.txt
@@ -1,1 +1,1 @@
-https://github.com/bovinemagnet/MyMediaScanner/blob/main/PRIVACY.md
+https://bovinemagnet.github.io/MyMediaScanner/privacy-policy.html

--- a/ios/fastlane/metadata/en-GB/subtitle.txt
+++ b/ios/fastlane/metadata/en-GB/subtitle.txt
@@ -1,1 +1,1 @@
-Catalogue your physical media collection
+Catalogue your physical media

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1962,7 +1962,7 @@ packages:
     source: hosted
     version: "1.1.0"
   xml:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -107,6 +107,9 @@ dev_dependencies:
   retrofit_generator: ^10.2.4
   mocktail: ^1.0.4
   sqlite3: ^3.3.0
+  # Parses ios/Runner/Info.plist and PrivacyInfo.xcprivacy in
+  # test/unit/platform/ios_release_config_test.dart.
+  xml: ^6.6.1
   flutter_launcher_icons: ^0.14.4
   flutter_native_splash: ^2.4.6
   msix: ^3.16.8

--- a/test/unit/platform/ios_release_config_test.dart
+++ b/test/unit/platform/ios_release_config_test.dart
@@ -1,0 +1,173 @@
+// Guards the iOS release configuration that only fails at runtime on a device
+// or at upload time in App Store Connect — neither of which the rest of the
+// suite can reach.
+//
+// Author: Paul Snow
+// Since: 0.0.0
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xml/xml.dart';
+
+const _infoPlistPath = 'ios/Runner/Info.plist';
+const _privacyManifestPath = 'ios/Runner/PrivacyInfo.xcprivacy';
+const _pubspecPath = 'pubspec.yaml';
+
+/// Purpose strings iOS demands before a plugin may touch a protected
+/// resource. Reaching one of these APIs without its string terminates the
+/// app, so the pairing is a hard requirement rather than store paperwork.
+const _purposeStringsByPlugin = <String, List<String>>{
+  // ImageSource.camera / ImageSource.gallery in cover_ocr_helper.dart.
+  'image_picker': ['NSCameraUsageDescription', 'NSPhotoLibraryUsageDescription'],
+  'mobile_scanner': ['NSCameraUsageDescription'],
+  // Sync connects straight to a Postgres host, which is typically on the
+  // user's LAN. iOS 14+ denies those connections without this string.
+  'postgres': ['NSLocalNetworkUsageDescription'],
+};
+
+/// Required-reason API declarations Apple expects in the app's own privacy
+/// manifest. Values are the reason codes for the APIs this app reaches
+/// through path_provider, shared_preferences and disk-space checks.
+const _requiredApiReasons = <String, String>{
+  'NSPrivacyAccessedAPICategoryFileTimestamp': 'C617.1',
+  'NSPrivacyAccessedAPICategoryUserDefaults': 'CA92.1',
+  'NSPrivacyAccessedAPICategoryDiskSpace': 'E174.1',
+};
+
+/// Top-level key/value pairs of a plist `<dict>`, with values returned as
+/// their raw XML elements so callers can inspect type as well as content.
+Map<String, XmlElement> _topLevelDict(String path) {
+  final file = File(path);
+  if (!file.existsSync()) {
+    fail('$path is missing');
+  }
+  final dict = XmlDocument.parse(file.readAsStringSync())
+      .rootElement
+      .childElements
+      .firstWhere((e) => e.name.local == 'dict',
+          orElse: () => fail('$path has no top-level <dict>'));
+
+  final entries = <String, XmlElement>{};
+  final children = dict.childElements.toList();
+  for (var i = 0; i + 1 < children.length; i += 2) {
+    if (children[i].name.local != 'key') continue;
+    entries[children[i].innerText] = children[i + 1];
+  }
+  return entries;
+}
+
+/// Direct dependencies declared in pubspec.yaml. Deliberately crude — it only
+/// needs to spot a plugin name, and a YAML parser would pull in a dependency
+/// for no gain.
+Set<String> _declaredDependencies() {
+  final lines = File(_pubspecPath).readAsLinesSync();
+  final names = <String>{};
+  for (final line in lines) {
+    final match = RegExp(r'^  ([a-z0-9_]+):').firstMatch(line);
+    if (match != null) names.add(match.group(1)!);
+  }
+  return names;
+}
+
+void main() {
+  group('Info.plist', () {
+    final info = _topLevelDict(_infoPlistPath);
+    final dependencies = _declaredDependencies();
+
+    for (final entry in _purposeStringsByPlugin.entries) {
+      test('declares the purpose strings ${entry.key} requires', () {
+        if (!dependencies.contains(entry.key)) {
+          markTestSkipped('${entry.key} is no longer a dependency');
+          return;
+        }
+        for (final key in entry.value) {
+          final value = info[key];
+          expect(
+            value,
+            isNotNull,
+            reason: '$key is missing from $_infoPlistPath, so iOS will block '
+                'the resource ${entry.key} needs — media pickers terminate '
+                'the app outright, local-network connections just fail',
+          );
+          expect(value!.name.local, 'string', reason: '$key must be a string');
+          expect(
+            value.innerText.trim(),
+            isNotEmpty,
+            reason: '$key must explain why access is needed; App Store review '
+                'rejects empty purpose strings',
+          );
+        }
+      });
+    }
+
+    test('declares export compliance so uploads are not held up', () {
+      final value = info['ITSAppUsesNonExemptEncryption'];
+      expect(
+        value,
+        isNotNull,
+        reason: 'without this key App Store Connect asks the export '
+            'compliance question on every single upload',
+      );
+      expect(value!.name.local, anyOf('true', 'false'));
+    });
+
+    test('uses the product name for the home-screen label', () {
+      expect(info['CFBundleDisplayName']?.innerText, 'MyMediaScanner');
+    });
+  });
+
+  group('privacy manifest', () {
+    test('exists in the app target', () {
+      expect(
+        File(_privacyManifestPath).existsSync(),
+        isTrue,
+        reason: 'App Store Connect rejects uploads without the app\'s own '
+            'PrivacyInfo.xcprivacy (ITMS-91053); the pods\' manifests do not '
+            'cover the app target',
+      );
+    });
+
+    test('declares tracking and collected data types', () {
+      final manifest = _topLevelDict(_privacyManifestPath);
+
+      expect(manifest['NSPrivacyTracking']?.name.local, 'false',
+          reason: 'this app does not track users');
+      expect(manifest['NSPrivacyTrackingDomains']?.name.local, 'array');
+      expect(manifest['NSPrivacyCollectedDataTypes']?.name.local, 'array');
+    });
+
+    test('declares a reason for every required-reason API it uses', () {
+      final manifest = _topLevelDict(_privacyManifestPath);
+      final accessed = manifest['NSPrivacyAccessedAPITypes'];
+      expect(accessed?.name.local, 'array',
+          reason: 'NSPrivacyAccessedAPITypes is missing');
+
+      // Each entry is a dict of API category -> array of reason codes.
+      final declared = <String, List<String>>{};
+      for (final item in accessed!.childElements) {
+        final children = item.childElements.toList();
+        String? category;
+        final reasons = <String>[];
+        for (var i = 0; i + 1 < children.length; i += 2) {
+          final key = children[i].innerText;
+          final value = children[i + 1];
+          if (key == 'NSPrivacyAccessedAPIType') {
+            category = value.innerText;
+          } else if (key == 'NSPrivacyAccessedAPITypeReasons') {
+            reasons.addAll(value.childElements.map((e) => e.innerText));
+          }
+        }
+        if (category != null) declared[category] = reasons;
+      }
+
+      for (final entry in _requiredApiReasons.entries) {
+        expect(
+          declared[entry.key],
+          contains(entry.value),
+          reason: '${entry.key} must declare reason ${entry.value}',
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Why

Reviewing iOS release readiness turned up two live bugs alongside the missing signing setup:

- No `NSPhotoLibraryUsageDescription`, yet `cover_ocr_helper.dart:53` calls `ImageSource.gallery` — iOS **terminates** the app when it reaches the picker.
- No `NSLocalNetworkUsageDescription`, so Postgres sync to a LAN host fails silently on iOS 14+.

Neither is reachable from the existing suite, which is why they survived this long.

## What changed

**Info.plist** — the two missing purpose strings, `ITSAppUsesNonExemptEncryption = false` (HTTPS and Keychain only, both exempt, so the export-compliance question stops appearing on every upload), and the home-screen label corrected from `Mymediascanner`.

**Privacy manifest** — new `ios/Runner/PrivacyInfo.xcprivacy`, wired into the Runner target's resources so it ships in the bundle. The pods carry their own; the app target needs its own or App Store Connect rejects the upload (ITMS-91053). Declares no tracking, no collected data types, and required-reason codes for file timestamps, `UserDefaults` and disk space.

**Signing** — `Release.xcconfig` optionally includes a git-ignored `Signing.xcconfig` holding `DEVELOPMENT_TEAM`, with a committed `.example`. Same shape as `android/key.properties`: release builds stay unsigned until the file exists, and no Team ID lands in the repo. The Release configuration no longer pins `CODE_SIGN_IDENTITY` to `iPhone Developer`, which would have overridden the xcconfig and produced a development-signed archive.

**CI** — `release-ios.yml` imports certs, signs, and uploads to TestFlight when the secrets exist; otherwise it keeps today's unsigned compile check. This mirrors `release-android.yml` gating on `ANDROID_KEYSTORE_BASE64`, so CI stays green with no secrets configured. Build numbers come from `github.run_number`, since TestFlight rejects a number it has already seen.

**fastlane** — the `beta`/`release` lanes now authenticate with an App Store Connect API key rather than an Apple ID, so uploads work unattended and do not break under 2FA. The IPA path is globbed rather than hardcoded.

**Runbook** — `docs/IOS_RELEASE.md`, mirroring `docs/PLAY_STORE_RELEASE.md`: enrolment, App Store Connect app record, local signing, API key, first manual upload, the App Privacy questionnaire, the CI secrets table, and per-release steps.

## Tests

`test/unit/platform/ios_release_config_test.dart` pins each purpose string to the plugin that requires it, so adding a permission-requiring plugin without its string fails the suite instead of a device. It also guards the export-compliance key and every required-reason declaration in the privacy manifest.

Written test-first: it flagged all five gaps on the first run, while `mobile_scanner` passed throughout — the camera string was already present, so the test was discriminating rather than blanket-failing.

## Verification

- `flutter analyze` — no issues
- `flutter test` — 1833/1833 passing (8 new)
- `flutter build ios --release --no-codesign` succeeds, and the built `Runner.app` contains `PrivacyInfo.xcprivacy` plus all four Info.plist keys with the expected values
- All three plists pass `plutil -lint`; the workflow YAML parses and no `${{ }}` interpolation remains inside a `run:` block

## Not covered

Signed-build verification end to end — that needs the Team ID and certificates. Screenshots and the App Privacy questionnaire are App Store submission rather than TestFlight, so they are documented in the runbook rather than automated.
