### PR TITLE
fix(ci): make the Linux release build and package succeed

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -84,9 +84,16 @@ jobs:
           VERSION=$(grep '^\s*version:' pubspec.yaml | sed 's/.*version:[[:space:]]*//' | sed 's/+.*//' | tr -d ' ')
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      # appimagetool is itself an AppImage, so it tries to self-mount with
+      # FUSE 2 — which current Ubuntu runners do not carry, giving
+      # "dlopen(): error loading libfuse.so.2". Unpacking it instead avoids
+      # needing FUSE on the runner at all, which is steadier than installing
+      # a deprecated libfuse2 whose package name keeps changing between
+      # Ubuntu releases.
       - name: Build AppImage
         env:
           APP_VERSION: ${{ steps.version.outputs.version }}
+          APPIMAGE_EXTRACT_AND_RUN: 1
         run: |
           # Download appimagetool
           wget -q https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O appimagetool

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -22,10 +22,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Three plugins pkg-config their way to native libraries that the
+      # runner does not ship, and CMake fails configuration rather than
+      # skipping them:
+      #   camera_desktop        gstreamer-1.0, gstreamer-app-1.0,
+      #                         gstreamer-video-1.0  (webcam scanning)
+      #   audioplayers_linux    gstreamer-audio-1.0
+      #   flutter_secure_storage_linux
+      #                         libsecret-1 >= 0.18.4  (API keys)
+      # printing needs gtk+-unix-print-3.0, which libgtk-3-dev already
+      # provides.
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y ninja-build libgtk-3-dev libblkid-dev liblzma-dev
+          sudo apt-get install -y \
+            ninja-build \
+            libgtk-3-dev \
+            libblkid-dev \
+            liblzma-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libsecret-1-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Why

`flutter build linux` had never succeeded. Dispatching `release-linux` for the first time failed at CMake configuration, and fixing that exposed a second failure behind it.

## Two fixes

**Missing native libraries.** CMake fails configuration at the *first* plugin whose `pkg_check_modules` cannot resolve, so the GStreamer error in the log was only the front of a queue. Rather than fix one per CI round, I checked every Linux plugin's requirements in the pub cache:

| Plugin | Requires | Package |
|---|---|---|
| `camera_desktop` | gstreamer-1.0, gstreamer-app-1.0, gstreamer-video-1.0 | `libgstreamer1.0-dev`, `libgstreamer-plugins-base1.0-dev` |
| `audioplayers_linux` | gstreamer-audio-1.0 | `libgstreamer-plugins-base1.0-dev` |
| `flutter_secure_storage_linux` | libsecret-1 >= 0.18.4 | `libsecret-1-dev` |
| `printing` | gtk+-unix-print-3.0 | already provided by `libgtk-3-dev` |

Only GStreamer appeared in the failing log; `libsecret` — which is where API keys are stored — would have failed the very next run.

**FUSE.** With the build finally compiling, packaging died on `dlopen(): error loading libfuse.so.2`. `appimagetool` is itself an AppImage and self-mounts via FUSE 2, which current Ubuntu runners do not carry. `APPIMAGE_EXTRACT_AND_RUN=1` makes it unpack in place instead. I chose that over installing `libfuse2`, whose package name has changed across Ubuntu releases and would break again on the next runner image bump.

## Verification

Both fixes were dispatched from this branch before merging, so `main` was never left broken:

- Run `31296058523` — dependency fix: `Build Linux release` **succeeds**, fails at `Build AppImage` on FUSE
- Run `31296337645` — after the FUSE fix: **every step green**, artefact `MyMediaScanner-1.0.0-linux-x86_64.AppImage` (23 MB)

This is the first installable artefact any release workflow in this repository has produced.

## Worth a follow-up

The AppImage's *runtime* may still expect FUSE on an end-user machine unless the embedded runtime is static. `troubleshooting.adoc` does not mention it, and I have not tested the AppImage on an actual Linux box — worth confirming before this is offered as the recommended Linux download.
