### PR TITLE
feat(macos): sign and notarise the DMG so it opens on other Macs

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -18,6 +18,14 @@ jobs:
     permissions:
       contents: write
 
+    # Signing switches on only when the secrets exist, matching how
+    # release-ios.yml and release-android.yml gate. Without them the job still
+    # produces a DMG, but one Gatekeeper rejects — see docs/MACOS_RELEASE.md.
+    env:
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
+      APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,8 +71,71 @@ jobs:
       - name: Run tests
         run: flutter test
 
+      - name: Report signing mode
+        id: signing
+        run: |
+          if [ -n "$MACOS_DEVELOPER_ID_CERT_BASE64" ] && [ -n "$APPLE_TEAM_ID" ]; then
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+            echo "Developer ID signing enabled."
+          else
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No macOS signing secrets set. The DMG will be ad-hoc signed and Gatekeeper will reject it. See docs/MACOS_RELEASE.md."
+          fi
+
+      - name: Import Developer ID certificate
+        if: steps.signing.outputs.signed == 'true'
+        env:
+          CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
+        run: |
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          KEYCHAIN=$RUNNER_TEMP/signing.keychain-db
+
+          echo "$MACOS_DEVELOPER_ID_CERT_BASE64" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" \
+            -P "$CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+
+          rm -f "$RUNNER_TEMP/cert.p12"
+          security find-identity -v -p codesigning "$KEYCHAIN"
+
       - name: Build macOS release
         run: flutter build macos --release
+
+      # Flutter ad-hoc signs the bundle, so re-sign it with the Developer ID
+      # identity. Nested code has to be signed before the bundle that contains
+      # it, or the outer signature seals a stale inner one. --options runtime
+      # enables the hardened runtime, without which notarisation is refused.
+      - name: Sign for distribution
+        if: steps.signing.outputs.signed == 'true'
+        run: |
+          APP="build/macos/Build/Products/Release/MyMediaScanner.app"
+          IDENTITY="Developer ID Application"
+          ENTITLEMENTS="macos/Runner/Release.entitlements"
+
+          sign() {
+            codesign --force --timestamp --options runtime \
+              --sign "$IDENTITY" "$@"
+          }
+
+          # Frameworks and loose dylibs first, deepest paths ahead of shallow.
+          find "$APP/Contents/Frameworks" \
+            -name "*.dylib" -o -name "*.framework" -o -name "*.xpc" 2>/dev/null |
+            awk '{ print gsub("/","/"), $0 }' | sort -rn | cut -d" " -f2- |
+            while read -r item; do
+              echo "signing nested: $item"
+              sign "$item"
+            done
+
+          # Then the app itself, which is what carries the entitlements.
+          sign --entitlements "$ENTITLEMENTS" "$APP"
+
+          codesign --verify --deep --strict --verbose=2 "$APP"
 
       - name: Install create-dmg
         run: brew install create-dmg
@@ -95,6 +166,34 @@ jobs:
             "${BUILD_DIR}/${APP_NAME}.app"
           echo "dmg_name=${DMG_NAME}" >> "$GITHUB_ENV"
           echo "dmg_path=build/${DMG_NAME}" >> "$GITHUB_ENV"
+
+      # Notarisation is what actually clears Gatekeeper: signing alone is not
+      # enough for a download. Stapling attaches the ticket so the first launch
+      # works without a network round-trip.
+      - name: Notarise and staple the DMG
+        if: steps.signing.outputs.signed == 'true' && env.APPSTORE_API_KEY_ID != ''
+        env:
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          KEY_FILE="$RUNNER_TEMP/AuthKey.p8"
+          printf '%s' "$APPSTORE_API_PRIVATE_KEY" > "$KEY_FILE"
+
+          xcrun notarytool submit "$dmg_path" \
+            --key "$KEY_FILE" \
+            --key-id "$APPSTORE_API_KEY_ID" \
+            --issuer "$APPSTORE_API_ISSUER_ID" \
+            --wait
+
+          rm -f "$KEY_FILE"
+          xcrun stapler staple "$dmg_path"
+
+      - name: Verify Gatekeeper accepts the DMG
+        if: steps.signing.outputs.signed == 'true' && env.APPSTORE_API_KEY_ID != ''
+        run: |
+          xcrun stapler validate "$dmg_path"
+          # This is the check that failed before notarisation was wired up.
+          spctl -a -t open --context context:primary-signature -vvv "$dmg_path"
 
       - name: Upload DMG artefact
         uses: actions/upload-artifact@v4

--- a/README.adoc
+++ b/README.adoc
@@ -258,6 +258,8 @@ Android releases go to Google Play. See link:docs/PLAY_STORE_RELEASE.md[docs/PLA
 
 iOS releases go to TestFlight and the App Store. See link:docs/IOS_RELEASE.md[docs/IOS_RELEASE.md] -- Developer Program enrolment, signing, the privacy manifest, App Store Connect API key, and the tag-and-publish workflow.
 
+macOS ships as a DMG from GitHub Releases. See link:docs/MACOS_RELEASE.md[docs/MACOS_RELEASE.md] -- Developer ID certificate, hardened-runtime signing, notarisation and stapling. Without those the DMG builds but Gatekeeper rejects it on any machine other than the one that built it.
+
 == Privacy
 
 MyMediaScanner has no servers and no accounts. Your collection is stored locally on your device, and the app contains no analytics, advertising, or crash-reporting SDKs.

--- a/docs/MACOS_RELEASE.md
+++ b/docs/MACOS_RELEASE.md
@@ -1,0 +1,143 @@
+# Releasing MyMediaScanner on macOS
+
+Author: Paul Snow
+
+macOS is distributed as a DMG from GitHub Releases rather than through the Mac
+App Store. The build works today; what stops the DMG being usable by anyone
+else is signing, and this is how to fix that.
+
+Bundle identifier: `com.paulsnow.mymediascanner`.
+
+---
+
+## The problem this solves
+
+`flutter build macos --release` ad-hoc signs the app: no team, no certificate.
+That runs fine on the machine that built it and is refused everywhere else:
+
+```
+$ codesign -dvv MyMediaScanner.app
+Signature=adhoc
+TeamIdentifier=not set
+
+$ spctl -a -vvv MyMediaScanner.app
+MyMediaScanner.app: rejected
+```
+
+A user who downloads that DMG is told the app is damaged or from an
+unidentified developer. Signing alone is not enough either — a downloaded app
+must also be **notarised**, which means submitting it to Apple and stapling the
+ticket they return.
+
+`release-macos.yml` performs both, but only when the secrets below exist.
+Without them it still builds a DMG so the workflow stays green, and that DMG is
+the ad-hoc one — fine for local testing, not for distribution.
+
+---
+
+## 1. Get a Developer ID certificate
+
+This needs the same Apple Developer Program membership as iOS, so if you have
+already enrolled for TestFlight you have it.
+
+**Xcode → Settings → Accounts →** select the team **→ Manage Certificates → +
+→ Developer ID Application.**
+
+Note that "Developer ID Application" is a different certificate from the
+"Apple Distribution" one iOS uses. You need both; they are not
+interchangeable.
+
+## 2. Export it for CI
+
+Keychain Access → **My Certificates** → find *Developer ID Application: …* →
+right-click → **Export** → `.p12`, and set a password.
+
+Make sure you export the certificate *with* its private key — if the private
+key is missing the import will succeed in CI and the signing step will then
+fail with "no identity found".
+
+```bash
+base64 -i DeveloperID.p12 | pbcopy
+```
+
+## 3. Add the secrets
+
+**Settings → Secrets and variables → Actions.**
+
+| Secret | Value |
+|---|---|
+| `APPLE_TEAM_ID` | your 10-character Team ID (shared with iOS) |
+| `MACOS_DEVELOPER_ID_CERT_BASE64` | the base64 from step 2 |
+| `MACOS_DEVELOPER_ID_CERT_PASSWORD` | the `.p12` password |
+| `APPSTORE_API_KEY_ID` | App Store Connect API key ID (shared with iOS) |
+| `APPSTORE_API_ISSUER_ID` | issuer ID (shared with iOS) |
+| `APPSTORE_API_PRIVATE_KEY` | the `.p8` contents (shared with iOS) |
+
+Notarisation reuses the App Store Connect API key rather than an Apple ID and
+app-specific password, so if iOS is already set up only the two macOS-specific
+secrets are new.
+
+With `APPLE_TEAM_ID` and `MACOS_DEVELOPER_ID_CERT_BASE64` present the app is
+signed; notarisation additionally needs the three `APPSTORE_API_*` values.
+
+## 4. Release
+
+```bash
+git tag v1.1.0
+git push origin v1.1.0
+```
+
+Or dispatch `release-macos` by hand from the Actions tab.
+
+The workflow signs the nested frameworks before the app bundle — the outer
+signature seals the inner ones, so the order matters — enables the hardened
+runtime, which notarisation requires, builds the DMG, submits it, staples the
+ticket, and then proves the result with:
+
+```bash
+spctl -a -t open --context context:primary-signature -vvv <dmg>
+```
+
+If that check passes, the DMG opens cleanly on a machine that has never seen
+your certificate.
+
+---
+
+## Verifying by hand
+
+Downloading the artefact and checking it yourself is worth doing once:
+
+```bash
+hdiutil attach -nobrowse -mountpoint /tmp/mms MyMediaScanner-1.0.0-macOS.dmg
+codesign -dvv /tmp/mms/MyMediaScanner.app     # expect Authority=Developer ID Application: …
+spctl -a -vvv /tmp/mms/MyMediaScanner.app     # expect accepted
+hdiutil detach /tmp/mms
+```
+
+## Troubleshooting
+
+**"no identity found"** — the `.p12` was exported without its private key, or
+it holds an Apple Distribution certificate rather than a Developer ID one.
+
+**Notarisation rejected, "The signature does not include a secure timestamp"**
+— signing ran without `--timestamp`, which needs network access at signing
+time.
+
+**Notarisation rejected, "The executable does not have the hardened runtime
+enabled"** — `--options runtime` was missing on one of the nested items, not
+just the app.
+
+**Still rejected after notarisation succeeds** — the ticket was not stapled, so
+the first launch needs to reach Apple. Check `xcrun stapler validate`.
+
+**The App Sandbox** — the app runs sandboxed, and the rip library folder is
+only readable through the security-scoped bookmark captured when the user picks
+it with Browse…. Signing does not change that, but note that Keychain items do
+not survive relaunches of ad-hoc-signed builds, so some storage oddities seen
+in local debug builds should disappear once the app is properly signed.
+
+## Related files
+
+- `.github/workflows/release-macos.yml` — build, sign, notarise, staple
+- `macos/Runner/Release.entitlements` — sandbox and capability entitlements
+- `docs/IOS_RELEASE.md` — the iOS equivalent, and where the shared API key comes from


### PR DESCRIPTION
## Why

The DMG this workflow produces cannot be opened by anyone except the person who built it. I downloaded the artefact from the first-ever `release-macos` run (`31298359717`), mounted it, and checked the app inside:

```
Signature=adhoc
TeamIdentifier=not set
spctl -a: rejected
```

`flutter build macos --release` ad-hoc signs the bundle, and the workflow had no signing or notarisation step at all. So it has been reliably producing something undistributable — a download tells the user the app is damaged or from an unidentified developer.

Signing alone would not fix it either: a downloaded app must also be notarised and have the ticket stapled.

## Approach

**Re-sign after the build rather than changing the Xcode project.** The macOS target pins `CODE_SIGN_IDENTITY = "-"` in three places in `project.pbxproj`, and an xcconfig cannot override a setting the project sets explicitly. Re-signing the built bundle is deterministic, needs no project surgery, and cannot be undone by whatever Xcode decides to do.

Two details that are easy to get wrong and are why this is more than a one-liner:

- **Nested code is signed before the bundle containing it.** The outer signature seals the inner ones, so signing the app first leaves stale inner signatures and notarisation refuses it. The step sorts by path depth, deepest first.
- **`--options runtime` on everything.** The hardened runtime is a notarisation requirement, and it has to be on the nested items too, not just the app.

Then `notarytool submit --wait`, `stapler staple`, and a verification step running the exact check that fails today:

```bash
spctl -a -t open --context context:primary-signature -vvv <dmg>
```

## Gating

Follows `release-ios.yml` and `release-android.yml`: signing runs only when the secrets exist, so the job stays green until you have the certificate. Notarisation reuses the App Store Connect API key iOS already uses, so only two secrets are new — `MACOS_DEVELOPER_ID_CERT_BASE64` and `MACOS_DEVELOPER_ID_CERT_PASSWORD`.

## Verification

Dispatched from this branch — run `31336015485`, **success**. The four new steps skip cleanly and the existing unsigned path is unchanged, so nothing regresses before the secrets land.

**What is not verified:** the signed path itself. Certificate import, re-signing, notarisation and stapling have never executed, because no Developer ID certificate exists yet. Same position as the iOS signed path. The first run with secrets present should be a manual dispatch, not a tag.

## Docs

`docs/MACOS_RELEASE.md` — the certificate (Developer ID Application is *not* the Apple Distribution certificate iOS uses; you need both), exporting it with its private key, the secrets table, and how to verify a downloaded DMG by hand. Linked from the README beside the Play and iOS runbooks.
