### PR TITLE
fix(metadata): catch Cover Art Archive failures in MusicBrainz detail fetch

### DIFF
--- a/lib/data/repositories/metadata_repository_impl.dart
+++ b/lib/data/repositories/metadata_repository_impl.dart
@@ -701,7 +701,7 @@ class MetadataRepositoryImpl implements IMetadataRepository {
       final release = await musicBrainzApi!.getRelease(candidate.sourceId);
       if (release != null) {
         await _cacheResponse(barcode, 'music', 'musicbrainz', release.toJson());
-        return _buildMusicBrainzResult(release, barcode, barcodeType);
+        return await _buildMusicBrainzResult(release, barcode, barcodeType);
       }
     } on RateLimitExceededException catch (e) {
       debugLog('MusicBrainz rate-limited during detail fetch: $e');

--- a/test/unit/data/repositories/metadata_repository_musicbrainz_test.dart
+++ b/test/unit/data/repositories/metadata_repository_musicbrainz_test.dart
@@ -433,5 +433,32 @@ void main() {
 
       expect(result, isNull);
     });
+
+    test('returns null when Cover Art Archive lookup throws', () async {
+      const release = MusicBrainzReleaseDto(
+        id: 'rel-art-fails',
+        title: 'Artwork Unavailable',
+        releaseGroup:
+            MusicBrainzReleaseGroupDto(id: 'rg-2', title: 'Group'),
+      );
+      when(() => mbApi.getRelease('rel-art-fails'))
+          .thenAnswer((_) async => release);
+      when(() => coverArtApi.findFrontArtwork(
+            releaseId: any(named: 'releaseId'),
+            releaseGroupId: any(named: 'releaseGroupId'),
+          )).thenThrow(Exception('cover art archive unreachable'));
+
+      final result = await repo.fetchCandidateDetail(
+        const MetadataCandidate(
+          sourceApi: 'musicbrainz',
+          sourceId: 'rel-art-fails',
+          title: 'Artwork Unavailable',
+        ),
+        barcode,
+        'ean13',
+      );
+
+      expect(result, isNull);
+    });
   });
 }


### PR DESCRIPTION
## Problem

CI has been red on `main` since #129. The `Analyse code` step fails, and because it gates the test step, **the suite has not run on main since that commit**:

```
warning • Returning a 'Future' without 'await' inside a try block •
lib/data/repositories/metadata_repository_impl.dart:704:9 • unawaited_return_in_try_block
```

The warning arrived with Flutter 3.47.0's analyser rather than with any code change, but it points at a real defect.

`_fetchMusicBrainzDetail` returned `_buildMusicBrainzResult(...)` without awaiting it, so the future left the `try` block before completing. `_buildMusicBrainzResult` calls `_resolveCoverArt`, which hits the Cover Art Archive over the network — and any exception from that call propagated straight out of the public `fetchCandidateDetail` instead of being caught and degraded to `null`. A Cover Art Archive outage or rate-limit therefore broke candidate disambiguation rather than simply yielding artwork-free metadata.

## Fix

Await the call so it stays inside the `try`, letting the existing `RateLimitExceededException` and `Exception` handlers see it. This matches what the other call site (line 1093) already does.

## Test

Added to the existing `fetchCandidateDetail — musicbrainz` group: with `findFrontArtwork` throwing, `fetchCandidateDetail` must return `null` rather than throw. Confirmed it fails before the fix (the stack trace ran through `_resolveCoverArt` → `_buildMusicBrainzResult` → line 704) and passes after.

## Verification

- `flutter analyze` — No issues found
- `flutter test` — 1840 tests, all passing